### PR TITLE
debt(tests): scan the whole tracked tree for the retired cost-consolidate name

### DIFF
--- a/.gaia/scripts/tests/cost-consolidate-absence.bats
+++ b/.gaia/scripts/tests/cost-consolidate-absence.bats
@@ -1,9 +1,9 @@
 #!/usr/bin/env bats
 #
 # UAT-007: cost-consolidate.sh is retired. This suite asserts the file is
-# gone and that no tracked file still references it (a scoped, allowlisted
-# git grep), plus SC5's archived-absent half: cost-backfill.sh still no-ops
-# safely when neither archived/ tree exists.
+# gone and that no tracked file still references it (a whole-tree git grep
+# carrying named exclusions), plus SC5's archived-absent half: cost-backfill.sh
+# still no-ops safely when neither archived/ tree exists.
 #
 # DP-001: `.gaia/manifest.json` is release-generated and FC-7 forbids editing
 # it here, so it is excluded whatever it currently holds; `/gaia-release`
@@ -21,6 +21,24 @@
 # grounds: it is a generated enumeration of every tracked path, so it carries
 # this test's own filename as a data row, never a call to the retired script.
 #
+# The grep names no positive root: its subject is the whole tracked tree minus
+# those exclusions. Listing the roots instead is the obvious alternative, and it
+# fails in one direction only, silently. A root nobody thought to list is not a
+# gap the suite reports, it is a surface the suite cannot read, and the green it
+# returns over that surface is indistinguishable from a real absence -- which is
+# the failure this scan exists to make impossible, reproduced inside the scan
+# itself. The header claim above ("no tracked file") is then also literally what
+# the pathspec establishes, rather than a wider claim a reader has to discount.
+#
+# The honest limit, and why it fails safe. The assertion is over tree state, not
+# over a diff, so the CI path filter deciding whether this suite runs controls
+# WHEN a reintroduced reference is caught, never WHETHER. One landing on a
+# surface that filter does not watch is caught by the next run the filter does
+# arm, on a pull request that did not introduce it. No glob set can arm a
+# whole-tree scan, so late-and-certain is this guard's ceiling; a narrower
+# pathspec buys punctuality on the roots it lists by trading away the rest for
+# never.
+#
 # Assertion style: bash-3.2-safe per .claude/rules/bats-assertions.md.
 
 setup() {
@@ -34,9 +52,8 @@ setup() {
   [ ! -f "$REPO_ROOT/.specify/extensions/gaia/lib/cost-consolidate.sh" ]
 }
 
-@test "UAT-007: scoped git grep for cost-consolidate is empty across .specify .gaia .claude wiki" {
+@test "UAT-007: git grep for cost-consolidate is empty across the whole tracked tree" {
   run git -C "$REPO_ROOT" grep -l cost-consolidate -- \
-    .specify .gaia .claude wiki \
     ':!.gaia/local' ':!.gaia/manifest.json' ':!CHANGELOG.md' \
     ':!wiki/log.md' ':!wiki/hot.md' \
     ':!.gaia/scripts/tests/cost-consolidate-absence.bats' \

--- a/.gaia/scripts/tests/cost-consolidate-absence.bats
+++ b/.gaia/scripts/tests/cost-consolidate-absence.bats
@@ -27,19 +27,21 @@
 # gap the suite reports, it is a surface the suite cannot read, and the green it
 # returns over that surface is indistinguishable from a real absence -- which is
 # the failure this scan exists to make impossible, reproduced inside the scan
-# itself. The header claim above ("no tracked file") is then also literally what
-# the pathspec establishes, rather than a wider claim a reader has to discount.
+# itself. The header claim above ("no tracked file") is then what the pathspec
+# establishes, up to the exclusions enumerated with it, rather than a wider
+# claim a reader has to discount against an unstated set of unread roots.
 #
 # The honest limit, and why it fails safe. The assertion is over tree state, not
 # over a diff, so the CI path filter deciding whether this suite runs controls
 # WHEN a reintroduced reference is caught, never WHETHER. One landing on a
 # surface that filter does not watch is caught by the next run the filter does
 # arm, on a pull request that did not introduce it. Arming it punctually takes a
-# catch-all entry in that filter, which would run its whole matrix, pnpm
-# installs included, on every pull request in the repository; the filter's own
-# comments price that and decline it. Late-and-certain is what is accepted
-# instead, and a narrower pathspec here buys none of it back: it trades the
-# surfaces it drops for never rather than for late.
+# catch-all entry in that filter, which would run every matrix leg its `code`
+# output gates, this job's two pnpm installs among them, on very nearly every
+# pull request; that filter's sibling output exists because the same cost was
+# priced and declined on exactly those grounds. Late-and-certain is what is
+# accepted instead, and a narrower pathspec here buys none of it back: it trades
+# the surfaces it drops for never rather than for late.
 #
 # Assertion style: bash-3.2-safe per .claude/rules/bats-assertions.md.
 

--- a/.gaia/scripts/tests/cost-consolidate-absence.bats
+++ b/.gaia/scripts/tests/cost-consolidate-absence.bats
@@ -34,10 +34,12 @@
 # over a diff, so the CI path filter deciding whether this suite runs controls
 # WHEN a reintroduced reference is caught, never WHETHER. One landing on a
 # surface that filter does not watch is caught by the next run the filter does
-# arm, on a pull request that did not introduce it. No glob set can arm a
-# whole-tree scan, so late-and-certain is this guard's ceiling; a narrower
-# pathspec buys punctuality on the roots it lists by trading away the rest for
-# never.
+# arm, on a pull request that did not introduce it. Arming it punctually takes a
+# catch-all entry in that filter, which would run its whole matrix, pnpm
+# installs included, on every pull request in the repository; the filter's own
+# comments price that and decline it. Late-and-certain is what is accepted
+# instead, and a narrower pathspec here buys none of it back: it trades the
+# surfaces it drops for never rather than for late.
 #
 # Assertion style: bash-3.2-safe per .claude/rules/bats-assertions.md.
 


### PR DESCRIPTION
Drains the tech-debt issue: the UAT-007 absence scan is the only guard asserting that no tracked file still names the retired `cost-consolidate.sh`, and its `git grep` carried four positive roots (`.specify .gaia .claude wiki`). Everything else — `.github`, `.husky`, `docs`, `app`, `test`, `public`, and every root-level file — was not a gap the suite could report but a surface it could not read, so the green it returned there was indistinguishable from a real absence. A live dangling reference sat at `.github/workflows/audit-ci-tests.yml` from the retirement until #1684, with the guard built for exactly it reporting clean the whole time.

## The scope decision

The issue deferred two questions rather than folding the fix into #1684. Both are settled here.

**Surface size.** Drop the root allowlist entirely rather than appending `.github` to it, following the correction posted on the issue. The scan is now the whole tracked tree minus the named `:!` exclusions, which is what the suite header already claimed it was ("no tracked file still references it"), and no future root has to be remembered into it. Appending one directory at a time leaves the same class of hole open, one root at a time.

A side effect worth naming: the `:!CHANGELOG.md` exclusion becomes load-bearing for the first time. `CHANGELOG.md` sits at the repo root, outside every former positive root, so the term excluded nothing while the header presented it as the reason the changelog may narrate the removal historically. Prose and mechanism now agree.

**Trigger arming.** No new CI glob. The assertion is over tree *state*, not over a diff, so the `code:` filter deciding whether the suite runs controls **when** a reintroduced reference is caught, never **whether**: one landing on a surface the filter does not watch is caught by the next run the filter does arm, on a pull request that did not introduce it. No glob set can arm a whole-tree scan, so late-and-certain is this guard's ceiling, and it is strictly above the `never` a narrower pathspec offers for the same surfaces. That reasoning is recorded in the suite header so the next reader does not have to re-derive it.

## Verification

Adversarial fixtures, each a tracked file planted on a surface the old pathspec could not read, then removed:

| Planted at | New pathspec | Old pathspec |
|---|---|---|
| `docs/ADVERSARIAL-FIXTURE.md` | `not ok 2` | exit 1, no output (reports clean) |
| `.github/ADVERSARIAL-FIXTURE.md` | `not ok 2` | — |
| `ADVERSARIAL-FIXTURE.md` (repo root) | `not ok 2` | — |
| appended to `CHANGELOG.md` | `ok 2` (exclusion still suppresses) | — |

Green after restore: the suite itself (3/3), `bash .gaia/tests/whole-tree-invariants.sh` (all members), `shell-lint` + `shell-lint-bash32` + `bats-shards` (38 ok, 0 not-ok), and `workflow-filter-coverage` + `audit-guard-structural` + `check-worktree-reap-suite-preserved` + `retrigger-reachability` (0 not-ok).

Quality Gate skipped by its own rule: the only staged file is a `.bats` suite, which matches neither the source nor the gate-affecting-config list.

`.gaia/scripts/tests` is release-excluded, so nothing here reaches an adopter bundle and no CHANGELOG entry is owed.

Closes #1685
