### PR TITLE
debt(guard-fidelity): say which way the roster scan diverges from the machinery's parser

### DIFF
--- a/.gaia/tests/hooks/audit-root-resolution.bats
+++ b/.gaia/tests/hooks/audit-root-resolution.bats
@@ -90,10 +90,21 @@
 # one spelling: an indented `- name: X` carrying its value on the entry line. An
 # expanded block entry, a flow mapping (`- {name: x}`), a quoted key, `globs:`
 # written before `name:`, or a value held over to a more-indented line below the
-# key are each valid YAML this scan would otherwise read short. Deliberately NOT
-# widened to accept them: `.claude/hooks/lib/audit-scope.sh:302` pins the same
-# spelling, so a scan that accepted more would answer differently from the
-# parser the rest of the machinery uses, which is worse than agreeing with it.
+# key are each valid YAML this scan would otherwise read short.
+#
+# Deliberately NOT widened to accept them. The parser the rest of the machinery
+# uses, `.claude/hooks/lib/audit-scope.sh:302`, pins that spelling plus three
+# looser readings: a leading `[[:space:]]*` on its member regex, so a
+# column-0 sequence reads as members there; `name[[:space:]]*:` for the key, so
+# `- name : x` reads there; and an `unq()` that strips a quoted value this scan
+# keeps verbatim. Measured, not inferred from the regex: fed the same fixtures,
+# that parser emits both members where this scan does not. Every divergence
+# therefore makes this scan STRICTER, never looser, and none of them reaches a
+# member drop -- a column-0 roster reds at the caller's non-empty guard,
+# `- name : x` reds at the count below, and a quoted value reds at setup()'s
+# `cp` of a path no agent file has. Widening this scan past the strictest of
+# those readings would answer differently from that parser, which is worse than
+# agreeing with it.
 #
 # What that leaves is counted instead of assumed. The block's member entries are
 # its shallowest `-` lines (a `globs:` item is indented deeper), so an entry that

--- a/.gaia/tests/hooks/audit-root-resolution.bats
+++ b/.gaia/tests/hooks/audit-root-resolution.bats
@@ -93,18 +93,29 @@
 # key are each valid YAML this scan would otherwise read short.
 #
 # Deliberately NOT widened to accept them. The parser the rest of the machinery
-# uses, `.claude/hooks/lib/audit-scope.sh:302`, pins that spelling plus three
-# looser readings: a leading `[[:space:]]*` on its member regex, so a
-# column-0 sequence reads as members there; `name[[:space:]]*:` for the key, so
-# `- name : x` reads there; and an `unq()` that strips a quoted value this scan
-# keeps verbatim. Measured, not inferred from the regex: fed the same fixtures,
-# that parser emits both members where this scan does not. Every divergence
-# therefore makes this scan STRICTER, never looser, and none of them reaches a
-# member drop -- a column-0 roster reds at the caller's non-empty guard,
-# `- name : x` reds at the count below, and a quoted value reds at setup()'s
-# `cp` of a path no agent file has. Widening this scan past the strictest of
-# those readings would answer differently from that parser, which is worse than
-# agreeing with it.
+# uses, `.claude/hooks/lib/audit-scope.sh`'s _audit_scope_parse_auditors, is
+# LOOSER on three readings, not equal: its member line at `:302` leads with
+# `[[:space:]]*`, so a column-0 sequence reads as members there; that same line
+# spells the key `name[[:space:]]*:`, so `- name : x` reads there; and the
+# `unq()` it calls at `:309` (defined at `:244`) strips a quoted value this
+# scan keeps verbatim. Measured on three fixtures, each confirmed valid YAML
+# and two members first: that parser reads both members in all three, where
+# this scan reads NONE (column-0), REFUSES (`- name : x`), or reads the name
+# verbatim with its quotes still on it (`- name: "X"`).
+#
+# What none of them reaches is a SILENT member drop, the only failure this
+# helper exists to prevent. Two are read short and stop: a column-0 roster
+# drops every member and reds at the caller's non-empty guard, and `- name : x`
+# reds at the count below. The third is read WRONG rather than short, so it
+# satisfies the count and stops one step later, at setup()'s `cp` of a path no
+# agent file has. Loud in all three.
+#
+# Note which way that cuts, because it is the opposite of the obvious reading:
+# widening this scan toward those readings would AGREE with that parser more,
+# not less. Agreement is not what earns the strictness. This helper's contract
+# is that a roster it cannot read canonically stops the suite, and every
+# spelling it accepts is one more that can shrink the roster instead of
+# stopping it. It stays strict because stopping is the product.
 #
 # What that leaves is counted instead of assumed. The block's member entries are
 # its shallowest `-` lines (a `globs:` item is indented deeper), so an entry that


### PR DESCRIPTION
Refs #1552

## What

PR #1570's accepted residual, now fixed. It was recorded there rather than folded in because six audit rounds had already been paid on that branch and a prose edit would have rotated the digest into a seventh.

The `roster_members` header in `.gaia/tests/hooks/audit-root-resolution.bats` justified not widening the scan by asserting that `.claude/hooks/lib/audit-scope.sh:302` "pins the same spelling". It does not. That parser is looser on three points:

- its member regex leads with `[[:space:]]*`, so a column-0 sequence reads as members there;
- it spells the key `name[[:space:]]*:`, so `- name : x` reads there;
- its `unq()` strips a quoted value this scan keeps verbatim.

## Why it was worth fixing rather than leaving recorded

The claim was not merely imprecise, it pointed the wrong way. An equivalence invites a future reader to "restore parity" by widening the scan, which is exactly the change the paragraph exists to forbid. Stated as a direction, the constraint survives: every divergence makes this scan **stricter**, never looser, so none of them reaches a member drop, which is the failure the whole helper exists to prevent.

Where each lands: column-0 reds at the caller's non-empty guard (status 0, zero names), `- name : x` reds at the END count (status 1), and a quoted value reds at `setup()`'s `cp` of `.claude/agents/"X".md`.

## Verification

Measured against both readers rather than inferred from the regex. Each fixture confirmed valid YAML and two-member with PyYAML first, then fed to both:

| fixture | PyYAML | `_audit_scope_parse_auditors` | `roster_members` |
|---|---|---|---|
| column-0 sequence | alpha, beta | both members | status 0, **zero names** |
| `- name : beta` | alpha, beta | both members | **status 1**, count message |
| `- name: "beta"` | alpha, beta | both members (unquoted) | status 0, `alpha` + `"beta"` verbatim |

The `cp` arm was verified loud rather than silent by running a bats file whose `setup()` copies `.claude/agents/"code-audit-maintainer-shell".md` and watching it report `not ok`, naming the failed command and the quoted path.

One deliberate departure from the residual's suggested fix: the quoted value is **not** added to the list of spellings this scan "would otherwise read short". It is not read short, it is read verbatim and wrong, so it belongs with the divergences rather than in that list.

No `awk` change. The scan's behavior is what the header now describes correctly.

Suites: `audit-root-resolution.bats` 24/24, `audit-ci-shards.bats` 44/44, `check-registry-settings-permissions.bats` 8/8, all under bash 5 via `.gaia/scripts/bats5.sh`. `whole-tree-invariants.sh` and `shell-lint.sh` pass. `shellcheck` output on the changed file is byte-identical to the merged baseline.

Comment-only change to one release-excluded test file (absent from `.gaia/manifest.json`). Quality Gate skipped: no staged source or gate-affecting config. CHANGELOG: not owed, comment-only, no shipped behavior changed.


## Audit rounds

**Round 1** passed clean but raised two Suggestions. Both were regressions this branch itself had introduced into the sentence it exists to repair, so they were fixed in `340bc06c` rather than recorded: the measured sentence had over-quantified ("emits both members where this scan does not" is true of two of the three readings, not the quoted one), and "none of them reaches a member drop" was leaning on an unwritten *silent* when a column-0 roster drops every member loudly.

That commit also corrected something round 1 did **not** raise, but which this branch's own measurement falsifies. The paragraph closed by saying a widened scan "would answer differently from that parser". The parser is looser on all three readings, so widening this scan toward them would agree with it *more*, not less. The rationale was inverted, and it is the sentence a future reader would act on, in exactly the direction the paragraph exists to forbid. It now rests on this helper's own contract: a roster it cannot read canonically stops the suite, so every spelling it accepts is one more reading it must get exactly right. Round 2 was asked to scrutinise that replacement hardest, and confirmed it true, correctly aimed, and at the right altitude.

Anchors were corrected in the same commit: `unq()` is called at `:309` and defined at `:244`, so `:302` is credited only with the two readings it carries. Round 2 verified all three anchors independently.

**Round 2** passed clean. Its measurements reproduce the header's per-reading claim exactly, and it confirmed all three stops land where the header says.

## Accepted residuals

Round 2's two Suggestions, both graded by the auditor as not warranting a third round. Neither is a false claim, which is what separates them from round 1's findings.

**1. `.gaia/tests/hooks/audit-root-resolution.bats:117`, compressed step.** "every spelling it accepts is one more that can shrink the roster instead of stopping it" reads literally as though accepting a spelling shrinks something. The real hazard is a widened reader that accepts an entry and reads its name wrongly or emptily, satisfying `entries == n` and then being dropped by the caller's per-entry `[ -n "$m" ]`. The next paragraph supplies exactly that mechanism via the bare-`name:` example, so a reader who continues is not left wrong. Suggested bridge, deferred: "every spelling it accepts is one more reading it has to get exactly right, and a reading that is subtly wrong satisfies the count while shrinking the roster."

**2. `.gaia/tests/hooks/audit-root-resolution.bats:145`, pre-existing prose this branch does not touch.** "it emits a record per glob, so a member declaring no globs produces no record and vanishes from its output" has a counterexample: `flush()` at `.claude/hooks/lib/audit-scope.sh:278-286` prints `DEFAULT <member>` unconditionally before the per-glob loop when `is_default` is set, so a `default: true` member with zero globs emits one record and does not vanish. Unexercised by the shipped roster, since `code-audit-frontend` declares globs, and the sentence's load-bearing point survives. Left alone here per surgical-changes; suggested scoping if picked up later: "…and vanishes from its output (a `default: true` member still emits its `DEFAULT` line)."
