### PR TITLE
fix(ci): drop the retired cost-consolidate.sh from the audit-ci-tests filter rationale

### DIFF
--- a/.github/workflows/audit-ci-tests.yml
+++ b/.github/workflows/audit-ci-tests.yml
@@ -400,11 +400,11 @@ jobs:
               # the assertions it broke zero times.
               - '.gaia/tests/helpers/**'
               # The .gaia/tests/lib/ suites exercise the SPEC-ledger lib scripts
-              # under .specify/extensions/gaia/lib/ (spec-archive-merged.sh and
-              # its shared cost-consolidate.sh, the allocators, ledger-update,
-              # etc.), so trigger on that source dir too. A source-only edit then
-              # runs the suite, matching the test-dir + source-dir pairing the
-              # filters above already use (.gaia/tests/hooks/** + .claude/hooks/**;
+              # under .specify/extensions/gaia/lib/ (spec-archive-merged.sh, the
+              # allocators, ledger-update, etc.), so trigger on that source dir
+              # too. A source-only edit then runs the suite, matching the
+              # test-dir + source-dir pairing the filters above already use
+              # (.gaia/tests/hooks/** + .claude/hooks/**;
               # .gaia/tests/forensics/** + .github/forensics/**).
               - '.specify/extensions/gaia/lib/**'
               # registry.bats (.gaia/tests/lib/) asserts every commands/*.md


### PR DESCRIPTION
Drains the tech-debt issue: the `dorny/paths-filter` rationale in `audit-ci-tests.yml` still named `cost-consolidate.sh`, retired and absent from the tree under every name, as half the ground for watching `.specify/extensions/gaia/lib/**`. A maintainer auditing why the filter watches that source directory was sent to a file that does not exist, and could not tell from the comment whether the entry was still earned by the remaining scripts or was itself residue.

The filter's behavior was always correct; only its stated rationale was stale. The remaining scripts (`spec-archive-merged.sh`, the allocators, `ledger-update`) now carry the entry's ground on their own.

Comment-only, no behavior change. `.github/workflows/audit-ci-tests.yml` is release-excluded, so nothing here reaches an adopter bundle and no CHANGELOG entry is owed.

## Verification

- `git grep cost-consolidate -- .github/` returns nothing.
- Workflow YAML parses.
- 91/91 bats across `workflow-filter-coverage`, `retrigger-reachability`, `cost-consolidate-absence`, `lint-yaml`, `audit-ci-shards`.
- `.gaia/tests/whole-tree-invariants.sh`: all invariants pass.

## Deferred, filed separately

#1684 flagged a second half it deliberately did not fold in: the UAT-007 absence suite's positive pathspecs stop at `.specify .gaia .claude wiki`, so it structurally could not reach `.github/` and reported clean over this live instance for the whole period it existed. Widening it is a scope decision, not a wording one, so it is filed as #1685 rather than folded here.

Closes #1684
