### PR TITLE
debt(verb-arming-cost): say what the past-bound test measured, and widen the band to what was observed

### DIFF
--- a/.gaia/tests/hooks/verb-arming-cost.bats
+++ b/.gaia/tests/hooks/verb-arming-cost.bats
@@ -14,7 +14,7 @@
 #   2KB     ~21-23ms                 ~16-19ms
 #   8KB     ~27ms                    ~16-19ms
 #   16KB    ~32-38ms                 ~16-20ms
-#   32KB (past bound, one hook)      ~80-90ms (walker takes the identity path;
+#   32KB (past bound, one hook)      ~75-90ms (walker takes the identity path;
 #                                    the hook body, not the walk, is the cost)
 #
 #   gaia_verb_arm_view alone (library call, no hook process): 16KB ~8-12ms,
@@ -307,7 +307,7 @@ CEILING_ELEVEN_RAWMATCH_MS=2000
 
 # Past-bound (32KB), one hook (token-tally-git-op.sh), armed for real: the
 # walker's length check must short-circuit before it does any real work. What
-# is left is hook-body cost, not walk cost: measured ~80-90ms across runs
+# is left is hook-body cost, not walk cost: measured ~75-90ms across runs
 # against ~21-23ms for an unmatched payload, the gap being the armed path's
 # own work. Headroom: 300/90 ~= 3.3x. Margin below a
 # conservative doubling of the 16KB byte-walk figure for a 32KB unbounded
@@ -366,7 +366,7 @@ CEILING_VIEW_16K_MS=100
   done
 }
 
-@test "cost: a payload past the character bound costs about what an unmatched payload costs" {
+@test "cost: a payload past the character bound never pays the walk, so only the hook body's own cost is left" {
   local hook="$HOOKS_DIR/token-tally-git-op.sh"
   local armed nonmatch
   armed=$(build_plain_armed_payload "git commit -m x" 32768)


### PR DESCRIPTION
Closes #1557

Two prose corrections in `.gaia/tests/hooks/verb-arming-cost.bats`, both accepted rather than folded on PR #1555 because they were findings on that round's own repair. Neither is a defect in logic: the suite was and is 7/7 and `CEILING_PAST_BOUND_MS` is not breached.

### 1. The `@test` name contradicted the comment three lines above it

The name still read *"costs about what an unmatched payload costs"*, a claim #1555 removed from the `CEILING_PAST_BOUND_MS` comment as refuted: armed measures ~80ms against ~21ms unmatched, a ~3.7x gap. The walker does short-circuit; the gap is armed hook-body work an unmatched payload never reaches, and the body pins neither figure against the other, it checks both against the same 300ms ceiling independently.

The name is what the bats reporter prints on every run and every CI leg, so the refuted claim was the most visible statement of the test's purpose. Renamed to match the comment it sits under.

### 2. The `~80-90ms` band's floor sat above most observations

The band came from one four-sample burst (84, 87, 90, 80). A second seven-sample burst gave 75, 81, 75, 77, 78, 76, 80, and a third taken on this branch on the same Apple Silicon macOS host under bash 5.3.15 gave 82, 81, 82, 83, 78, 78, 81. Across all eighteen samples the honest band is `~75-90ms`, so both statements of it now say that. A later maintainer measuring 76ms would otherwise have read ordinary jitter as an improvement. The derived `300/90` headroom takes the pessimistic end and is unchanged.

### Citation drift, checked rather than assumed

The 43-line insertion PR #1559 made in this file after the issue was filed shifted the `@test` citation from line 335 to 369. The quoted text is byte-identical, and #1559 touched neither figure: the past-bound case is swept through `token-tally-git-op.sh`, which makes no repo-scope call, so #1559's scanner speedup does not reach it.

### Verification

- `verb-arming-cost.bats` 7/7 under bash 5 via `.gaia/scripts/bats5.sh`
- `.gaia/tests/shell-lint.sh` clean
- `.gaia/tests/whole-tree-invariants.sh` green, which is the check that reads W10: this file's byte size feeds the size-weighted shard split, and the split is unmoved

No CHANGELOG entry: maintainer-only test prose, no behavior change and nothing for an adopter to act on.