### PR TITLE
fix(guards): exempt wiki/log.md from the debt-origin contract net

### DIFF
--- a/.gaia/scripts/tests/debt-origin-contract.bats
+++ b/.gaia/scripts/tests/debt-origin-contract.bats
@@ -50,19 +50,25 @@ setup() {
   # Without it, this suite's own needles and debt-origin-lib.bats's own
   # fixtures would count as third copies of the contract.
   #
-  # `wiki/log.md` is excluded because no assertion below can apply to it. It
-  # is a generated, append-only sync ledger, written a line at a time by
-  # `/gaia-wiki sync` and overwritten wholesale at release, so it is neither
-  # an emitting route nor an instruction surface and can never be made to
-  # point at an owner file. Without the exclusion, a sync reason quoting a
-  # needle verbatim -- which is what a commit about the provenance marker
-  # produces -- reds this suite over the ledger's own wording, with a
-  # failure message describing the guard's model rather than the tree.
+  # The generated wiki files are excluded because no assertion below can
+  # apply to either one. `wiki/log.md` is an append-only sync ledger written
+  # a line at a time by `/gaia-wiki sync`; `wiki/hot.md` is a recent-context
+  # cache an agent is told to overwrite completely with a free-prose session
+  # summary. Both are overwritten wholesale as a pair at release. Neither is
+  # an emitting route nor an instruction surface, and neither can be made to
+  # point at an owner file, since the next write discards whatever pointer a
+  # previous one carried. Without the exclusion, prose quoting a needle
+  # verbatim -- which is what a session or a sync about the provenance marker
+  # produces -- reds this suite over a generated file's own wording, with a
+  # failure message describing the guard's model rather than the tree. The
+  # sibling roster reconcile in .gaia/tests/lib/doc-noop-terminal-contract.bats
+  # excludes the same pair for the same reason.
   EXCLUDE_PATHSPEC=(
     ':!.gaia/local/'
     ':!.gaia/tests/'
     ':!.gaia/scripts/tests/'
     ':!wiki/log.md'
+    ':!wiki/hot.md'
   )
 }
 

--- a/.gaia/scripts/tests/debt-origin-contract.bats
+++ b/.gaia/scripts/tests/debt-origin-contract.bats
@@ -49,7 +49,21 @@ setup() {
   # `.gaia/tests/` (both listed separately in `.gaia/release-exclude`).
   # Without it, this suite's own needles and debt-origin-lib.bats's own
   # fixtures would count as third copies of the contract.
-  EXCLUDE_PATHSPEC=(':!.gaia/local/' ':!.gaia/tests/' ':!.gaia/scripts/tests/')
+  #
+  # `wiki/log.md` is excluded because no assertion below can apply to it. It
+  # is a generated, append-only sync ledger, written a line at a time by
+  # `/gaia-wiki sync` and overwritten wholesale at release, so it is neither
+  # an emitting route nor an instruction surface and can never be made to
+  # point at an owner file. Without the exclusion, a sync reason quoting a
+  # needle verbatim -- which is what a commit about the provenance marker
+  # produces -- reds this suite over the ledger's own wording, with a
+  # failure message describing the guard's model rather than the tree.
+  EXCLUDE_PATHSPEC=(
+    ':!.gaia/local/'
+    ':!.gaia/tests/'
+    ':!.gaia/scripts/tests/'
+    ':!wiki/log.md'
+  )
 }
 
 # ---------- shared extraction helpers ----------


### PR DESCRIPTION
Closes #1677

## Problem

`.gaia/scripts/tests/debt-origin-contract.bats`'s shared `EXCLUDE_PATHSPEC` netted the generated wiki files. Assertions 2b and 3 require every file the `gaia-debt-origin` grep returns to be an allowlisted emitting route and to point at `.claude/skills/file-tech-debt/SKILL.md`. Neither `wiki/log.md` nor `wiki/hot.md` can satisfy that by construction: `log.md` is an append-only sync ledger written a line at a time by `/gaia-wiki sync`, `hot.md` is a recent-context cache an agent is told to overwrite completely with a free-prose session summary, and release overwrites the pair wholesale. Neither emits anything or instructs anybody, and the next write discards whatever pointer a previous one carried.

Any `/gaia-wiki sync` or session summary quoting the token verbatim, which is what work on the provenance marker produces, reddened shard `scripts-1` on a mechanical wiki-sync PR. The failure text described the guard's own model rather than anything wrong with the tree. Observed on #1676 and worked around by rewording one log line, which left the trap armed for the next sync.

## Fix

Add `':!wiki/log.md'` and `':!wiki/hot.md'` to `EXCLUDE_PATHSPEC`, with a comment naming the generated-wiki-file class and why no assertion in the suite can reach it. The exclusion mechanism is already the suite's own idiom for this, per the existing `.gaia/scripts/tests/` entry, and the sibling roster reconcile in `.gaia/tests/lib/doc-noop-terminal-contract.bats:95` excludes the same pair for the same reason. The array is reflowed one entry per line so the reasons stay legible as it grows.

## Verification

The guard was driven red and back to green in both directions, for each excluded file:

- Token planted in `wiki/log.md`: 2b and 3 red before the fix (`unaccounted-for file names gaia-debt-origin: wiki/log.md`), green after.
- Token planted in `wiki/hot.md`: green with the exclusion; mutating the exclusion away reds both assertions with the matching message.
- Token planted in `README.md` after the fix: 2b and 3 still red. A genuine unaccounted-for emitter is unaffected, so the net narrows nothing it exists to catch.
- `.gaia/scripts/tests/debt-origin-contract.bats` green on a clean tree (bash 5 via `.gaia/scripts/bats5.sh`).
- `bash .gaia/tests/shell-lint.sh` and `bash .gaia/tests/whole-tree-invariants.sh` both pass.

## Audit

`code-audit-maintainer-shell` withheld its first-round marker on one Important finding: the exclusion covered `log.md` only, leaving the identical trap armed on `hot.md`. Verified independently and fixed in the second commit.

The same finding named a larger repair out of scope here: the "generated wiki files" exclusion list is three uncoordinated literal copies with no shared source, and `.gaia/scripts/tests/cost-consolidate-absence.bats:43` still omits `hot.md`. Filed as #1680 rather than folded in, since converging the three copies onto a shared helper is a design decision of its own.

Quality Gate skipped: no source file staged. No CHANGELOG entry: `.gaia/scripts/tests` is release-excluded, so no adopter-visible behavior changes.