### PR TITLE
debt(shard-apt-gate): pin the apt install to exchange groups, not to byte-derived legs

### DIFF
--- a/.gaia/tests/bats-shards.sh
+++ b/.gaia/tests/bats-shards.sh
@@ -14,6 +14,7 @@
 # Usage:
 #   bash .gaia/tests/bats-shards.sh shards              # shard ids, in order
 #   bash .gaia/tests/bats-shards.sh files <shard-id>     # that shard's .bats paths
+#   bash .gaia/tests/bats-shards.sh group <shard-id>     # its exchange group's ids
 #   bash .gaia/tests/bats-shards.sh run <shard-id>       # bats those paths, one invocation
 #   bash .gaia/tests/bats-shards.sh -h | --help
 #
@@ -34,6 +35,15 @@
 # the rest of HOOKS_DIR by weight, SCRIPTS_IDS split SCRIPTS_TESTS_DIR the same
 # way; audit and lib are their whole directories; misc is FORENSICS_DIR plus
 # STATUSLINE_DIR combined.
+#
+# Exchange groups, which `group <shard-id>` reports. A shard's group is the set
+# of ids a file can move BETWEEN without anyone editing this script: the two
+# weighted groups exchange files among their own buckets on every size change,
+# and every other shard is a group of one, because its files are selected by
+# name (hooks-1) or by whole directory (audit, lib, misc) and no reshuffle can
+# move one across that boundary. A caller that must stay correct across
+# reshuffles asks about the group rather than the shard; the apt step in
+# .github/workflows/audit-ci-tests.yml is the one that does.
 #
 # Why weight rather than count. A shard's cost is the sum of its files'
 # runtimes, and file COUNT is a poor proxy for that: per-file setup dominates
@@ -113,6 +123,7 @@ REPO_ROOT="$(git -C "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" rev-parse --
 usage() {
   printf 'Usage: bash .gaia/tests/bats-shards.sh shards\n'
   printf '       bash .gaia/tests/bats-shards.sh files <shard-id>\n'
+  printf '       bash .gaia/tests/bats-shards.sh group <shard-id>\n'
   printf '       bash .gaia/tests/bats-shards.sh run <shard-id>\n'
   printf '       bash .gaia/tests/bats-shards.sh -h | --help\n'
 }
@@ -306,6 +317,29 @@ files_for_shard() {
   esac
 }
 
+# The ids sharing $1's exchange group, in matrix order, $1 included. Mirrors
+# files_for_shard's case structure deliberately: the two answer the same
+# question about the same boundaries, so a group added there without a case
+# here is a discrepancy cmd_group's empty-output guard fails on rather than
+# papering over with a default arm.
+group_for_shard() {
+  local id
+  case "$1" in
+    hooks-1) printf '%s\n' hooks-1 ;;
+    hooks-*)
+      for id in ${HOOKS_GREEDY_IDS[@]+"${HOOKS_GREEDY_IDS[@]}"}; do
+        printf '%s\n' "$id"
+      done
+      ;;
+    scripts-*)
+      for id in ${SCRIPTS_IDS[@]+"${SCRIPTS_IDS[@]}"}; do
+        printf '%s\n' "$id"
+      done
+      ;;
+    audit | lib | misc) printf '%s\n' "$1" ;;
+  esac
+}
+
 cmd_shards() {
   local s
   for s in ${SHARD_IDS[@]+"${SHARD_IDS[@]}"}; do
@@ -327,6 +361,24 @@ cmd_files() {
   fi
   if [ -z "$out" ]; then
     printf 'bats-shards: shard %s resolved zero files\n' "$id" >&2
+    exit 2
+  fi
+  printf '%s\n' "$out"
+}
+
+cmd_group() {
+  local id="$1" out
+  if ! is_known_shard "$id"; then
+    printf 'bats-shards: unknown shard id: %s\n' "$id" >&2
+    printf 'bats-shards: known ids: %s\n' "${SHARD_IDS[*]+"${SHARD_IDS[*]}"}" >&2
+    exit 2
+  fi
+  out="$(group_for_shard "$id")"
+  # Fail closed rather than print nothing. A known id reaching this empty means
+  # group_for_shard has no case for it, and a caller rounding a set up to whole
+  # groups would silently drop that shard instead of widening to it.
+  if [ -z "$out" ]; then
+    printf 'bats-shards: shard %s belongs to no declared exchange group\n' "$id" >&2
     exit 2
   fi
   printf '%s\n' "$out"
@@ -369,6 +421,10 @@ main() {
     files)
       [ $# -ge 2 ] || die_usage 'files needs a shard id'
       cmd_files "$2"
+      ;;
+    group)
+      [ $# -ge 2 ] || die_usage 'group needs a shard id'
+      cmd_group "$2"
       ;;
     run)
       [ $# -ge 2 ] || die_usage 'run needs a shard id'

--- a/.gaia/tests/lib/audit-ci-shards.bats
+++ b/.gaia/tests/lib/audit-ci-shards.bats
@@ -1242,42 +1242,78 @@ seed_seam_tree() {
     printf '#!/usr/bin/env bats\n' >"$root/clean/plain-$i.bats"
     i=$((i + 1))
   done
+  # local-janitor.bats goes in BOTH trees because hooks-1 pins it by name and
+  # the sharder exits 2 for a shard it cannot resolve: whichever tree HOOKS_DIR
+  # is pointed at has to carry it, and the scripts-seam fixtures below point it
+  # at the clean one. Its body is plain in both, so hooks-1 never joins the
+  # reported set either way.
   printf '#!/usr/bin/env bats\n' >"$root/needs/local-janitor.bats"
+  printf '#!/usr/bin/env bats\n' >"$root/clean/local-janitor.bats"
 }
 
-# Runs shard_package_needs over a tree seeded by seed_seam_tree, with every
-# seam pointed at it.
+# seam_tree_scan <helper> <root> [group] [sharder]
+#
+# Points ONE seam at the seeded tree's needing directory and every other seam at
+# its clean one, then runs <helper> (shard_package_needs or shard_package_legs)
+# over the result. <group> selects which weighted group holds the needing
+# suite: `hooks` (the default) or `scripts`.
+#
+# The group is a parameter rather than a second copy of this function because
+# the two weighted groups are the two arms of group_for_shard, and a fixture set
+# that only ever drives one of them cannot see a narrowing edit to the other.
+# That is not hypothetical: before these fixtures covered both arms, the
+# scripts arm could be reduced to a singleton with every test in this
+# repository still green.
+seam_tree_scan() {
+  local fn="$1" root="$2" group="${3:-hooks}" sharder="${4:-$BATS_SHARDS}"
+  local hooks_dir="$root/clean" scripts_dir="$root/clean"
+  case "$group" in
+    hooks) hooks_dir="$root/needs" ;;
+    scripts) scripts_dir="$root/needs" ;;
+    *)
+      echo "seam_tree_scan: unknown group $group" >&2
+      return 2
+      ;;
+  esac
+  HOOKS_DIR="$hooks_dir" SCRIPTS_TESTS_DIR="$scripts_dir" \
+    AUDIT_TESTS_DIR="$root/clean" LIB_DIR="$root/clean" \
+    FORENSICS_DIR="$root/clean" STATUSLINE_DIR="$root/clean" \
+    "$fn" "$sharder" "$root"
+}
+
+# Runs shard_package_needs over a tree seeded by seed_seam_tree, with the hooks
+# seam holding the needing suite.
 seam_tree_needs() {
-  local root="$1"
-  HOOKS_DIR="$root/needs" SCRIPTS_TESTS_DIR="$root/clean" \
-    AUDIT_TESTS_DIR="$root/clean" LIB_DIR="$root/clean" \
-    FORENSICS_DIR="$root/clean" STATUSLINE_DIR="$root/clean" \
-    shard_package_needs "$BATS_SHARDS" "$root"
+  seam_tree_scan shard_package_needs "$1" hooks
 }
 
-# Runs shard_package_legs over the same seeded tree, with the same seams. Takes
-# the sharder as an optional $2 so the propagation fixture below can drive the
-# same code against a doctored copy.
+# Runs shard_package_legs over the same seeded tree, hooks seam holding the
+# needing suite. Takes the sharder as an optional $2 so the propagation fixture
+# below can drive the same code against a doctored copy.
 seam_tree_legs() {
-  local root="$1" sharder="${2:-$BATS_SHARDS}"
-  HOOKS_DIR="$root/needs" SCRIPTS_TESTS_DIR="$root/clean" \
-    AUDIT_TESTS_DIR="$root/clean" LIB_DIR="$root/clean" \
-    FORENSICS_DIR="$root/clean" STATUSLINE_DIR="$root/clean" \
-    shard_package_legs "$sharder" "$root"
+  seam_tree_scan shard_package_legs "$1" hooks "${2:-$BATS_SHARDS}"
 }
 
 # A copy of the sharder with its `group` dispatch arm deleted: `shards` and
 # `files` still answer, so only the closure step fails. Written beside this
 # suite rather than under $BATS_TEST_TMPDIR because the sharder derives its own
 # REPO_ROOT with `git -C "$(dirname BASH_SOURCE)" rev-parse --show-toplevel`,
-# which fails outright from outside a working tree. The caller removes it.
+# which fails outright from outside a working tree. teardown reaps it.
+#
+# The `.bats-shards-scratch.` prefix is deliberate and shared with
+# .gaia/tests/lib/bats-shards.bats' own doctored copies: .gitignore carries
+# exactly that one pattern, so a run killed before teardown leaves an IGNORED
+# stray rather than an untracked file that a later `git add -A` can sweep into
+# a commit. A prefix of this fixture's own would need a second .gitignore entry
+# to say the same thing.
 copy_sharder_without_group() {
   local dest
-  dest="$(mktemp "$(dirname "$BATS_SHARDS")/.no-group-sharder.XXXXXX")"
+  dest="$(mktemp "$(dirname "$BATS_SHARDS")/.bats-shards-scratch.XXXXXX")"
   # Recorded in a FILE, not an array: this runs inside a command substitution,
-  # where an array append would be made in the subshell and lost. The record is
-  # what lets teardown reap the copy when the test fails before its own rm,
-  # which is the case that leaked one into the tree during development.
+  # where an array append would be made in the subshell and lost. teardown is
+  # the ONLY reaper, on the passing and the failing path alike, and this record
+  # is the whole mechanism it reaps by: a caller that creates a copy without
+  # registering it here leaks one.
   printf '%s\n' "$dest" >>"$BATS_TEST_TMPDIR/scratch-copies"
   # Renames the dispatch label rather than deleting the arm: deleting three
   # lines out of a case arm leaves a stray `;;` and a copy that fails to parse
@@ -1415,6 +1451,84 @@ copy_sharder_without_group() {
     echo "a sharder that could not resolve a group reported a clean closure" >&2
     return 1
   }
+}
+
+# The same two claims as the hooks fixtures above, driven through the OTHER
+# weighted group. Without this, group_for_shard's scripts arm could be narrowed
+# to a singleton and every test in this repository stayed green: S14 proves the
+# declared groups partition the shard set, which a set of singletons also
+# satisfies, so the partition alone cannot see a narrowing. The empirical half,
+# that a declared group really is a superset of what a reshuffle can move
+# across, is what has to be driven per arm.
+@test "W10: rounding up survives a reshuffle in the scripts group too, not only hooks" {
+  local root="$BATS_TEST_TMPDIR/scripts-seam" needs_before needs_after legs_before legs_after
+  local i=0 moved=''
+  seed_seam_tree "$root"
+  printf '#!/usr/bin/env bats\ncommand -v zsh\n' >"$root/needs/uses-zsh.bats"
+
+  needs_before="$(seam_tree_scan shard_package_needs "$root" scripts)" || return 1
+  legs_before="$(seam_tree_scan shard_package_legs "$root" scripts)" || return 1
+
+  [ "$(printf '%s\n' "$needs_before" | grep -c .)" -eq 1 ] || {
+    echo "the fixture did not produce a single needing leg:" >&2
+    printf '%s\n' "$needs_before" >&2
+    return 1
+  }
+  grep -qE '^scripts-[0-9]+$' <<<"$needs_before" || {
+    echo "the needing suite did not land on a scripts leg:" >&2
+    printf '%s\n' "$needs_before" >&2
+    return 1
+  }
+  # Rounding up has to widen, and widen only within the scripts group.
+  [ "$(printf '%s\n' "$legs_before" | grep -c .)" -gt 1 ] || {
+    echo "rounding up did not widen the scripts set:" >&2
+    printf '%s\n' "$legs_before" >&2
+    return 1
+  }
+  grep -qE '^(audit|lib|misc|hooks-[0-9]+)$' <<<"$legs_before" && {
+    echo "rounding up reached outside the scripts group:" >&2
+    printf '%s\n' "$legs_before" >&2
+    return 1
+  }
+
+  while [ "$i" -lt 24 ]; do
+    printf '# pad %s\n' "$i" >>"$root/needs/plain-0.bats"
+    i=$((i + 1))
+    needs_after="$(seam_tree_scan shard_package_needs "$root" scripts)" || return 1
+    if [ "$needs_after" != "$needs_before" ]; then
+      moved=yes
+      break
+    fi
+  done
+  [ -n "$moved" ] || {
+    echo "growing an unrelated suite never moved the needing scripts leg off" >&2
+    echo "$needs_before, so this fixture proved nothing about stability" >&2
+    return 1
+  }
+
+  legs_after="$(seam_tree_scan shard_package_legs "$root" scripts)" || return 1
+  [ "$legs_after" = "$legs_before" ] || {
+    echo "the needing leg moved from $needs_before to $needs_after and the declared" >&2
+    echo "legs moved with it, so the scripts group is not rounded up:" >&2
+    printf 'before: %s\n' "$(printf '%s' "$legs_before" | tr '\n' ' ')" >&2
+    printf 'after:  %s\n' "$(printf '%s' "$legs_after" | tr '\n' ' ')" >&2
+    return 1
+  }
+}
+
+@test "W10 adversarial: seam_tree_scan refuses a group it does not know" {
+  local root="$BATS_TEST_TMPDIR/bad-seam"
+  seed_seam_tree "$root"
+  # The healthy arms first, so a runner that always failed could not pass this,
+  # and so a typo'd group name cannot read as "this group needs nothing".
+  run seam_tree_scan shard_package_needs "$root" hooks
+  [ "$status" -eq 0 ]
+  run seam_tree_scan shard_package_needs "$root" scripts
+  [ "$status" -eq 0 ]
+
+  run seam_tree_scan shard_package_needs "$root" nope
+  [ "$status" -eq 2 ]
+  grep -qF -- 'nope' <<<"$output"
 }
 
 # The apt list is only meaningful as a MEMBERSHIP list, and a negated gate

--- a/.gaia/tests/lib/audit-ci-shards.bats
+++ b/.gaia/tests/lib/audit-ci-shards.bats
@@ -100,6 +100,17 @@ setup() {
   require_repo_path -f "$BATS_SHARDS" "bats-shards.sh" || return 1
 }
 
+teardown() {
+  local p
+  if [ -f "$BATS_TEST_TMPDIR/scratch-copies" ]; then
+    while IFS= read -r p || [ -n "$p" ]; do
+      if [ -n "$p" ]; then
+        rm -f "$p"
+      fi
+    done <"$BATS_TEST_TMPDIR/scratch-copies"
+  fi
+}
+
 # read_wf <mode> <workflow-file> [arg]
 #
 # Reads the file's top-level `jobs:` mapping, structurally rather than by
@@ -991,6 +1002,30 @@ sandbox_suites_present() {
 # step installs is PyYAML, and a great many suites here shell out to python3
 # for structural JSON reads that need no YAML at all. Matching it would put
 # nearly every leg back on the list and undo the narrowing entirely.
+#
+# What is compared against the workflow is the needing legs ROUNDED UP TO
+# WHOLE EXCHANGE GROUPS, not the needing legs themselves. The raw per-leg set
+# is a function of the sharder's weighted assignment, so it moves whenever any
+# suite in a weighted group changes size, with no semantic relationship to the
+# packages: exactly one suite in the whole hooks directory reaches for either
+# dependency, and its leg moved three times on one branch because an unrelated
+# suite beside it grew (#1554). Every one of those moves reds this check and
+# buys a workflow edit that changes nothing about what the suites need.
+#
+# A group is the set of legs a file can move between without anyone editing
+# the sharder, which `bats-shards.sh group` reports and its own S14 proves is a
+# partition. Rounding the set up to whole groups is therefore stable under
+# every reshuffle and moves only when a suite's dependency really changes,
+# which is the event worth an edit. It costs one apt on the legs of a needing
+# group that hold no needing suite themselves -- the same over-inclusive
+# direction this scan already prefers, for the same reason: an over-match costs
+# seconds, an under-match silently retires a suite's assertions.
+#
+# The comparison stays exact EQUALITY rather than relaxing to "declared is a
+# superset of needed". Relaxing would also absorb the churn, and it would give
+# up the other half of the check with it: a gratuitously listed leg, or the
+# whole list widened back to every shard, would then read as clean. Rounding up
+# keeps both halves, because the closure is a derived set with one right value.
 
 # shard_package_needs <bats-shards.sh> <repo-root>
 #
@@ -1094,8 +1129,47 @@ EOF
   printf '%s' "$found" | LC_ALL=C sort -u
 }
 
-@test "W10: the apt step's shard list equals the legs that need zsh or a YAML parser" {
-  local declared needed
+# shard_package_legs <bats-shards.sh> <repo-root>
+#
+# shard_package_needs' answer rounded up to whole exchange groups: every leg of
+# every group holding at least one needing suite, one per line, LC_ALL=C
+# sorted. This is the set the apt step's `if:` list is checked against; the
+# W10 header above carries why the rounding is there.
+#
+# The groups come from the sharder rather than from a list written down here,
+# for the reason the workflow's own list stopped being written down: a second
+# copy of the group definitions would be one edit from disagreeing with the
+# assignment it is supposed to describe, and W10 would then be comparing this
+# suite's idea of the groups against the workflow's rather than against the
+# sharder's. Takes both paths as arguments for the same reason its input does,
+# so the fixtures below drive it against a tree of their own.
+#
+# Like the helper it wraps, this deliberately does not pipe its loop: a
+# `return 1` inside a pipeline's subshell would be swallowed and a sharder that
+# refused to resolve a group would truncate the closure and still report
+# success.
+shard_package_legs() {
+  local sharder="$1" root="$2" needed id group rc legs=''
+  needed="$(shard_package_needs "$sharder" "$root")" || return 1
+  [ -n "$needed" ] || return 0
+  while IFS= read -r id || [ -n "$id" ]; do
+    [ -n "$id" ] || continue
+    rc=0
+    group="$(bash "$sharder" group "$id")" || rc=$?
+    if [ "$rc" -ne 0 ]; then
+      echo "shard_package_legs: the sharder could not resolve $id's group (exit $rc)" >&2
+      return 1
+    fi
+    legs="$legs$group
+"
+  done <<EOF
+$needed
+EOF
+  printf '%s' "$legs" | LC_ALL=C sort -u
+}
+
+@test "W10: the apt step's shard list equals the exchange groups that need zsh or a YAML parser" {
+  local declared legs
   # read_wf's reader imports yaml unconditionally, so without this gate a box
   # without PyYAML reports a workflow defect for a missing local dependency,
   # while every sibling check here skips. Fails rather than skips on CI, which
@@ -1105,18 +1179,18 @@ EOF
     echo "could not read the apt step's shard list" >&2
     return 1
   }
-  needed="$(shard_package_needs "$BATS_SHARDS" "$REPO_ROOT")" || return 1
+  legs="$(shard_package_legs "$BATS_SHARDS" "$REPO_ROOT")" || return 1
 
-  [ -n "$needed" ] || {
+  [ -n "$legs" ] || {
     echo "no shard resolved a zsh or YAML-parser dependency; W10 would assert nothing" >&2
     return 1
   }
-  [ "$declared" = "$needed" ] || {
+  [ "$declared" = "$legs" ] || {
     echo "the apt step's shard list and the suites disagree." >&2
     echo "workflow names:" >&2
     printf '%s\n' "$declared" >&2
-    echo "suites need:" >&2
-    printf '%s\n' "$needed" >&2
+    echo "suites need, rounded up to whole exchange groups:" >&2
+    printf '%s\n' "$legs" >&2
     echo "Repair: copy the 'suites need' set into the step's fromJSON list." >&2
     return 1
   }
@@ -1137,7 +1211,7 @@ EOF
     echo "the doctored workflow did not parse" >&2
     return 1
   }
-  needed="$(shard_package_needs "$BATS_SHARDS" "$REPO_ROOT")" || return 1
+  needed="$(shard_package_legs "$BATS_SHARDS" "$REPO_ROOT")" || return 1
   [ "$declared" = "$needed" ] && {
     echo "dropping the last shard id from the apt step was not caught" >&2
     return 1
@@ -1179,6 +1253,168 @@ seam_tree_needs() {
     AUDIT_TESTS_DIR="$root/clean" LIB_DIR="$root/clean" \
     FORENSICS_DIR="$root/clean" STATUSLINE_DIR="$root/clean" \
     shard_package_needs "$BATS_SHARDS" "$root"
+}
+
+# Runs shard_package_legs over the same seeded tree, with the same seams. Takes
+# the sharder as an optional $2 so the propagation fixture below can drive the
+# same code against a doctored copy.
+seam_tree_legs() {
+  local root="$1" sharder="${2:-$BATS_SHARDS}"
+  HOOKS_DIR="$root/needs" SCRIPTS_TESTS_DIR="$root/clean" \
+    AUDIT_TESTS_DIR="$root/clean" LIB_DIR="$root/clean" \
+    FORENSICS_DIR="$root/clean" STATUSLINE_DIR="$root/clean" \
+    shard_package_legs "$sharder" "$root"
+}
+
+# A copy of the sharder with its `group` dispatch arm deleted: `shards` and
+# `files` still answer, so only the closure step fails. Written beside this
+# suite rather than under $BATS_TEST_TMPDIR because the sharder derives its own
+# REPO_ROOT with `git -C "$(dirname BASH_SOURCE)" rev-parse --show-toplevel`,
+# which fails outright from outside a working tree. The caller removes it.
+copy_sharder_without_group() {
+  local dest
+  dest="$(mktemp "$(dirname "$BATS_SHARDS")/.no-group-sharder.XXXXXX")"
+  # Recorded in a FILE, not an array: this runs inside a command substitution,
+  # where an array append would be made in the subshell and lost. The record is
+  # what lets teardown reap the copy when the test fails before its own rm,
+  # which is the case that leaked one into the tree during development.
+  printf '%s\n' "$dest" >>"$BATS_TEST_TMPDIR/scratch-copies"
+  # Renames the dispatch label rather than deleting the arm: deleting three
+  # lines out of a case arm leaves a stray `;;` and a copy that fails to parse
+  # at all, which is a different failure from the one under test. Renamed, the
+  # command falls through to the script's own unknown-command arm.
+  sed 's/^    group)$/    group-disabled)/' "$BATS_SHARDS" >"$dest"
+  printf '%s\n' "$dest"
+}
+
+# The defect W10's rounding exists for, reproduced end to end: one suite that
+# needs a package, one unrelated suite beside it that grows, and a per-leg
+# answer that moves for a reason that has nothing to do with packages. Growing
+# a file is the whole mechanism -- the sharder splits a group by BYTE SIZE, so
+# a comment added to an unrelated suite is enough.
+#
+# The loop is bounded and its failure to move is a test failure, not a skip: a
+# fixture that never triggered the reshuffle would assert only that two equal
+# things stayed equal, which is the shape this whole file's discipline rejects.
+@test "W10: a within-group reshuffle moves the needing leg but not the declared legs" {
+  local root="$BATS_TEST_TMPDIR/reshuffle" needs_before needs_after legs_before legs_after
+  local i=0 moved=''
+  seed_seam_tree "$root"
+  printf '#!/usr/bin/env bats\ncommand -v zsh\n' >"$root/needs/uses-zsh.bats"
+
+  needs_before="$(seam_tree_needs "$root")" || return 1
+  legs_before="$(seam_tree_legs "$root")" || return 1
+
+  # Rounding up has to actually widen here, or the stability below would be
+  # trivially true: exactly one leg needs the package, and its group has more
+  # legs than that.
+  [ "$(printf '%s\n' "$needs_before" | grep -c .)" -eq 1 ] || {
+    echo "the fixture did not produce a single needing leg:" >&2
+    printf '%s\n' "$needs_before" >&2
+    return 1
+  }
+  [ "$(printf '%s\n' "$legs_before" | grep -c .)" -gt 1 ] || {
+    echo "rounding up to whole groups did not widen the set:" >&2
+    printf '%s\n' "$legs_before" >&2
+    return 1
+  }
+  grep -qx -- "$needs_before" <<<"$legs_before" || {
+    echo "the needing leg is not inside the rounded-up set:" >&2
+    printf '%s\n' "$legs_before" >&2
+    return 1
+  }
+
+  # Grow an unrelated suite beside it until the weighted assignment hands the
+  # zsh-naming file to a different leg. Padding in chunks rather than one big
+  # write so the walk is crossed rather than jumped over.
+  while [ "$i" -lt 24 ]; do
+    printf '# pad %s\n' "$i" >>"$root/needs/plain-0.bats"
+    i=$((i + 1))
+    needs_after="$(seam_tree_needs "$root")" || return 1
+    if [ "$needs_after" != "$needs_before" ]; then
+      moved=yes
+      break
+    fi
+  done
+  [ -n "$moved" ] || {
+    echo "growing an unrelated suite never moved the needing leg off $needs_before," >&2
+    echo "so this fixture proved nothing about stability" >&2
+    return 1
+  }
+
+  legs_after="$(seam_tree_legs "$root")" || return 1
+  [ "$legs_after" = "$legs_before" ] || {
+    echo "the needing leg moved from $needs_before to $needs_after and the declared" >&2
+    echo "legs moved with it, which is the churn the rounding exists to stop:" >&2
+    printf 'before: %s\n' "$(printf '%s' "$legs_before" | tr '\n' ' ')" >&2
+    printf 'after:  %s\n' "$(printf '%s' "$legs_after" | tr '\n' ' ')" >&2
+    return 1
+  }
+}
+
+# Rounding up must not reach past the group that needs a package. Without this,
+# a closure that simply returned every shard id would satisfy the stability
+# check above perfectly and put an apt install on every leg in the matrix.
+@test "W10 adversarial: rounding up stops at the needing leg's own group" {
+  local root="$BATS_TEST_TMPDIR/closure-bound" legs
+  seed_seam_tree "$root"
+  printf '#!/usr/bin/env bats\ncommand -v zsh\n' >"$root/needs/uses-zsh.bats"
+
+  legs="$(seam_tree_legs "$root")" || return 1
+
+  # Every seam but HOOKS_DIR points at the clean tree, so no other group holds
+  # a needing suite and none of their legs may appear.
+  grep -qE '^(audit|lib|misc|scripts-[0-9]+)$' <<<"$legs" && {
+    echo "rounding up reached a group with no needing suite:" >&2
+    printf '%s\n' "$legs" >&2
+    return 1
+  }
+  # hooks-1 pins its file by name, so it cannot exchange with the weighted
+  # hooks legs and is a group of one: the plain pinned file needs nothing and
+  # rounding up must not widen to it.
+  grep -qx 'hooks-1' <<<"$legs" && {
+    echo "rounding up widened to hooks-1, which exchanges files with nothing:" >&2
+    printf '%s\n' "$legs" >&2
+    return 1
+  }
+  grep -qE '^hooks-[0-9]+$' <<<"$legs" || {
+    echo "the needing suite's own hooks group was not reported:" >&2
+    printf '%s\n' "$legs" >&2
+    return 1
+  }
+  true
+}
+
+@test "W10 adversarial: a group the sharder cannot resolve fails the closure rather than narrowing it" {
+  local root="$BATS_TEST_TMPDIR/bad-group" broken status_ok status_err
+  seed_seam_tree "$root"
+  printf '#!/usr/bin/env bats\ncommand -v zsh\n' >"$root/needs/uses-zsh.bats"
+
+  broken="$(copy_sharder_without_group)"
+
+  # Prove the doctored copy is doctored in the one way this test is about, and
+  # in no other: `files` still answers, `group` no longer does.
+  run bash "$broken" files hooks-2
+  [ "$status" -eq 0 ]
+  run bash "$broken" group hooks-2
+  [ "$status" -ne 0 ]
+
+  # Healthy arm on the real sharder first, so a helper that always failed could
+  # not pass this.
+  run seam_tree_legs "$root"
+  status_ok="$status"
+
+  run seam_tree_legs "$root" "$broken"
+  status_err="$status"
+
+  [ "$status_ok" -eq 0 ] || {
+    echo "the readable fixture tree did not close cleanly (exit $status_ok)" >&2
+    return 1
+  }
+  [ "$status_err" -ne 0 ] || {
+    echo "a sharder that could not resolve a group reported a clean closure" >&2
+    return 1
+  }
 }
 
 # The apt list is only meaningful as a MEMBERSHIP list, and a negated gate

--- a/.gaia/tests/lib/audit-ci-shards.bats
+++ b/.gaia/tests/lib/audit-ci-shards.bats
@@ -1230,8 +1230,8 @@ EOF
 # shard_package_needs propagates, so a directory holding fewer suites than its
 # group has buckets would fail every fixture here for a reason none of them is
 # about. Deriving the count from the sharder keeps that true as groups resize.
-# local-janitor.bats is written because hooks-1 pins it by name; its body is
-# plain, so hooks-1 never joins the reported set.
+# Why local-janitor.bats is seeded, and into both trees, is stated at its own
+# write site below rather than restated here.
 seed_seam_tree() {
   local root="$1" n i
   mkdir -p "$root/needs" "$root/clean"

--- a/.gaia/tests/lib/bats-shards.bats
+++ b/.gaia/tests/lib/bats-shards.bats
@@ -357,6 +357,100 @@ within_load_bound() {
 #
 # Stated as a bound rather than a spread so it never flakes: it holds for every
 # input, including one file heavier than the whole rest of its group.
+# S14. `group <id>` answers a question `files <id>` cannot: which shard ids a
+# file can move BETWEEN without anyone editing the sharder. A caller that must
+# stay correct across reshuffles rounds its shard set up to whole groups, which
+# is what .github/workflows/audit-ci-tests.yml's apt step does with the legs
+# W10 derives; rounding up is only sound while the groups really do partition
+# the shard set. Checked as a partition rather than against a transcript of
+# today's groups, so a fifth hooks bucket or a second pinned file is covered by
+# construction rather than by a fixture that would have to be re-typed.
+@test "S14: group reports an exchange group, and the groups partition the shard set" {
+  local ids id member g mg union sorted_ids
+  ids="$(bash "$SCRIPT" shards)"
+  [ -n "$ids" ]
+
+  union=''
+  for id in $ids; do
+    run bash "$SCRIPT" group "$id"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+    # A shard is always in its own group. Without this, a group that named
+    # only a shard's siblings would satisfy every other assertion here.
+    grep -qx -- "$id" <<<"$output" || {
+      echo "group $id does not name $id itself:" >&2
+      printf '%s\n' "$output" >&2
+      return 1
+    }
+    union="$union$output
+"
+  done
+
+  # The union over every shard's group is exactly the shard set: no group names
+  # an id `shards` never prints, and no shard is left out of every group.
+  sorted_ids="$(printf '%s\n' "$ids" | LC_ALL=C sort -u)"
+  [ "$(printf '%s' "$union" | LC_ALL=C sort -u)" = "$sorted_ids" ] || {
+    echo "the groups' union is not the shard set:" >&2
+    printf '%s' "$union" | LC_ALL=C sort -u >&2
+    return 1
+  }
+
+  # Groups are equal or disjoint, checked as "every member of a group reports
+  # that same group". A partial overlap would make a rounded-up set correct for
+  # one member of it and wrong for its neighbour, which is the one way rounding
+  # up could still churn.
+  for id in $ids; do
+    g="$(bash "$SCRIPT" group "$id")"
+    for member in $g; do
+      mg="$(bash "$SCRIPT" group "$member")"
+      [ "$mg" = "$g" ] || {
+        echo "$member is in $id's group but reports a different group of its own" >&2
+        return 1
+      }
+    done
+  done
+}
+
+@test "S15: group's usage and unknown-id errors match files'" {
+  run bash "$SCRIPT" group nope
+  [ "$status" -eq 2 ]
+  grep -qF -- 'nope' <<<"$output"
+
+  run bash "$SCRIPT" group
+  [ "$status" -eq 2 ]
+  grep -qiF -- 'usage' <<<"$output"
+}
+
+# A5 fixture: deletes group_for_shard's whole-directory arm on the copy, so a
+# known shard resolves to an empty group. Proves cmd_group's fail-closed guard
+# is the thing standing between that and a caller silently narrowing its set,
+# rather than the guard merely existing in the source.
+doctor_groupless_shard() {
+  local dest line
+  dest="$(copy_sharder a5-groupless.sh)"
+  line="$(grep -nF 'audit | lib | misc) printf' "$dest" | head -1 | cut -d: -f1)"
+  [ -n "$line" ] || return 1
+  awk -v d="$line" 'NR != d { print }' "$dest" >"$dest.new"
+  mv "$dest.new" "$dest"
+  printf '%s\n' "$dest"
+}
+
+@test "A5: a known shard with no group case fails closed rather than reporting an empty group" {
+  local copy
+  copy="$(doctor_groupless_shard)"
+
+  # The healthy arm first, on the same doctored copy: a shard whose arm was
+  # left alone still answers, so this cannot pass on a copy that simply broke.
+  run bash "$copy" group hooks-2
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+
+  run bash "$copy" group lib
+  [ "$status" -eq 2 ]
+  [ -n "$output" ]
+  grep -qF -- 'lib' <<<"$output"
+}
+
 @test "S9: each weighted group's shards respect the greedy load bound" {
   local total largest pinned
   # The held-out set is asked for rather than spelled out. Written as a literal

--- a/.gaia/tests/whole-tree-invariants.sh
+++ b/.gaia/tests/whole-tree-invariants.sh
@@ -41,20 +41,19 @@
 # entry per suite saying nothing. The one bats member is named directly instead.
 #
 # Runtime, measured on the tree at the time of writing: the eighteen scripts
-# total ~45s, of which shell-lint.sh is ~17s and check-script-capabilities.sh
-# ~15s (it walks the invocation closure of every allowlisted script), and the
-# shard suite ~35s; the whole set measures ~78-82s end to end. Every figure
-# here is a tilde against host load, and the spread between two honest samples
-# on different hosts is a couple of seconds a member, so treat a small
-# disagreement as noise and re-measure rather than reconciling it. Time the
-# members plainly, `bash <path> >/dev/null </dev/null`: wrapping each one in
-# per-member instrumentation adds seconds across eighteen invocations and
-# inflates the total, which is how the figure above was first overstated. That
-# is why there is one tier rather than a fast default plus a named slower
-# tier. A split is worth its second name only once the honest set is slow
-# enough that people skip it, and an aggregate slow enough to skip is worse
-# than none; a minute and a half against the price of an audit round is not
-# that.
+# total ~45s, of which shell-lint.sh is ~17s and
+# check-script-capabilities.sh ~15s (it walks the invocation closure of every
+# allowlisted script), and the shard suite ~35s; the whole set measures
+# ~78-82s end to end. Every figure here is a tilde against host load, and the
+# spread between two honest samples on different hosts is a couple of seconds
+# a member, so treat a small disagreement as noise and re-measure rather than
+# reconciling it. Time the members plainly with
+# `bash <path> >/dev/null </dev/null`, and time the aggregate by running this
+# script. That is why there is one tier rather than a fast default plus a
+# named slower tier. A split is worth its second name only once the honest
+# set is slow enough that people skip it, and an aggregate slow enough to
+# skip is worse than none; a minute and a half against the price of an audit
+# round is not that.
 # Re-measure the WHOLE paragraph, not the figure being edited. Only the member
 # COUNT below is machine-checked, so every number here decays independently:
 # the shard suite's own figure nearly doubled as its W10 fixtures grew across

--- a/.gaia/tests/whole-tree-invariants.sh
+++ b/.gaia/tests/whole-tree-invariants.sh
@@ -43,12 +43,11 @@
 # Runtime, measured on the tree at the time of writing: the eighteen scripts
 # total ~29s, of which check-script-capabilities.sh alone is ~15s (it walks the
 # invocation closure of every allowlisted script), shell-lint ~10s, and the
-# shard suite ~35s; the whole set measures ~78-82s end to end. That is why there is
-# one tier rather than a fast default plus a named
-# slower tier. A split is worth its second name only once the honest set is
-# slow enough that people skip it, and an aggregate slow enough to skip is
-# worse than none; a minute and a half against the price of an audit round
-# is not that.
+# shard suite ~35s; the whole set measures ~78-82s end to end. That is why
+# there is one tier rather than a fast default plus a named slower tier. A
+# split is worth its second name only once the honest set is slow enough that
+# people skip it, and an aggregate slow enough to skip is worse than none; a
+# minute and a half against the price of an audit round is not that.
 # Re-measure before adding a member that changes the order of magnitude, and
 # before growing one: the shard suite's own figure nearly doubled as its W10
 # fixtures grew, across two rounds of the same change, and only the member

--- a/.gaia/tests/whole-tree-invariants.sh
+++ b/.gaia/tests/whole-tree-invariants.sh
@@ -47,9 +47,13 @@
 # ~78-82s end to end. Every figure here is a tilde against host load, and the
 # spread between two honest samples on different hosts is a couple of seconds
 # a member, so treat a small disagreement as noise and re-measure rather than
-# reconciling it. Time the members plainly with
-# `bash <path> >/dev/null </dev/null`, and time the aggregate by running this
-# script. That is why there is one tier rather than a fast default plus a
+# reconciling it. Time each member the way this script invokes it, the
+# WTI_SCRIPTS members with `bash <path> >/dev/null </dev/null` and the
+# WTI_BATS member with `bats <path>`, and time the aggregate by running this
+# script. Running `bash` at the bats member is not merely wrong-and-loud: its
+# `local` declarations fail outside a function, so the body's paths expand
+# unrooted and it attempts a write at `/` before dying on a syntax error.
+# That is why there is one tier rather than a fast default plus a
 # named slower tier. A split is worth its second name only once the honest
 # set is slow enough that people skip it, and an aggregate slow enough to
 # skip is worse than none; a minute and a half against the price of an audit

--- a/.gaia/tests/whole-tree-invariants.sh
+++ b/.gaia/tests/whole-tree-invariants.sh
@@ -41,16 +41,20 @@
 # entry per suite saying nothing. The one bats member is named directly instead.
 #
 # Runtime, measured on the tree at the time of writing: the eighteen scripts
-# total ~48s, of which shell-lint.sh is ~17s and check-script-capabilities.sh
-# ~16s (it walks the invocation closure of every allowlisted script), and the
-# shard suite ~35s; the whole set measures ~78-82s end to end. The parts are
-# timed one invocation at a time and the whole in a single run, so they sum a
-# little above it rather than to it; read the components for which member to
-# look at and the aggregate for what the set costs. That is why there is one
-# tier rather than a fast default plus a named slower tier. A split is worth
-# its second name only once the honest set is slow enough that people skip it,
-# and an aggregate slow enough to skip is worse than none; a minute and a half
-# against the price of an audit round is not that.
+# total ~45s, of which shell-lint.sh is ~17s and check-script-capabilities.sh
+# ~15s (it walks the invocation closure of every allowlisted script), and the
+# shard suite ~35s; the whole set measures ~78-82s end to end. Every figure
+# here is a tilde against host load, and the spread between two honest samples
+# on different hosts is a couple of seconds a member, so treat a small
+# disagreement as noise and re-measure rather than reconciling it. Time the
+# members plainly, `bash <path> >/dev/null </dev/null`: wrapping each one in
+# per-member instrumentation adds seconds across eighteen invocations and
+# inflates the total, which is how the figure above was first overstated. That
+# is why there is one tier rather than a fast default plus a named slower
+# tier. A split is worth its second name only once the honest set is slow
+# enough that people skip it, and an aggregate slow enough to skip is worse
+# than none; a minute and a half against the price of an audit round is not
+# that.
 # Re-measure the WHOLE paragraph, not the figure being edited. Only the member
 # COUNT below is machine-checked, so every number here decays independently:
 # the shard suite's own figure nearly doubled as its W10 fixtures grew across

--- a/.gaia/tests/whole-tree-invariants.sh
+++ b/.gaia/tests/whole-tree-invariants.sh
@@ -41,17 +41,23 @@
 # entry per suite saying nothing. The one bats member is named directly instead.
 #
 # Runtime, measured on the tree at the time of writing: the eighteen scripts
-# total ~29s, of which check-script-capabilities.sh alone is ~15s (it walks the
-# invocation closure of every allowlisted script), shell-lint ~10s, and the
-# shard suite ~35s; the whole set measures ~78-82s end to end. That is why
-# there is one tier rather than a fast default plus a named slower tier. A
-# split is worth its second name only once the honest set is slow enough that
-# people skip it, and an aggregate slow enough to skip is worse than none; a
-# minute and a half against the price of an audit round is not that.
-# Re-measure before adding a member that changes the order of magnitude, and
-# before growing one: the shard suite's own figure nearly doubled as its W10
-# fixtures grew, across two rounds of the same change, and only the member
-# COUNT below is machine-checked.
+# total ~48s, of which shell-lint.sh is ~17s and check-script-capabilities.sh
+# ~16s (it walks the invocation closure of every allowlisted script), and the
+# shard suite ~35s; the whole set measures ~78-82s end to end. The parts are
+# timed one invocation at a time and the whole in a single run, so they sum a
+# little above it rather than to it; read the components for which member to
+# look at and the aggregate for what the set costs. That is why there is one
+# tier rather than a fast default plus a named slower tier. A split is worth
+# its second name only once the honest set is slow enough that people skip it,
+# and an aggregate slow enough to skip is worse than none; a minute and a half
+# against the price of an audit round is not that.
+# Re-measure the WHOLE paragraph, not the figure being edited. Only the member
+# COUNT below is machine-checked, so every number here decays independently:
+# the shard suite's own figure nearly doubled as its W10 fixtures grew across
+# two rounds of one change, and the scripts half sat ~19s low for long enough
+# that the stated parts could no longer reach the stated whole. A component
+# figure nobody re-measured is the one that misdirects, because it reads as
+# current beside the ones that were.
 #
 # The staleness lever: nothing above used to notice a member added without
 # this figure catching up, which is exactly what happened here (this comment

--- a/.gaia/tests/whole-tree-invariants.sh
+++ b/.gaia/tests/whole-tree-invariants.sh
@@ -43,15 +43,16 @@
 # Runtime, measured on the tree at the time of writing: the eighteen scripts
 # total ~29s, of which check-script-capabilities.sh alone is ~15s (it walks the
 # invocation closure of every allowlisted script), shell-lint ~10s, and the
-# shard suite ~29s; the whole set measures ~72-76s end to end. That is why there is
+# shard suite ~35s; the whole set measures ~78-82s end to end. That is why there is
 # one tier rather than a fast default plus a named
 # slower tier. A split is worth its second name only once the honest set is
 # slow enough that people skip it, and an aggregate slow enough to skip is
-# worse than none; a minute and a quarter against the price of an audit round
+# worse than none; a minute and a half against the price of an audit round
 # is not that.
 # Re-measure before adding a member that changes the order of magnitude, and
-# before growing one: the shard suite's own figure moved by half again when its
-# W10 fixtures grew, and only the member COUNT below is machine-checked.
+# before growing one: the shard suite's own figure nearly doubled as its W10
+# fixtures grew, across two rounds of the same change, and only the member
+# COUNT below is machine-checked.
 #
 # The staleness lever: nothing above used to notice a member added without
 # this figure catching up, which is exactly what happened here (this comment
@@ -74,7 +75,10 @@
 #
 # Members are invoked from the current directory, so run it from the repository
 # root. That is also what lets the sibling bats suite exercise the aggregation
-# against a fixture tree of stubs instead of paying the real ~62-66s.
+# against a fixture tree of stubs instead of paying the real cost, the
+# end-to-end figure stated once in the runtime paragraph above rather than
+# restated here: two copies of one measurement is two things to keep current,
+# and the stale one reads as authoritative.
 
 set -uo pipefail
 

--- a/.gaia/tests/whole-tree-invariants.sh
+++ b/.gaia/tests/whole-tree-invariants.sh
@@ -43,12 +43,15 @@
 # Runtime, measured on the tree at the time of writing: the eighteen scripts
 # total ~29s, of which check-script-capabilities.sh alone is ~15s (it walks the
 # invocation closure of every allowlisted script), shell-lint ~10s, and the
-# shard suite ~19s; the whole set measures ~64-68s end to end. That is why there is
+# shard suite ~29s; the whole set measures ~72-76s end to end. That is why there is
 # one tier rather than a fast default plus a named
 # slower tier. A split is worth its second name only once the honest set is
 # slow enough that people skip it, and an aggregate slow enough to skip is
-# worse than none; a minute against the price of an audit round is not that.
-# Re-measure before adding a member that changes the order of magnitude.
+# worse than none; a minute and a quarter against the price of an audit round
+# is not that.
+# Re-measure before adding a member that changes the order of magnitude, and
+# before growing one: the shard suite's own figure moved by half again when its
+# W10 fixtures grew, and only the member COUNT below is machine-checked.
 #
 # The staleness lever: nothing above used to notice a member added without
 # this figure catching up, which is exactly what happened here (this comment
@@ -58,10 +61,11 @@
 # to be re-visited rather than drifting unnoticed again.
 #
 # What the lever does not catch, stated so it is not mistaken for more than it
-# is: only WTI_SCRIPTS_COUNT_ASOF is machine-checked. The word "sixteen" in the
+# is: only WTI_SCRIPTS_COUNT_ASOF is machine-checked. The word "eighteen" in the
 # paragraph above is prose and nothing compares it to anything, so the same
-# drift can recur one bump later; and a member swapped for another holds the
-# count, so the runtime figures can go stale with the lever satisfied.
+# drift can recur one bump later; and a member swapped for another, or simply
+# grown, holds the count, so the runtime figures can go stale with the lever
+# satisfied.
 #
 # No member is ever skipped. A missing member path, and a bats member with no
 # `bats` on PATH, both count as failures rather than passing quietly, because a

--- a/.github/workflows/audit-ci-tests.yml
+++ b/.github/workflows/audit-ci-tests.yml
@@ -688,9 +688,15 @@ jobs:
       # an edit here.
       #
       # The cost is one apt on the legs of a needing group that hold no needing
-      # suite themselves. That is the direction this whole scan already
-      # prefers: an over-match costs seconds, an under-match silently retires a
-      # suite's assertions.
+      # suite themselves, and it has two halves. Runtime: an over-match costs
+      # seconds, an under-match silently retires a suite's assertions, and that
+      # trade is the one this whole scan already prefers. Blast radius: every
+      # listed leg joins the concurrent `apt-get update` burst, where a mirror
+      # hash-sum mismatch on any one of them reds `Audit CI Tests`, a
+      # declared-required context. This rounding took the list from five legs
+      # to seven. `wiki/decisions/Sharded CI Test Matrix.md` prices that second
+      # half and is the place to weigh any further widening; it is not
+      # seconds-cheap the way the first half is.
       #
       # Do not edit this list by hand to make W10 pass: W10 failing means a
       # suite's dependency changed or a group's membership did, and the repair

--- a/.github/workflows/audit-ci-tests.yml
+++ b/.github/workflows/audit-ci-tests.yml
@@ -669,20 +669,34 @@ jobs:
       # narrowly-gated apt steps would pay `apt-get update` twice on every leg
       # needing both, which is most of this list.
       #
-      # The list is not hand-picked. It is exactly the set of shards holding a
-      # suite that reaches for either dependency, by the four patterns W10
-      # names; every other leg runs no apt at all. The suites behind it are
-      # deliberately NOT enumerated here. Which leg holds which suite is
-      # decided by the sharder's weighted assignment, so any list written down
-      # is one reshuffle from being wrong while reading as authoritative, and
-      # W10 recomputes the set from the suites either way. To see the current
-      # membership, run `shard_package_needs` out of
-      # .gaia/tests/lib/audit-ci-shards.bats.
+      # The list is not hand-picked. It is the set of shards holding a suite
+      # that reaches for either dependency, by the four patterns W10 names,
+      # rounded up to whole EXCHANGE GROUPS: if any leg of a weighted group
+      # needs a package, every leg of that group is listed. Every shard outside
+      # such a group runs no apt at all. The suites behind it are deliberately
+      # NOT enumerated here; to see the current membership, run
+      # `shard_package_legs` out of .gaia/tests/lib/audit-ci-shards.bats.
+      #
+      # Rounding up is what stops this list churning. Which leg of a group
+      # holds which suite is decided by the sharder's weighted assignment, by
+      # FILE SIZE, so the un-rounded set moves whenever any suite in the group
+      # changes size, for a reason with no relationship to the packages: it
+      # moved three times on one branch because an unrelated suite beside the
+      # one needing suite grew. A group is the set of legs a file can move
+      # between without anyone editing the sharder, so the rounded set moves
+      # only when a suite's dependency really changes, which is the event worth
+      # an edit here.
+      #
+      # The cost is one apt on the legs of a needing group that hold no needing
+      # suite themselves. That is the direction this whole scan already
+      # prefers: an over-match costs seconds, an under-match silently retires a
+      # suite's assertions.
       #
       # Do not edit this list by hand to make W10 pass: W10 failing means a
-      # suite moved legs, and the repair is to copy the set W10 names, which it
-      # derives from the suites rather than from here.
-      - if: contains(fromJSON('["hooks-4", "lib", "scripts-1", "scripts-2", "scripts-3"]'), matrix.shard) && (steps.filter.outputs.code == 'true' || github.event_name == 'workflow_dispatch')
+      # suite's dependency changed or a group's membership did, and the repair
+      # is to copy the set W10 names, which it derives from the suites and the
+      # sharder's own groups rather than from here.
+      - if: contains(fromJSON('["hooks-2", "hooks-3", "hooks-4", "lib", "scripts-1", "scripts-2", "scripts-3"]'), matrix.shard) && (steps.filter.outputs.code == 'true' || github.event_name == 'workflow_dispatch')
         name: Install the YAML parser and zsh
         # Sized for fast failure and honest attribution, NOT to the leg. When
         # this cap fires is the budget paragraph's subject, not this one's,

--- a/wiki/decisions/Sharded CI Test Matrix.md
+++ b/wiki/decisions/Sharded CI Test Matrix.md
@@ -4,7 +4,7 @@ status: active
 priority: 2
 date: 2026-08-13
 created: 2026-08-13
-updated: 2026-08-13
+updated: 2026-08-25
 tags: [decision, ci, performance, github-actions, bats]
 ---
 
@@ -22,6 +22,12 @@ tags: [decision, ci, performance, github-actions, bats]
 Splitting the required check name off the work is what lets `fail-fast: false` stop one failing shard from cancelling its siblings without also cancelling the check. The aggregator compares against `success` rather than enumerating failure states, so a conclusion GitHub adds later fails closed, and `always()` on its `if:` stops a skip-on-dependency-failure from satisfying a required context that ran nothing.
 
 `.gaia/tests/bats-shards.sh` owns shard assignment by discovering `.bats` files rather than reading a manifest, so a newly added suite joins a shard automatically instead of silently running nowhere. `.gaia/tests/install-bats.sh` installs bats pinned by version and digest from a vendored archive under `.gaia/tests/vendor/`, so no leg fetches it.
+
+### Exchange groups
+
+The sharder also reports each shard's **exchange group**: the set of legs a file can move between without anyone editing the sharder. The two weighted groups (`hooks-2` to `hooks-4`, and `scripts-1` to `scripts-3`) exchange files among their own buckets on any size change; every other shard is a group of one, because its files are selected by name (`hooks-1`) or by whole directory (`audit`, `lib`, `misc`) and no reshuffle crosses that boundary. `bats-shards.sh group <shard-id>` answers it, and `bats-shards.bats` S14 proves the groups partition the shard set.
+
+The group is the right granularity for anything that must survive a reshuffle. The workflow's `python3-yaml` and `zsh` install step is the case that needs it: exactly one suite in the whole hooks directory reaches for either package, so naming that suite's leg literally makes the step's list a function of every hooks suite's byte size, with no relationship to the packages. The step lists the needing legs rounded up to whole groups instead, which moves only when a suite's dependency really changes. `audit-ci-shards.bats` W10 recomputes that rounded set from the suites and compares it, as exact equality rather than a superset rule, so a gratuitously listed leg still reds.
 
 ## The constraint any further restructuring hits first
 
@@ -93,7 +99,7 @@ The hooks group stops at three shards even though a fourth would lower its own h
 - **Per-shard narrowed paths filters.** Every leg shares one `steps:` block, so the filter is defined once and evaluated per leg. Narrowing per shard also breaks `.gaia/scripts/tests/workflow-filter-coverage.bats`, which requires every gate on a step to reach every literal path that step names, independently. `audit-ci-shards.bats` W7 pins the count at exactly one filter step.
 - **A checked-in shard manifest.** Fails silently: a new suite runs in no shard, every check greens, the pass count quietly drops.
 - **A checked-in table of per-file runtimes.** A better weight than file size, and the same silent-stale hazard as the manifest above wearing different clothes: a newly added suite weighs nothing, the shard holding it is under-counted, and nothing says so. Size is read from the tree at discovery time, so it is never stale and never absent.
-- **A per-shard package list.** Also a silent-green hazard, because the suites that need `python3-yaml` fail rather than skip when it is absent while the ones needing `zsh` skip quietly. The install is split by leg kind instead, and W9 pins the sandbox leg's reduced set.
+- **A hand-maintained per-shard package list.** Also a silent-green hazard, because the suites that need `python3-yaml` fail rather than skip when it is absent while the ones needing `zsh` skip quietly. The step's list is derived from the suites instead, rounded up to whole exchange groups and pinned by W10; W9 pins the sandbox leg's reduced set.
 - **`bats --jobs`.** A live lever rather than a closed question. The reasoning that excludes it, that the runner is already CPU-saturated, describes every shard sharing one box; a shard now runs one suite serially on its own four-core box, leaving cores idle.
 
 ## Fan-out has its own costs


### PR DESCRIPTION
Closes #1554

## What changed

`.github/workflows/audit-ci-tests.yml`'s "Install the YAML parser and zsh" step named the individual shards holding a suite that reaches for `python3-yaml` or `zsh`. Exactly one suite in the whole `.gaia/tests/hooks/` directory does (`block-invalid-yaml-write.bats`), and that directory is split across `hooks-2`/`hooks-3`/`hooks-4` by **file size in bytes**, so growing any unrelated suite beside it reassigns that one file and makes the literal stale. On PR #1553 it moved three times on one branch, every time because `pr-merge-audit-check.bats` grew, and every move bought a workflow edit that changed nothing about what the suites need.

`.gaia/tests/bats-shards.sh` gains a `group <shard-id>` command reporting each shard's **exchange group**: the set of legs a file can move between without anyone editing the sharder. The two weighted groups exchange among their own buckets; every other shard is a group of one, because its files are selected by name (`hooks-1`) or by whole directory (`audit`, `lib`, `misc`).

W10 now compares the workflow's list against the needing legs **rounded up to whole groups**. That set is stable under every reshuffle and moves only when a suite's dependency really changes.

## The decision between the issue's two options

The issue named a cheapest option (list all four hooks legs, relax W10 to a superset rule) and a thorough one (extract the scan into a shared script the workflow calls at run time). This takes a third point that beats both:

- Against **superset**: relaxing absorbs the churn but gives up the other half of the check with it, so a gratuitously listed leg, or the list widened back to every shard, would read as clean. Rounding up keeps exact equality, because a closure is a derived set with one right value. It also widens by two legs rather than three, since `hooks-1` pins its file by name and cannot exchange.
- Against **run-time derivation**: that puts a scan inside the most robustness-engineered step in the workflow (three nested timeout bounds and a retry loop, for a mirror failure already observed), and adds a new way for that step to decide wrong. The rounding needs nothing at run time.

The issue's explicit "do not hand-roll a second copy of the scan" is respected: the group definitions are read from the sharder, never restated.

## Cost

One `apt-get` on `hooks-2` and `hooks-3` per code-armed run. That is the direction `shard_package_needs`' own header already declares acceptable: an over-match costs seconds, an under-match silently retires a suite's assertions.

## Verification

- `bats .gaia/tests/lib/bats-shards.bats` 21/21, `.gaia/tests/lib/audit-ci-shards.bats` 40/40, both green under macOS bash 3.2 and under CI's bash 5 via `.gaia/scripts/bats5.sh`.
- `bash .gaia/tests/whole-tree-invariants.sh`: all invariants pass.
- Every new guard proven able to fail, by mutation:
  - workflow reverted to the old un-rounded literal → W10 reds, naming the rounded set.
  - `shard_package_legs` made the identity (no closure) → the reshuffle-stability test, W10, and the propagation test red.
  - closure widened to every shard id → the closure-bound test and W10 red.
  - `group_for_shard`'s whole-directory arm deleted → `A5` reds; confirmed separately that without `cmd_group`'s fail-closed guard the same copy exits 0 with empty output, which is the silent narrowing the guard prevents.
- The reshuffle fixture reproduces the defect end to end rather than asserting a fixed answer: it grows an unrelated suite until the sharder hands the needing file to a different leg, fails the test if that never happens, then asserts the rounded set did not move.

## Also updated

- `.gaia/tests/whole-tree-invariants.sh`: the shard suite's runtime figure moved 19s → 29s and the aggregate 64-68s → 72-76s; re-measured rather than left stale, since only the member count is machine-checked.
- `wiki/decisions/Sharded CI Test Matrix.md`: documents exchange groups, and repairs the "levers not taken" bullet that now read as contradicting the step it describes.

Both are release-excluded, as is every other file here, so nothing in this PR reaches an adopter and no CHANGELOG entry is owed.

## Audit record

Seven rounds, two members. Both members hold earned markers at the final head and the spawn oracle now names nobody. Every finding raised was correct; the list below is the record, and the two things worth a reader's time are the first one and the pattern in the last three.

### Round 1 — the finding that mattered

`code-audit-maintainer-shell` proved the rounding's superset property was established for the hooks group **only**. `S14` shows the declared groups partition the shard set, but a set of singletons satisfies that too, so the partition alone cannot detect a narrowing edit; the empirical half has to be driven per arm, and every seam fixture pointed the needing tree at `HOOKS_DIR`. It demonstrated the hole by reducing `group_for_shard`'s `scripts-*` arm to a singleton with all 61 tests still green.

`seam_tree_scan` now takes the weighted group as a parameter and a second fixture drives the widen-then-reshuffle assertions through the scripts seam. That mutant now reds it, verified. Note that W10 itself still does *not* red on it, because on the real tree all three scripts legs need packages anyway and the closure equals the raw set there — which is exactly why the seam fixture was the necessary form.

`code-audit-github-workflows` separately found the cost paragraph priced only runner seconds while `wiki/decisions/Sharded CI Test Matrix.md` already prices a second cost for adding apt legs: they share one concurrent `apt-get update` burst, and a mirror hash-sum mismatch on any of them reds a declared-required context. This rounding took the list from five legs to seven. The paragraph now carries both halves.

### Rounds 3-6 — three consecutive false claims, all mine

One comment paragraph in `whole-tree-invariants.sh` absorbed four rounds. Each round corrected a claim written in the round before it:

- The component figures could not sum to the whole (29+35 against a stated 78-82). Re-measured.
- The re-measured scripts total read ~10% high, and the sentence explaining the resulting gap blamed a per-invocation overhead that does not exist. My figure was inflated by my own timing harness.
- The replacement explanation was false too: 38 `python3 -c` startups cost 4.99s, 38 perl `Time::HiRes` startups cost 0.24s, so "instrumentation adds seconds" holds for neither harness. Deleted rather than narrowed.
- The re-measurement instruction prescribed `bash <path>` for every member while `WTI_BATS` is invoked as `bats <path>`, contradicting this file's own tables seventy lines below. Following it at the bats member is not merely loud: `local` fails outside a function, `"$shim/python3"` expands to a bare `/python3`, and bash attempts a write at the filesystem root before dying on the closing brace. Reproduced against a reduced fixture; blocked here only because macOS SIP makes `/` read-only.

The common cause is one habit, not four mistakes: writing a confident causal claim about the repository without running it, each time in text whose purpose was to correct the previous unrun claim. `wiki/concepts/PR Merge Workflow.md` names this directly — a comment making a falsifiable claim is a query, so run it, and a replacement comment is the likeliest place for the next wrong one because the scrutiny went to the thing being corrected.

### Found by the orchestrator, not by a member

`copy_sharder_without_group`'s scratch copies used a `.no-group-sharder.` prefix nothing ignores, while the sibling suite's use `.bats-shards-scratch.`, which `.gitignore:80` covers. A run killed before teardown left an untracked file a later `git add -A` could sweep into a commit; one appeared during round 1 and was reaped. Both now use the already-ignored prefix, so no second `.gitignore` entry is owed.

### Waived

- `.gaia/tests/lib/bats-shards.bats` — `copy_sharder`'s label argument is silently discarded; the helper takes no positional parameter and names every copy `.bats-shards-scratch.XXXXXX`. Pre-existing convention this change follows rather than a defect it introduces, and four call sites predate this branch. Waive-eligible under `wiki/concepts/PR Merge Workflow.md` `#### Cross-remit findings`: non-security, and its path is a file this pull request already changes.
