### PR TITLE
fix(shell-lint): peel an fd-numbered leading redirect, and scope the ap-peel comment to its own position

### DIFF
--- a/.gaia/scripts/lint-oracle-blind-invocations.sh
+++ b/.gaia/scripts/lint-oracle-blind-invocations.sh
@@ -321,6 +321,18 @@ _obi_rewrite_line() {
     lp=""; tp=""; core="$word"
     while :; do
       case "$core" in
+        # The same redirect wearing an explicit file descriptor,
+        # `2>out/log.sh cat`. The digit run sits in FRONT of the operator, so
+        # the class arm below stops at the `2` and leaves the operator inside
+        # the core to be swapped away with it, which is the failure that arm
+        # exists to prevent. Peeled as one unit, digits and operator together,
+        # rather than a character at a time: a lone digit is not punctuation,
+        # and peeling one wherever it leads a word would take the head off an
+        # ordinary path.
+        [0-9]*)
+          [[ $core =~ ^([0-9]+[<>]) ]] || break
+          lp="$lp${BASH_REMATCH[1]}"; core="${core#"${BASH_REMATCH[1]}"}"
+          ;;
         # A redirect glued to its target is peeled with the group openers, so
         # the sentinel keeps the operator in front of it. Without that,
         # `>out/log.sh cat` -- a redirect written before its command -- swaps
@@ -372,7 +384,13 @@ _obi_rewrite_line() {
       # re-emitted as two literal characters, never expanded. The two-character
       # openers each need their own arm because the character class below reads
       # one character at a time, and peeling a lone `$`, `<` or `>` would be
-      # wrong everywhere else it appears.
+      # wrong HERE, in the position this loop occupies: behind an assignment
+      # prefix none of the three stands in front of a command word, so there is
+      # no operator for the sentinel to stay behind. The leading peel above
+      # does take a lone `<` and a lone `>`, deliberately and for exactly the
+      # opposite reason -- there the operator does precede the whole word, and
+      # swapping it away with the word puts the sentinel in command position.
+      # The claim is about this position, not about the two characters.
       # shellcheck disable=SC2016
       case "$core" in
         '$('*) ap="$ap"'$(' ; core="${core:2}" ;;

--- a/.gaia/scripts/tests/lint-oracle-blind-invocations.bats
+++ b/.gaia/scripts/tests/lint-oracle-blind-invocations.bats
@@ -431,6 +431,14 @@ uncovered() {
   quiet '>out/target.sh cat'
 }
 
+@test "is quiet on an fd-numbered redirect glued to such a target" {
+  # The same shape wearing an explicit file descriptor. The digit sits in front
+  # of the operator, so a peel that reads only the punctuation class stops at
+  # the `2`, leaves `2>` inside the core, and swaps operator and all for the
+  # sentinel -- command position again, on a correct file.
+  quiet '2>out/target.sh cat'
+}
+
 @test "a span kept out of a carried body does not vouch for a blind call beside it" {
   # The two records one source line can produce have different anchor
   # provenance, which is why the splitter stopped handing them out joined. A

--- a/.gaia/scripts/tests/lint-oracle-blind-invocations.bats
+++ b/.gaia/scripts/tests/lint-oracle-blind-invocations.bats
@@ -439,6 +439,21 @@ uncovered() {
   quiet '2>out/target.sh cat'
 }
 
+# The descriptor is a digit RUN and the operator is one of two characters, so
+# the arm above witnesses one spelling of a three-part construct and leaves the
+# other two parts asserted by nobody. Narrowed to a single digit and a single
+# operator, the peel keeps that arm green while both spellings below regress to
+# a false blind finding on a correct file. One witness each, so neither the
+# quantifier nor the alternation can be dropped silently.
+
+@test "is quiet on a multi-digit fd redirect glued to such a target" {
+  quiet '12>out/target.sh cat'
+}
+
+@test "is quiet on an input-side fd redirect glued to such a target" {
+  quiet '2<out/target.sh cat'
+}
+
 @test "a span kept out of a carried body does not vouch for a blind call beside it" {
   # The two records one source line can produce have different anchor
   # provenance, which is why the splitter stopped handing them out joined. A


### PR DESCRIPTION
Two findings in `.gaia/scripts/lint-oracle-blind-invocations.sh`, drained together because they sit in the same file, one loop apart.

## The fd-numbered leading redirect (#1616)

The leading peel's character class is `[({;&|<>]`, so the peel breaks at a digit. A redirect written before its command with an explicit file-descriptor number loses its operator to the whole-word sentinel swap: the sentinel lands in command position, bash alias-expands it, and the lint reports a file redirection target as a blind invocation.

A scan-root file containing `2>out/target.sh cat` exits 1 with `invocation in a shape the capability oracle cannot see`, on a correct file, reddening a declared-required blocking context (the suite's first arm runs this scan over the real tree in the `Audit CI Tests` scripts shard).

Latent, not live: no such site exists under the four scan roots today. Worth closing anyway because it is the last unmodelled member of the operator set enumerated during PR #1615's round-8 audit, rather than one more discovered a round at a time.

**Fix.** An arm ahead of the character-class arm matches a digit run followed by a redirect operator and moves both into `$lp`. It peels the pair as one unit rather than a character at a time: a lone digit is not punctuation, and peeling one wherever it leads a word would take the head off an ordinary path. The append (`2>>`), clobber (`2>|`) and multi-digit (`12>`) spellings fall out of the existing class arm once the first `<digits><op>` pair is off.

## The ap-peel comment (#1617)

The comment on the post-assignment-prefix peel justified its separate `<(` and `>(` arms by saying that peeling a lone `$`, `<` or `>` "would be wrong everywhere else it appears". The leading peel contradicts that as written: it takes a lone `<` and a lone `>` deliberately, which is exactly what keeps a redirect glued to its target out of command position.

Read flat, the sentence tells the next maintainer that the leading peel's character class is a defect, and a maintainer acting on it would remove two characters a suite arm now depends on. The two loops are correct as they stand; only the comment was wrong.

**Fix.** The sentence is scoped to the position the loop occupies, and names the leading peel's opposite reason for taking the same two characters.

## Verification

The peel's regex is a three-part construct (a digit run, a quantifier, an operator alternation), so each part has its own witness in the suite:

| mutant | reds |
|---|---|
| `^([0-9]+[<>])` → `^([0-9][>])` | `12>` and `2<` arms; `2>` stays green |
| `^([0-9]+[<>])` → `^([0-9]+>)` | `2<` arm; `2>` and `12>` stay green |
| arm disabled outright | all three fd arms |
| operator dropped from `$lp` instead of kept | all three fd arms |

The linter was restored from the index after each mutant.

Adversarially, a genuinely blind call sitting behind an fd redirect (`2>out/log.sh .gaia/scripts/target.sh`) is still reported, so the peel opens no false clean; the anchored form behind the same redirect stays quiet. An arm pinning that was written and then dropped, because it stayed green under every mutant tried: it held a verdict without proving a rule, which is the shape this suite's header exists to reject.

Full suite 49/49, `.gaia/tests/shell-lint.sh` clean, `.gaia/tests/whole-tree-invariants.sh` passes.

Quality Gate: skipped on a positive answer, no staged source or gate-affecting config (two files, `.sh` and `.bats`).

CHANGELOG: no entry. Both the script and its suite are release-excluded, so nothing here reaches an adopter tree; this matches the precedent set by #1641.

Audit: two rounds, both clean. Round 1's single Suggestion (the arm witnessed one spelling of a three-part construct) was verified by mutation and folded; round 2 returned zero findings.

Closes #1616
Closes #1617

🤖 Generated with [Claude Code](https://claude.com/claude-code)