### PR TITLE
fix(tests): exclude wiki/hot.md from the cost-consolidate absence scan

### DIFF
--- a/.gaia/scripts/tests/cost-consolidate-absence.bats
+++ b/.gaia/scripts/tests/cost-consolidate-absence.bats
@@ -38,9 +38,13 @@ setup() {
 }
 
 @test "UAT-007: scoped git grep for cost-consolidate is empty across .specify .gaia .claude wiki" {
+  # wiki/log.md and wiki/hot.md are each wholly overwritten with free prose, so
+  # a session summary that happens to quote this needle is that file's own
+  # wording rather than a live reference this assertion can say anything about.
   run git -C "$REPO_ROOT" grep -l cost-consolidate -- \
     .specify .gaia .claude wiki \
-    ':!.gaia/local' ':!.gaia/manifest.json' ':!CHANGELOG.md' ':!wiki/log.md' \
+    ':!.gaia/local' ':!.gaia/manifest.json' ':!CHANGELOG.md' \
+    ':!wiki/log.md' ':!wiki/hot.md' \
     ':!.gaia/scripts/tests/cost-consolidate-absence.bats' \
     ':!.gaia/tests/hooks/fixtures/audit-routing-before.tsv'
   # git grep exits 1 (not 0) when it finds no match; the assertion that

--- a/.gaia/scripts/tests/cost-consolidate-absence.bats
+++ b/.gaia/scripts/tests/cost-consolidate-absence.bats
@@ -5,24 +5,21 @@
 # git grep), plus SC5's archived-absent half: cost-backfill.sh still no-ops
 # safely when neither archived/ tree exists.
 #
-# DP-001: `.gaia/manifest.json` legitimately still lists cost-consolidate.sh
-# until `/gaia-release` regenerates it (release-generated, FC-7 forbids
-# editing it here), so it is excluded from the grep by design, not an
-# oversight. `.gaia/local` is gitignored (not tracked, so `git grep` would
-# never surface it anyway) and CHANGELOG.md/wiki/log.md are excluded because
-# they may legitimately narrate the removal historically. This file itself is
-# excluded too: it is the absence assertion, so it names the retired symbol on
-# purpose (once committed it is tracked, and `git grep` would otherwise match
-# its own text). The routing-parity fixture
+# DP-001: `.gaia/manifest.json` is release-generated and FC-7 forbids editing
+# it here, so it is excluded whatever it currently holds; `/gaia-release`
+# decides its contents, not this suite. `.gaia/local` is gitignored (not
+# tracked, so `git grep` would never surface it anyway). CHANGELOG.md is
+# excluded because it may legitimately narrate the removal historically.
+# wiki/log.md and wiki/hot.md are excluded on a different ground: each is
+# wholly overwritten with free prose rather than edited, so a summary that
+# quotes the retired symbol is that file's own wording and not a live
+# reference this suite can say anything about. This file itself is excluded
+# too: it is the absence assertion, so it names the retired symbol on purpose
+# (once committed it is tracked, and `git grep` would otherwise match its own
+# text). The routing-parity fixture
 # (.gaia/tests/hooks/fixtures/audit-routing-before.tsv) is excluded on the same
 # grounds: it is a generated enumeration of every tracked path, so it carries
 # this test's own filename as a data row, never a call to the retired script.
-#
-# Parallel-authoring note: two live call sites (spec-archive-merged.sh via
-# spec-close.md, and plan-archive.sh) are removed by sibling tasks in the same
-# phase as this one. The grep test below is the phase-integration gate: it is
-# expected to be non-empty until every sibling task's edits land alongside
-# this one, at which point it goes empty.
 #
 # Assertion style: bash-3.2-safe per .claude/rules/bats-assertions.md.
 
@@ -38,9 +35,6 @@ setup() {
 }
 
 @test "UAT-007: scoped git grep for cost-consolidate is empty across .specify .gaia .claude wiki" {
-  # wiki/log.md and wiki/hot.md are each wholly overwritten with free prose, so
-  # a session summary that happens to quote this needle is that file's own
-  # wording rather than a live reference this assertion can say anything about.
   run git -C "$REPO_ROOT" grep -l cost-consolidate -- \
     .specify .gaia .claude wiki \
     ':!.gaia/local' ':!.gaia/manifest.json' ':!CHANGELOG.md' \


### PR DESCRIPTION
## What

`UAT-007` in `.gaia/scripts/tests/cost-consolidate-absence.bats` scans `.specify .gaia .claude wiki` for the string `cost-consolidate` and excluded `wiki/log.md` but not `wiki/hot.md`.

Both files are wholly overwritten with free prose rather than edited: the wiki session-stop hook instructs an agent to overwrite `hot.md` completely with a session summary, and the release scrub rewrites the two as one pair. A session summary that happens to quote the needle therefore reds the suite over a generated file's own wording, and the failure message names only the emptiness assertion, describing the guard's own model rather than anything wrong with the tree.

The sibling suite `.gaia/tests/lib/doc-noop-terminal-contract.bats` already excludes the pair; this one had drifted. Adding the second exclusion leaves both copies agreeing again.

A second commit folds three header-prose suggestions the audit gate raised: the DP-001 block now enumerates the new exclusion (it read as exhaustive while being incomplete), the `.gaia/manifest.json` rationale is restated forward-looking because the manifest no longer lists the retired script, and a stale parallel-authoring note claiming the grep test is expected to be non-empty is deleted.

## Why the one-liner rather than a shared helper

The issue as originally filed left that choice open and rested it on a three-copy count. That count was wrong: it named `.gaia/scripts/tests/debt-origin-contract.bats` as a third copy, and that file has never carried a generated-wiki-file exclusion (its only exclusion list is directory-scoped). Verified with `git grep -n ':!wiki/hot.md'` (one file repo-wide) and `git log -S':!wiki/hot.md' -- .gaia/scripts/tests/debt-origin-contract.bats` (empty). The issue has been corrected to two copies and re-graded `handler:prompt` / `difficulty:easy`.

At two call sites that both spell their pathspecs inline, a sourced helper buys a shared source at the cost of an indirection neither site needs.

## Verification

Both directions, with adversarial fixtures:

- Needle written into `wiki/hot.md`: suite **reds before** the change, **greens after**.
- Needle written into `wiki/index.md`: suite **still reds** after the change, so the scan is narrowed to the two generated files rather than blunted.

The audit member independently reproduced this with a four-way fixture of its own (nothing planted, a live tracked caller, `wiki/hot.md`, `wiki/other.md`) and got the same bounding.

Also run: `.gaia/tests/shell-lint.sh` (passed), `.gaia/tests/whole-tree-invariants.sh` (passed).

Quality Gate skipped by its own rule: the staged set is one `.bats` file, no source or gate-affecting config. No CHANGELOG entry: `.gaia/scripts/tests/` is release-excluded, so nothing here reaches adopters.

## Out-of-scope machinery findings (recorded, not filed)

Both sit on the file this PR changes, both are latent at the fork point (each reads identically whether or not this change lands), and neither leaves a pointer in shipped content, so both clear the waive rule's disqualifiers.

- `.gaia/scripts/tests/cost-consolidate-absence.bats:40` — `':!CHANGELOG.md'` is inert: the positive pathspecs are `.specify .gaia .claude wiki` and `CHANGELOG.md` sits at the repo root, so it can never enter the scanned set, while the DP-001 header presents it as a live carve-out. <!-- gaia-debt-key: v1 class=holistic/uncoupled-restatement path=.gaia/scripts/tests/cost-consolidate-absence.bats line=40 --> <!-- gaia-debt-origin: branch=worktree-debt+1680-exclude-wiki-hot mode=drain unit=1680 changed=1 head=19642985a203acc35909cf68e4e53c2760d1b490 -->
- `.gaia/scripts/tests/cost-consolidate-absence.bats:30` — shellcheck SC1091 info on the runtime-resolved `source` of the `files.sh` helper. Below the harness threshold (bats runs at `severity=warning`), unchanged line, no runtime failure mode; `shell-lint` is clean without a directive. <!-- gaia-debt-key: v1 class=holistic/unclassified path=.gaia/scripts/tests/cost-consolidate-absence.bats line=30 --> <!-- gaia-debt-origin: branch=worktree-debt+1680-exclude-wiki-hot mode=drain unit=1680 changed=1 head=19642985a203acc35909cf68e4e53c2760d1b490 -->

## Cross-remit finding (filed)

`.github/workflows/audit-ci-tests.yml:404` — the path-filter rationale still names the retired `cost-consolidate.sh`. Not waive-eligible (`audit_path_is_machinery` returns false and this PR does not change the file), so filed as #1684.

Closes #1680
