### PR TITLE
debt(comments): cut the IndexPage test comments that restate their own code

### DIFF
--- a/app/pages/Public/IndexPage/tests/index.test.tsx
+++ b/app/pages/Public/IndexPage/tests/index.test.tsx
@@ -6,9 +6,8 @@ import {LANGUAGES} from '~/languages';
 import common from '~/languages/en/common';
 import Meta, {Default} from './index.stories';
 
-// The story's decorator wraps these components in a stubbed data router, so
-// the router hooks they call (useFetcher, useLocation) have the context they
-// need outside the app.
+// The story's decorator wraps the page in a stubbed data router, so the router
+// hooks it and its children call have the context they need outside the app.
 const IndexPageStory = composeStory(Default, Meta);
 
 describe('IndexPage', () => {

--- a/app/pages/Public/IndexPage/tests/index.test.tsx
+++ b/app/pages/Public/IndexPage/tests/index.test.tsx
@@ -6,8 +6,8 @@ import {LANGUAGES} from '~/languages';
 import common from '~/languages/en/common';
 import Meta, {Default} from './index.stories';
 
-// composeStory applies the story's decorators (stubs.reactRouter()) so that
-// router hooks (useFetcher, useLocation) work without a real server.
+// The story's decorator supplies a stub router, so the router hooks these
+// components call (useFetcher, useLocation) work without a real server.
 const IndexPageStory = composeStory(Default, Meta);
 
 describe('IndexPage', () => {
@@ -43,12 +43,11 @@ describe('IndexPage', () => {
     expect(button).toBeInTheDocument();
   });
 
-  // Conditional: language select tracks LANGUAGES (LanguageSelect guard)
+  // Conditional: language select
 
-  // LanguageSelect renders nothing with a single configured language and the
-  // <select> only once a second locale is added (add-locale grows LANGUAGES).
-  // Branch at declaration so the suite stays green in both modes without a
-  // conditional expect.
+  // Branch at declaration so the suite stays green whether or not a second
+  // locale is configured, without a conditional expect that would pass
+  // vacuously in the mode it does not exercise.
   test.runIf(LANGUAGES.length <= 1)(
     'renders no language select for a single configured language',
     () => {

--- a/app/pages/Public/IndexPage/tests/index.test.tsx
+++ b/app/pages/Public/IndexPage/tests/index.test.tsx
@@ -6,8 +6,9 @@ import {LANGUAGES} from '~/languages';
 import common from '~/languages/en/common';
 import Meta, {Default} from './index.stories';
 
-// The story's decorator supplies a stub router, so the router hooks these
-// components call (useFetcher, useLocation) work without a real server.
+// The story's decorator wraps these components in a stubbed data router, so
+// the router hooks they call (useFetcher, useLocation) have the context they
+// need outside the app.
 const IndexPageStory = composeStory(Default, Meta);
 
 describe('IndexPage', () => {


### PR DESCRIPTION
Two comment-quality defects in `app/pages/Public/IndexPage/tests/index.test.tsx`, both surfaced by a peer prose review alongside #1703 and both untouched by the four locations PR #1705 drained.

**File header (#1706).** The first clause restated the `composeStory(Default, Meta)` call directly beneath it, and `stubs.reactRouter()` named a symbol living in `index.stories.tsx`, so a rename there orphans the comment with nothing reporting it. What earns its place is the cross-file contract, and that is what the rewrite keeps.

**Language-select block (#1707).** The banner re-narrated the paragraph two lines below it, and that paragraph's first two sentences copied `LanguageSelect`'s own comment near-verbatim, which drifts independently the moment the guard changes. The banner is reduced to navigation over the group, the copied sentences are dropped, and the why-not survives, now stating the vacuous-pass hazard the old wording left implicit.

No behavior change: comments only.

## Audit rounds

The gate ran four rounds. The two repairs it forced were both in the replacement prose rather than in the issues' analysis:

- **Round 1** — the rewritten header said the router hooks "work without a real server". Wrong missing thing: the decorator's `createRoutesStub` supplies a data-router context, and the hooks throw for want of that context, not for want of a backend.
- **Round 2** — the header carried a closed parenthetical `(useFetcher, useLocation)` naming two of the four router hooks the rendered tree calls (`useRouteLoaderData` via `useOptionalRequestInfo`, `useFetcher`, `useFetchers` via `useOptimisticThemeMode`, `useLocation`). The omission that mattered was `useRouteLoaderData`, the hook the theme-switch comment below reasons about, so the closed list argued against its own file. `"these components"` also had no antecedent above a line composing one story.
- **Round 3** — clean, marker earned.
- **Round 4** — rebase only. #1711 landed on main mid-round and touched this same file, adding a test directly above the banner #1707 rewrites. Their test is kept verbatim and the banner applied over it; the diff against main is the two comment blocks and nothing else.

One finding was declined: restoring a clause tying the language-select why-not back to the `LanguageSelect` guard. That copy is precisely what #1707 exists to remove, since the component owns the fact in its own comment and a copy drifts; both test names already state the behavior.

## Out-of-scope machinery findings (recorded, not filed)

- `app/pages/Public/IndexPage/tests/index.test.tsx:71` — the `// Absent: marketing chrome, branding, and layout landmarks` banner heads a single `test.each` statement whose five row labels already say what is absent. Waived rather than filed: the block expands to five cases, so it reads as a group banner the rule keeps, and it is one leg of a deliberate Present/Conditional/Absent partition. The site is outside this diff and reads identically at the fork point, so it is untouched-sibling debt on a file this PR happens to edit. Dedup key: `v1 class=holistic/unclassified path=app/pages/Public/IndexPage/tests/index.test.tsx line=71`

## Quality Gate

Re-run in full after the rebase onto #1711.

| Step | Result |
| --- | --- |
| Simplify | N/A, comment-only diff |
| Localization | N/A, no user-facing strings |
| Type checking | Pass |
| Linting | Pass |
| Unit tests | Pass, 157 passed / 1 skipped |
| E2E tests | Pass, 8 passed / 1 skipped |
| Dev server | Pass, Playwright webServer served every route |
| Build | Pass |
| Whole-tree invariants | Pass |

CHANGELOG: no entry. The gate's not-worthy list names comment-only edits explicitly.

Closes #1706
Closes #1707