### PR TITLE
test(husky): derive the glob-to-arm direction the suite's header calls the live failure mode

### DIFF
--- a/.gaia/tests/hooks/husky-pre-commit.bats
+++ b/.gaia/tests/hooks/husky-pre-commit.bats
@@ -162,9 +162,11 @@ assert_gate_skipped() {
 # assignments, so an arm whose spelling drifts stops the guard rather than
 # quietly shrinking it.
 #
-# What this covers and what it does not. The reverse direction, a glob whose
-# directory no arm names, is pinned by the per-directory @tests above rather
-# than derived; deriving it too is tracked as #1628.
+# Both directions of the contract are derived, one guard each: this one asks
+# whether every arm reaches a glob, the one below it whether every glob reaches
+# an arm. The per-directory @tests above still pin the four directories by
+# name, which is a different claim, that the hook really runs end to end for
+# each of them, not that the two files agree.
 
 # Every directory the hook's change-detection arms grep for, one per line.
 arm_dirs() {
@@ -190,32 +192,53 @@ eslint_globs() {
          | .key' "$REPO_ROOT/.lintstagedrc.json"
 }
 
-# Whether one glob key hands ESLint the files under directory $1.
+# The glob keys whose chain mentions ESLint anywhere, counted by a pattern
+# deliberately wider than the derivation above reads, for the same reason
+# arm_assignment_count is wider than arm_dirs. A count taken with the same
+# `startswith` test would agree with the derivation on every chain that spelling
+# cannot reach (`pnpm exec eslint`, a path-qualified binary), confirming its
+# blind spot instead of exposing it. This one over-counts, so a key the
+# derivation silently drops reds the guard rather than leaving its directory
+# unchecked.
+eslint_glob_mentions() {
+  jq -r '[to_entries[]
+          | select(any(.value[]?; type == "string" and test("eslint")))]
+         | length' "$REPO_ROOT/.lintstagedrc.json"
+}
+
+# Every directory one glob key hands ESLint files under, one per line, and
+# nothing at all for a key of any other shape.
 #
-# This asks for the literal shape `<dir>/**/<rest>`, in the key itself or in one
+# This reads the literal shape `<dir>/**/<rest>`, in the key itself or in each
 # alternative of its leading brace group, rather than matching a probe path
 # against the key. Matching would need lint-staged's own matcher: bash's [[ ]]
 # lets `*` cross a `/` where picomatch does not, so `app/*.{ts,tsx}` would
 # satisfy a probe while leaving app/routes/home.tsx unlinted, which is exactly
-# the miss this guard exists to catch. Demanding the recursive shape is the
-# narrower question, and it fails closed: a key written some other way reds the
-# guard rather than passing it.
-glob_covers_dir() {
-  local dir="$1" glob="$2" head alt
+# the miss these guards exist to catch. Demanding the recursive shape is the
+# narrower question, and it fails closed in both directions: a key written some
+# other way yields no directory, which reds the arm-to-glob guard on the arm it
+# should have covered and reds the glob-to-arm guard on the key itself.
+glob_head_dirs() {
+  local glob="$1" head alt
   case "$glob" in
     *"/**/"*) head="${glob%%/\*\*/*}" ;;
-    *) return 1 ;;
+    *) return 0 ;;
   esac
   case "$head" in
     "{"*"}")
       head="${head#\{}"; head="${head%\}}"
       while IFS= read -r alt; do
-        [ "$alt/" = "$dir" ] && return 0
+        printf '%s/\n' "$alt"
       done <<<"$(printf '%s' "$head" | tr ',' '\n')"
-      return 1
       ;;
-    *) [ "$head/" = "$dir" ] && return 0; return 1 ;;
+    *) printf '%s/\n' "$head" ;;
   esac
+}
+
+# Whether one glob key hands ESLint the files under directory $1.
+glob_covers_dir() {
+  local dir="$1" glob="$2"
+  glob_head_dirs "$glob" | grep -qxF -- "$dir"
 }
 
 @test "every pre-commit arm directory is covered by an ESLint lint-staged glob" {
@@ -248,6 +271,54 @@ glob_covers_dir() {
       return 1
     fi
   done <<<"$dirs"
+}
+
+# --- every ESLint lint-staged glob's directory is named by a hook arm ---
+#
+# The other half of the same contract, and the direction the header calls the
+# live failure mode: a glob whose directory no arm greps for means a commit
+# scoped to that directory alone matches nothing, the else branch fires, and the
+# change lands unlinted *and* untypechecked. That is strictly worse than the
+# uncovered-arm case the guard above catches, which still runs typecheck and
+# Vitest.
+#
+# The glob set is derived from .lintstagedrc.json rather than restated here, and
+# a key whose chain mentions ESLint in a spelling the derivation cannot read is
+# counted separately, so a config entry added with no arm reds here instead of
+# shipping behind a guard that never saw it.
+@test "every ESLint lint-staged glob directory is named by a pre-commit arm" {
+  local dirs globs derived mentions glob glob_dirs dir
+  dirs=$(arm_dirs)
+  [ -n "$dirs" ]
+
+  # Captured rather than piped, for the reason the guard above gives: a jq that
+  # is absent or cannot parse the config must report itself rather than empty
+  # the loop below into a vacuous pass.
+  globs=$(eslint_globs) || {
+    printf 'could not read .lintstagedrc.json (is jq installed?)\n' >&2
+    return 1
+  }
+  [ -n "$globs" ] || {
+    printf '.lintstagedrc.json declares no glob whose chain invokes eslint\n' >&2
+    return 1
+  }
+  derived=$(printf '%s\n' "$globs" | grep -c .)
+  mentions=$(eslint_glob_mentions)
+  [ "$derived" -eq "$mentions" ]
+
+  while IFS= read -r glob; do
+    glob_dirs=$(glob_head_dirs "$glob")
+    [ -n "$glob_dirs" ] || {
+      printf 'eslint glob %s is not of the recursive <dir>/**/ shape, so no directory can be checked against the arms\n' "$glob" >&2
+      return 1
+    }
+    while IFS= read -r dir; do
+      if ! grep -qxF -- "$dir" <<<"$dirs"; then
+        printf 'ESLint .lintstagedrc.json glob %s covers %s, which no pre-commit arm names\n' "$glob" "$dir" >&2
+        return 1
+      fi
+    done <<<"$glob_dirs"
+  done <<<"$globs"
 }
 
 # An arm assignment that never reaches the OR guard is dead: the directory looks

--- a/.gaia/tests/hooks/husky-pre-commit.bats
+++ b/.gaia/tests/hooks/husky-pre-commit.bats
@@ -164,7 +164,7 @@ assert_gate_skipped() {
 #
 # Both directions of the contract are derived, one guard each: this one asks
 # whether every arm reaches a glob, the one below it whether every glob reaches
-# an arm. The per-directory @tests above still pin the four directories by
+# an arm. The per-directory @tests above still pin each of those directories by
 # name, which is a different claim, that the hook really runs end to end for
 # each of them, not that the two files agree.
 
@@ -200,9 +200,15 @@ eslint_globs() {
 # blind spot instead of exposing it. This one over-counts, so a key the
 # derivation silently drops reds the guard rather than leaving its directory
 # unchecked.
+#
+# `tostring` rather than `.value[]?` is what keeps it wider on both axes.
+# lint-staged accepts a bare string chain as well as an array, and `.value[]?`
+# yields nothing for a string, so the derivation's own iteration silently drops
+# `"scripts/**/*.ts": "eslint --fix"`. A count that iterated the same way would
+# drop it too and agree, which is this control's failure mode rather than its
+# job. `tostring` reads a string value, an array value, and any nesting.
 eslint_glob_mentions() {
-  jq -r '[to_entries[]
-          | select(any(.value[]?; type == "string" and test("eslint")))]
+  jq -r '[to_entries[] | select(.value | tostring | test("eslint"))]
          | length' "$REPO_ROOT/.lintstagedrc.json"
 }
 
@@ -227,12 +233,23 @@ glob_head_dirs() {
   case "$head" in
     "{"*"}")
       head="${head#\{}"; head="${head%\}}"
-      while IFS= read -r alt; do
-        printf '%s/\n' "$alt"
-      done <<<"$(printf '%s' "$head" | tr ',' '\n')"
+      head=$(printf '%s' "$head" | tr ',' '\n')
       ;;
-    *) printf '%s/\n' "$head" ;;
   esac
+  # Validate every alternative before emitting any, so a head this reader cannot
+  # expand yields nothing rather than something. A brace group that is not the
+  # whole head (`app/{routes,components}`) is the case that makes the difference:
+  # emitting it literally would leave the shape check satisfied and send the
+  # guard's operator to add a hook arm named after an unexpanded glob, when the
+  # repair is to rewrite the key.
+  while IFS= read -r alt; do
+    case "$alt" in
+      "" | *[{}/]*) return 0 ;;
+    esac
+  done <<<"$head"
+  while IFS= read -r alt; do
+    printf '%s/\n' "$alt"
+  done <<<"$head"
 }
 
 # Whether one glob key hands ESLint the files under directory $1.
@@ -309,7 +326,7 @@ glob_covers_dir() {
   while IFS= read -r glob; do
     glob_dirs=$(glob_head_dirs "$glob")
     [ -n "$glob_dirs" ] || {
-      printf 'eslint glob %s is not of the recursive <dir>/**/ shape, so no directory can be checked against the arms\n' "$glob" >&2
+      printf 'eslint glob %s does not reduce to a plain recursive <dir>/**/ head, so no directory can be checked against the arms\n' "$glob" >&2
       return 1
     }
     while IFS= read -r dir; do


### PR DESCRIPTION
## What

`.gaia/tests/hooks/husky-pre-commit.bats` derived only one half of the pre-commit contract. It read the hook's change-detection arms and asserted that some ESLint `.lintstagedrc.json` glob covers each one. The opposite direction, a glob whose directory no arm greps for, which the file header calls the live failure mode, was pinned only by four hand-written per-directory `@test`s carrying literal path strings.

That asymmetry is the worse gap of the two. Adding a fifth config key with no matching hook arm turned nothing red: a commit scoped to that directory alone matches no arm, the hook takes its `else` branch, and the change lands unlinted **and** untypechecked. The arm-to-glob gap at least still ran typecheck and Vitest.

## How

- `glob_covers_dir` splits into `glob_head_dirs` (a glob key to the directories it covers, expanding a leading brace group) plus a thin membership test, so both guards read one expansion rather than two copies of it.
- A new guard walks the derived ESLint glob set and fails on any directory no arm names.
- It also fails on an ESLint key that is not of the recursive `<dir>/**/` shape, so a key written some other way reds rather than yielding nothing to check.
- It also fails on a count mismatch against a deliberately wider read of the config, mirroring `arm_assignment_count`, so a chain spelling the derivation cannot see (`pnpm exec eslint`, a path-qualified binary) reds the guard instead of silently shrinking its set.

The four per-directory `@test`s stay: they make a different claim, that the hook really runs end to end for each of those directories, not that the two files agree.

## Verification

Each failure path was driven against an adversarial fixture and confirmed red, then the config was restored and the suite confirmed green:

- `scripts/**/*.{ts,tsx}` with an ESLint chain and no arm → `covers scripts/, which no pre-commit arm names`
- `app/*.{ts,tsx}` (non-recursive) → `is not of the recursive <dir>/**/ shape`
- `scripts/**/*.{ts,tsx}` running `pnpm exec eslint` → count mismatch

Also re-verified that the refactored arm-to-glob guard still reds through the brace-group path (hollowing the `{.storybook,.playwright,test}` chain reds on `hook arm test/`).

`bash .gaia/tests/whole-tree-invariants.sh` and `bash .gaia/tests/shell-lint.sh` both pass. The Quality Gate does not apply: no staged file matches its source or gate-affecting-config set.

No CHANGELOG entry: the file is maintainer-only test infrastructure, absent from the adopter manifest, and the shipped `.husky/pre-commit` hook is unchanged.

Closes #1628

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Audit dispositions

`code-audit-maintainer-shell` ran two rounds.

**Round 1: marker withheld, 3 findings, all fixed on this branch** (commit `1f19266d`).

- *Important.* `eslint_glob_mentions` used `.value[]?`, the same iteration as the derivation it was written to check. lint-staged accepts a bare string task chain, and `.value[]?` yields nothing for a string, so `"scripts/**/*.ts": "eslint --fix"` was invisible to both: the counts agreed, the equality control passed, and the guard reported green in exactly the state it exists to catch. Now reads the value with `tostring`.
- *Suggestion.* `glob_head_dirs` expanded a brace group only when it was the whole head, so `app/{routes,components}/**/*.{ts,tsx}` printed an unexpanded literal and the guard blamed a missing hook arm instead of the key's shape. Every alternative is now validated before any is emitted.
- *Suggestion.* A cardinal in a comment describing a derived set, which `.claude/rules/bats-assertions.md` forbids. Dropped.

**Round 2: clean pass, marker earned.** One residual Suggestion, filed rather than fixed here:

- `.gaia/tests/hooks/husky-pre-commit.bats:247` -- the alternative validator's `/` rejection also catches a plain nested head (`app/routes`), so a legitimate key reds with a diagnostic naming the wrong repair. Fails closed, untriggered by the current config, and the arm-to-glob direction demanded the same narrow shape before this diff. Choosing between accepting nested heads (which changes what "covered" means for both guards) and splitting the diagnostic is a real design decision, so it is tracked as #1642 rather than folded in here.
