### PR TITLE
debt(guards): give the scan-surface discovery one definition (#1720)

### DIFF
--- a/.gaia/release-exclude
+++ b/.gaia/release-exclude
@@ -98,10 +98,11 @@
 # The workflow run-interpolation lint guards GAIA's own CI workflow YAML, its
 # composite actions, and the adopter workflow templates it renders CI from,
 # against a `${{ }}` expression substituted into a `run:` script body. Withheld
-# on the same reasoning as the diff-quoting lint above,
-# and on that reasoning ALONE: shell-lint.sh, its only runner, is
-# release-excluded wholesale via the `.gaia/tests` entry, so shipping this file
-# would ship a check nothing on an adopter clone invokes.
+# on the same reasoning as the diff-quoting lint above: shell-lint.sh, its only
+# runner, is release-excluded wholesale via the `.gaia/tests` entry, so shipping
+# this file would ship a check nothing on an adopter clone invokes. It also
+# sources guard-awk-lib.sh, withheld below, so the absent dependency would
+# decide the withhold on its own.
 #
 # Note what is deliberately NOT claimed here, because it is false and would be
 # the premise a future maintainer re-litigates this decision from: an adopter
@@ -114,22 +115,24 @@
 # The grep ERE-escape lint guards GAIA's own framework shell, its CI workflow and
 # composite-action YAML, and the adopter workflow templates against a
 # backslash-escaped letter in a `grep -E` pattern, which BSD grep and GNU grep
-# read differently. Withheld on the same reasoning as the two lints above, and on
-# that reasoning ALONE: shell-lint.sh, its only runner, is release-excluded
-# wholesale via the `.gaia/tests` entry, so shipping this file would ship a check
-# nothing on an adopter clone invokes. An adopter clone does have a populated
-# scan surface, for the reason the run-interpolation note above spells out, so
-# the withhold rests on the absent runner rather than on an empty surface.
+# read differently. Withheld on the same reasoning as the two lints above:
+# shell-lint.sh, its only runner, is release-excluded wholesale via the
+# `.gaia/tests` entry, so shipping this file would ship a check nothing on an
+# adopter clone invokes. It also sources guard-awk-lib.sh, withheld below, so
+# the absent dependency would decide the withhold on its own. An adopter clone
+# does have a populated scan surface, for the reason the run-interpolation note
+# above spells out, so neither withhold rests on an empty one.
 .gaia/scripts/lint-grep-ere-escapes.sh
 # The errexit status-read lint guards GAIA's own framework shell, its CI workflow
 # and composite-action YAML, and the adopter workflow templates against a `$?`
 # read that `set -e` has already made unreachable. Withheld on the same reasoning
-# as the three lints above, and on that reasoning ALONE: shell-lint.sh, its only
-# runner, is release-excluded wholesale via the `.gaia/tests` entry, so shipping
-# this file would ship a check nothing on an adopter clone invokes. An adopter
-# clone does have a populated scan surface, and the shipped workflow templates
-# render into their CI carrying the class's own exposure, so the withhold rests
-# on the absent runner rather than on an empty surface.
+# as the three lints above: shell-lint.sh, its only runner, is release-excluded
+# wholesale via the `.gaia/tests` entry, so shipping this file would ship a check
+# nothing on an adopter clone invokes. It also sources guard-awk-lib.sh, withheld
+# below, so the absent dependency would decide the withhold on its own. An
+# adopter clone does have a populated scan surface, and the shipped workflow
+# templates render into their CI carrying the class's own exposure, so neither
+# withhold rests on an empty one.
 .gaia/scripts/lint-errexit-status-read.sh
 # The shipped-issue-reference lint enforces GAIA's own authoring obligation: a
 # `#NNN` on a file GAIA ships must name gaia-react/gaia so an adopter reading it

--- a/.gaia/release-exclude
+++ b/.gaia/release-exclude
@@ -93,7 +93,8 @@
 # never author it, so a linter over the framework's own shell has no adopter
 # surface -- and shell-lint.sh, its only runner, is already release-excluded
 # wholesale via the .gaia/tests entry, so shipping it would ship a check nothing
-# on an adopter clone invokes.
+# on an adopter clone invokes. It also sources guard-awk-lib.sh, withheld
+# below, so the absent dependency would decide the withhold on its own.
 .gaia/scripts/lint-git-path-quoting.sh
 # The workflow run-interpolation lint guards GAIA's own CI workflow YAML, its
 # composite actions, and the adopter workflow templates it renders CI from,

--- a/.gaia/scripts/guard-awk-lib.sh
+++ b/.gaia/scripts/guard-awk-lib.sh
@@ -831,6 +831,9 @@ _gaia_guard_scan_set() {
 #      named at all, or one named twice. Either way the guard would scan a
 #      surface other than the one it asked for and still report clean, which is
 #      the discovery-stage failure `.claude/rules/guards-must-fail.md` names.
+# On any status but 0 the array is empty, never the surface a previous call
+# left in it.
+#
 #   3  the discovery machinery failed: a named set's own `git ls-files`, the
 #      sort, or the scratch file each of them needs. Distinct from 1 because
 #      the repairs differ, and distinct from a partial result because a set
@@ -857,6 +860,11 @@ _gaia_guard_scan_set() {
 # A read loop rather than mapfile, which is bash 4+, because these guards run on
 # stock macOS /bin/bash 3.2.57.
 gaia_guard_scan_files() {
+  # Emptied before anything can return, so a caller that reads the array
+  # after a refusal sees the nothing the refusal's message claims rather
+  # than whatever the previous call left there.
+  GAIA_GUARD_SCAN_FILES=()
+
   local label="${1:-guard}"
   if [ "$#" -lt 2 ]; then
     printf '%s: ERROR: gaia_guard_scan_files needs a label and at least one scan set\n' "$label" >&2
@@ -919,7 +927,6 @@ gaia_guard_scan_files() {
     return 3
   fi
 
-  GAIA_GUARD_SCAN_FILES=()
   while IFS= read -r -d '' f; do
     GAIA_GUARD_SCAN_FILES+=("$f")
   done < "$sorted_tmp"

--- a/.gaia/scripts/guard-awk-lib.sh
+++ b/.gaia/scripts/guard-awk-lib.sh
@@ -774,3 +774,92 @@ gaia_guard_bats_files() {
   fi
   return 0
 }
+
+# Filled by gaia_guard_scan_files, read by its caller. Declared here so a caller
+# that iterates before calling reads an empty array rather than an unset name.
+GAIA_GUARD_SCAN_FILES=()
+
+# gaia_guard_scan_files <guard-label> <set>...: fill GAIA_GUARD_SCAN_FILES with
+# the sorted union of the named tracked sets and return 0, or return 1 having
+# said so on stderr when a set name is unknown or the union came back empty.
+#
+# The sets, and the one place each pathspec is written:
+#
+#   shell      tracked `*.sh`, minus the hook directory the `husky` set owns.
+#   husky      the husky hooks, which are extensionless and so match no
+#              extension glob. `.husky/_/h` runs each one as `sh -e`, so a
+#              caller that arms them differently from an ordinary script asks
+#              for this set separately rather than folding it into `shell`.
+#   workflows  the Actions workflows and composite actions, plus the adopter
+#              workflow templates, which are `.tmpl` rather than `.yml`.
+#
+# `shell` excludes the hook directory because a git pathspec glob is matched
+# without FNM_PATHNAME, so its `*` crosses `/` and a `.husky/helper.sh` would
+# otherwise be returned by both sets: scanned twice, and reported twice, by a
+# caller that asked for both.
+#
+# One `git ls-files` per set rather than one call carrying every pathspec: a
+# `:(exclude)` magic pathspec applies to the whole call, so `shell`'s exclude
+# would also empty a `husky` set asked for in the same breath.
+#
+# An empty union is a hard error rather than a clean tree, for the reason
+# gaia_guard_bats_files states about its own surface, and the message names the
+# sets that were asked for, because a caller naming more than one has no other
+# way to learn which discovery broke. The status is the whole point of the
+# shape, so the caller reads it directly
+# (`gaia_guard_scan_files <label> <set>... || exit 1`) rather than through a
+# substitution that would swallow it.
+#
+# An unknown set name is the same class of failure one directory short of the
+# real surface is: the guard scans less than the rule it encodes governs and
+# still reports clean. It is rejected before any read, because the reads run
+# inside a process substitution whose subshell cannot return a status here.
+#
+# `core.quotepath=false` and a NUL-delimited read, so a path carrying a
+# non-ASCII byte is not handed over C-quoted and silently dropped. A read loop
+# rather than mapfile, which is bash 4+, because these guards run on stock macOS
+# /bin/bash 3.2.57.
+gaia_guard_scan_files() {
+  local label="${1:-guard}"
+  if [ "$#" -lt 2 ]; then
+    printf '%s: ERROR: gaia_guard_scan_files needs a label and at least one scan set\n' "$label" >&2
+    return 1
+  fi
+  shift
+  local name f
+  for name in "$@"; do
+    case "$name" in
+      shell | husky | workflows) ;;
+      *)
+        printf '%s: ERROR: unknown scan set "%s"; nothing was scanned\n' "$label" "$name" >&2
+        return 1
+        ;;
+    esac
+  done
+  GAIA_GUARD_SCAN_FILES=()
+  while IFS= read -r -d '' f; do
+    GAIA_GUARD_SCAN_FILES+=("$f")
+  done < <(
+    # Each pattern carries the optional leading `(`. Without it, stock macOS
+    # /bin/bash 3.2.57 reads the `)` closing a case pattern as the one closing
+    # the process substitution, and the whole file fails to parse.
+    for name in "$@"; do
+      case "$name" in
+        (shell) git -c core.quotepath=false ls-files -z '*.sh' ':(exclude).husky/*' ;;
+        (husky) git -c core.quotepath=false ls-files -z '.husky/*' ;;
+        (workflows)
+          git -c core.quotepath=false ls-files -z \
+            '.github/workflows/*.yml' '.github/workflows/*.yaml' \
+            '.github/actions/*/action.yml' '.github/actions/*/action.yaml' \
+            '.gaia/cli/src/automation/templates/workflows/*.tmpl'
+          ;;
+      esac
+    done | LC_ALL=C sort -zu
+  )
+  if [ "${#GAIA_GUARD_SCAN_FILES[@]}" -eq 0 ]; then
+    printf '%s: ERROR: no tracked files matched the scan surface (%s); nothing was scanned\n' \
+      "$label" "$*" >&2
+    return 1
+  fi
+  return 0
+}

--- a/.gaia/scripts/guard-awk-lib.sh
+++ b/.gaia/scripts/guard-awk-lib.sh
@@ -827,24 +827,32 @@ _gaia_guard_scan_set() {
 #      rather than a clean tree, for the reason gaia_guard_bats_files states
 #      about its own surface. This is the ONLY status a caller may tolerate,
 #      and only where an empty surface is a legitimate tree for it.
-#   2  the call itself is wrong: a set name this library does not know, or no
-#      set named at all. Either way the guard would scan less than the rule it
-#      encodes governs and still report clean, which is the discovery-stage
-#      failure `.claude/rules/guards-must-fail.md` names.
-#   3  a named set's own `git ls-files` failed (run outside a repository, a
-#      broken object store). Distinct from 1 because the repairs differ, and
-#      distinct from a partial union because a set that returned nothing on a
-#      failed call is otherwise indistinguishable from one that legitimately
-#      matched nothing: with several sets asked for, the survivors would carry
-#      the union past the empty check and the gate would report clean over a
-#      surface it never opened.
+#   2  the call itself is wrong: a set name this library does not know, no set
+#      named at all, or one named twice. Either way the guard would scan a
+#      surface other than the one it asked for and still report clean, which is
+#      the discovery-stage failure `.claude/rules/guards-must-fail.md` names.
+#   3  the discovery machinery failed: a named set's own `git ls-files`, the
+#      sort, or the scratch file each of them needs. Distinct from 1 because
+#      the repairs differ, and distinct from a partial result because a set
+#      that returned nothing on a failed call is otherwise indistinguishable
+#      from one that legitimately matched nothing: with several sets asked for,
+#      the survivors would carry the result past the empty check and the gate
+#      would report clean over a surface it never opened.
 #
-# Each set is written to a scratch file rather than straight into a process
-# substitution, because a process substitution's subshell cannot return its
-# status here, which is what leaves a per-set failure indistinguishable from a
-# per-set empty result. Every return path removes it explicitly rather than
-# through an EXIT trap: this library is sourced, so a trap installed here would
-# replace whatever the consuming guard armed for its own cleanup.
+# It really is a union: naming a set twice is refused rather than concatenated,
+# so no path can reach the array twice and be scanned and reported twice. Across
+# distinct names the sets are disjoint by construction, which is what lets the
+# sort below leave out `-u`; a `-u` there would be a second mechanism
+# guaranteeing the same thing, and a suite cannot red on either one alone while
+# the other still holds.
+#
+# Nothing here is read through a process substitution, whose subshell cannot
+# return its status to this function. That is what leaves a failure
+# indistinguishable from an empty result, so every stage writes to a scratch
+# file whose producer's status is read before the next stage runs. Every return
+# path removes those files explicitly rather than through an EXIT trap: this
+# library is sourced, so a trap installed here would replace whatever the
+# consuming guard armed for its own cleanup.
 #
 # A read loop rather than mapfile, which is bash 4+, because these guards run on
 # stock macOS /bin/bash 3.2.57.
@@ -856,13 +864,23 @@ gaia_guard_scan_files() {
   fi
   shift
 
-  local scan_tmp name status f
+  local scan_tmp sorted_tmp name status seen f
   scan_tmp="$(mktemp -t gaia-guard-scan-XXXXXX)" || {
     printf '%s: ERROR: could not create a scratch file for the scan surface; nothing was scanned\n' "$label" >&2
     return 3
   }
 
+  seen=""
   for name in "$@"; do
+    case " $seen " in
+      *" $name "*)
+        rm -f "$scan_tmp"
+        printf '%s: ERROR: scan set "%s" named more than once; nothing was scanned\n' "$label" "$name" >&2
+        return 2
+        ;;
+    esac
+    seen="$seen $name"
+
     # The `if` is what keeps a non-zero status readable: a bare call would abort
     # under the errexit every consuming guard arms before sourcing this library.
     if _gaia_guard_scan_set "$name" >> "$scan_tmp"; then
@@ -883,11 +901,29 @@ gaia_guard_scan_files() {
     fi
   done
 
+  sorted_tmp="$(mktemp -t gaia-guard-sort-XXXXXX)" || {
+    rm -f "$scan_tmp"
+    printf '%s: ERROR: could not create a scratch file to sort the scan surface; nothing was scanned\n' "$label" >&2
+    return 3
+  }
+  if LC_ALL=C sort -z < "$scan_tmp" > "$sorted_tmp"; then
+    status=0
+  else
+    status=$?
+  fi
+  rm -f "$scan_tmp"
+  if [ "$status" -ne 0 ]; then
+    rm -f "$sorted_tmp"
+    printf '%s: ERROR: sorting the scan surface failed, sort exited %s; nothing was scanned\n' \
+      "$label" "$status" >&2
+    return 3
+  fi
+
   GAIA_GUARD_SCAN_FILES=()
   while IFS= read -r -d '' f; do
     GAIA_GUARD_SCAN_FILES+=("$f")
-  done < <(LC_ALL=C sort -z < "$scan_tmp")
-  rm -f "$scan_tmp"
+  done < "$sorted_tmp"
+  rm -f "$sorted_tmp"
 
   if [ "${#GAIA_GUARD_SCAN_FILES[@]}" -eq 0 ]; then
     printf '%s: ERROR: no tracked files matched the scan surface (%s); nothing was scanned\n' \

--- a/.gaia/scripts/guard-awk-lib.sh
+++ b/.gaia/scripts/guard-awk-lib.sh
@@ -779,13 +779,16 @@ gaia_guard_bats_files() {
 # that iterates before calling reads an empty array rather than an unset name.
 GAIA_GUARD_SCAN_FILES=()
 
-# gaia_guard_scan_files <guard-label> <set>...: fill GAIA_GUARD_SCAN_FILES with
-# the sorted union of the named tracked sets and return 0, or return 1 having
-# said so on stderr when a set name is unknown or the union came back empty.
+# _gaia_guard_scan_set <set-name>: emit that set's tracked paths NUL-delimited
+# and return git's own status, or emit nothing and return 2 when the name is not
+# one this library knows. Private to gaia_guard_scan_files, and the one place
+# each pathspec is written.
 #
-# The sets, and the one place each pathspec is written:
-#
-#   shell      tracked `*.sh`, minus the hook directory the `husky` set owns.
+#   shell      tracked `*.sh`, minus the hook directory the `husky` set owns. A
+#              git pathspec glob is matched without FNM_PATHNAME, so its `*`
+#              crosses `/` and a `.husky/helper.sh` would otherwise be returned
+#              by both sets: scanned twice, and reported twice, by a caller that
+#              asked for both.
 #   husky      the husky hooks, which are extensionless and so match no
 #              extension glob. `.husky/_/h` runs each one as `sh -e`, so a
 #              caller that arms them differently from an ordinary script asks
@@ -793,69 +796,99 @@ GAIA_GUARD_SCAN_FILES=()
 #   workflows  the Actions workflows and composite actions, plus the adopter
 #              workflow templates, which are `.tmpl` rather than `.yml`.
 #
-# `shell` excludes the hook directory because a git pathspec glob is matched
-# without FNM_PATHNAME, so its `*` crosses `/` and a `.husky/helper.sh` would
-# otherwise be returned by both sets: scanned twice, and reported twice, by a
-# caller that asked for both.
+# One set per call rather than one call carrying every pathspec: a `:(exclude)`
+# magic pathspec applies to the whole call, so `shell`'s exclude would also
+# empty a `husky` set asked for in the same breath.
 #
-# One `git ls-files` per set rather than one call carrying every pathspec: a
-# `:(exclude)` magic pathspec applies to the whole call, so `shell`'s exclude
-# would also empty a `husky` set asked for in the same breath.
+# `core.quotepath=false`, so a path carrying a non-ASCII byte is not handed over
+# C-quoted and silently dropped.
+_gaia_guard_scan_set() {
+  case "$1" in
+    shell) git -c core.quotepath=false ls-files -z '*.sh' ':(exclude).husky/*' ;;
+    husky) git -c core.quotepath=false ls-files -z '.husky/*' ;;
+    workflows)
+      git -c core.quotepath=false ls-files -z \
+        '.github/workflows/*.yml' '.github/workflows/*.yaml' \
+        '.github/actions/*/action.yml' '.github/actions/*/action.yaml' \
+        '.gaia/cli/src/automation/templates/workflows/*.tmpl'
+      ;;
+    *) return 2 ;;
+  esac
+}
+
+# gaia_guard_scan_files <guard-label> <set>...: fill GAIA_GUARD_SCAN_FILES with
+# the sorted union of the named tracked sets, having said on stderr what went
+# wrong on any status but 0. The status is the whole point of the shape, so the
+# caller reads it directly (`gaia_guard_scan_files <label> <set>... || exit 1`)
+# rather than through a substitution that would swallow it.
 #
-# An empty union is a hard error rather than a clean tree, for the reason
-# gaia_guard_bats_files states about its own surface, and the message names the
-# sets that were asked for, because a caller naming more than one has no other
-# way to learn which discovery broke. The status is the whole point of the
-# shape, so the caller reads it directly
-# (`gaia_guard_scan_files <label> <set>... || exit 1`) rather than through a
-# substitution that would swallow it.
+#   0  the union is non-empty and the array holds it.
+#   1  every named set resolved and the union came back empty. A hard error
+#      rather than a clean tree, for the reason gaia_guard_bats_files states
+#      about its own surface. This is the ONLY status a caller may tolerate,
+#      and only where an empty surface is a legitimate tree for it.
+#   2  the call itself is wrong: a set name this library does not know, or no
+#      set named at all. Either way the guard would scan less than the rule it
+#      encodes governs and still report clean, which is the discovery-stage
+#      failure `.claude/rules/guards-must-fail.md` names.
+#   3  a named set's own `git ls-files` failed (run outside a repository, a
+#      broken object store). Distinct from 1 because the repairs differ, and
+#      distinct from a partial union because a set that returned nothing on a
+#      failed call is otherwise indistinguishable from one that legitimately
+#      matched nothing: with several sets asked for, the survivors would carry
+#      the union past the empty check and the gate would report clean over a
+#      surface it never opened.
 #
-# An unknown set name is the same class of failure one directory short of the
-# real surface is: the guard scans less than the rule it encodes governs and
-# still reports clean. It is rejected before any read, because the reads run
-# inside a process substitution whose subshell cannot return a status here.
+# Each set is written to a scratch file rather than straight into a process
+# substitution, because a process substitution's subshell cannot return its
+# status here, which is what leaves a per-set failure indistinguishable from a
+# per-set empty result. Every return path removes it explicitly rather than
+# through an EXIT trap: this library is sourced, so a trap installed here would
+# replace whatever the consuming guard armed for its own cleanup.
 #
-# `core.quotepath=false` and a NUL-delimited read, so a path carrying a
-# non-ASCII byte is not handed over C-quoted and silently dropped. A read loop
-# rather than mapfile, which is bash 4+, because these guards run on stock macOS
-# /bin/bash 3.2.57.
+# A read loop rather than mapfile, which is bash 4+, because these guards run on
+# stock macOS /bin/bash 3.2.57.
 gaia_guard_scan_files() {
   local label="${1:-guard}"
   if [ "$#" -lt 2 ]; then
     printf '%s: ERROR: gaia_guard_scan_files needs a label and at least one scan set\n' "$label" >&2
-    return 1
+    return 2
   fi
   shift
-  local name f
+
+  local scan_tmp name status f
+  scan_tmp="$(mktemp -t gaia-guard-scan-XXXXXX)" || {
+    printf '%s: ERROR: could not create a scratch file for the scan surface; nothing was scanned\n' "$label" >&2
+    return 3
+  }
+
   for name in "$@"; do
-    case "$name" in
-      shell | husky | workflows) ;;
-      *)
-        printf '%s: ERROR: unknown scan set "%s"; nothing was scanned\n' "$label" "$name" >&2
-        return 1
-        ;;
-    esac
+    # The `if` is what keeps a non-zero status readable: a bare call would abort
+    # under the errexit every consuming guard arms before sourcing this library.
+    if _gaia_guard_scan_set "$name" >> "$scan_tmp"; then
+      status=0
+    else
+      status=$?
+    fi
+    if [ "$status" -eq 2 ]; then
+      rm -f "$scan_tmp"
+      printf '%s: ERROR: unknown scan set "%s"; nothing was scanned\n' "$label" "$name" >&2
+      return 2
+    fi
+    if [ "$status" -ne 0 ]; then
+      rm -f "$scan_tmp"
+      printf '%s: ERROR: the %s discovery failed, git exited %s; nothing was scanned\n' \
+        "$label" "$name" "$status" >&2
+      return 3
+    fi
   done
+
   GAIA_GUARD_SCAN_FILES=()
   while IFS= read -r -d '' f; do
     GAIA_GUARD_SCAN_FILES+=("$f")
-  done < <(
-    # Each pattern carries the optional leading `(`. Without it, stock macOS
-    # /bin/bash 3.2.57 reads the `)` closing a case pattern as the one closing
-    # the process substitution, and the whole file fails to parse.
-    for name in "$@"; do
-      case "$name" in
-        (shell) git -c core.quotepath=false ls-files -z '*.sh' ':(exclude).husky/*' ;;
-        (husky) git -c core.quotepath=false ls-files -z '.husky/*' ;;
-        (workflows)
-          git -c core.quotepath=false ls-files -z \
-            '.github/workflows/*.yml' '.github/workflows/*.yaml' \
-            '.github/actions/*/action.yml' '.github/actions/*/action.yaml' \
-            '.gaia/cli/src/automation/templates/workflows/*.tmpl'
-          ;;
-      esac
-    done | LC_ALL=C sort -zu
-  )
+  done < <(LC_ALL=C sort -z < "$scan_tmp")
+  rm -f "$scan_tmp"
+
   if [ "${#GAIA_GUARD_SCAN_FILES[@]}" -eq 0 ]; then
     printf '%s: ERROR: no tracked files matched the scan surface (%s); nothing was scanned\n' \
       "$label" "$*" >&2

--- a/.gaia/scripts/lint-collapsed-signal-trap.sh
+++ b/.gaia/scripts/lint-collapsed-signal-trap.sh
@@ -7,9 +7,13 @@
 # lint-collapsed-signal-trap.sh: flag every `trap` that binds EXIT together with
 # INT or TERM in one arm, across the framework's tracked shell, the extensionless
 # husky hooks, its CI workflow and composite-action YAML, the adopter workflow
-# templates, and its tracked bats suites. Exit 1 with a file:line report on any
-# hit, exit 0 when clean. Run it directly from the repo root:
+# templates, and its tracked bats suites. Run it directly from the repo root:
 # `bash .gaia/scripts/lint-collapsed-signal-trap.sh`.
+#
+# Exit 0 when clean, and 1 either with a file:line report on any hit or on a
+# scan surface that came back empty. Two statuses say the gate never ran at
+# all: 2 when guard-awk-lib.sh is missing beside this script, and 3 when the
+# scan-surface discovery failed.
 # gaia:maintainer-only:start
 #
 # Enforced by the sibling bats suite
@@ -108,7 +112,12 @@ type gaia_guard_bats_files >/dev/null 2>&1 || {
 # GAIA_GUARD_SCAN_FILES and returns non-zero on an empty surface, which is a
 # hard error rather than a clean tree; the status is read directly, because a
 # substitution would swallow it.
-gaia_guard_scan_files lint-collapsed-signal-trap shell husky workflows || exit 1
+#
+# The library's own status is carried out rather than flattened to 1: 1 says the
+# tree was read and held nothing, 3 says it was never read at all, and an
+# operator handed 1 for the second would look at the tree instead of the
+# discovery.
+gaia_guard_scan_files lint-collapsed-signal-trap shell husky workflows || exit $?
 
 # A separate set from the scan surface above, never a widened pathspec: a tree
 # carrying .sh and no .bats must not pass clean carried by the rest of it.

--- a/.gaia/scripts/lint-collapsed-signal-trap.sh
+++ b/.gaia/scripts/lint-collapsed-signal-trap.sh
@@ -102,34 +102,16 @@ type gaia_guard_bats_files >/dev/null 2>&1 || {
   exit 2
 }
 
-# `git ls-files` rather than a filesystem walk, so an untracked scratch script is
-# never scanned; the same discovery .gaia/tests/shell-lint.sh uses. Collected
-# with a read loop rather than `mapfile`, which is bash 4+, because these scripts
-# run on stock macOS /bin/bash (3.2.57).
-scan_files=()
-while IFS= read -r -d '' f; do
-  scan_files+=("$f")
-done < <(git -c core.quotepath=false ls-files -z \
-                      '*.sh' '.husky/*' \
-                      '.github/workflows/*.yml' '.github/workflows/*.yaml' \
-                      '.github/actions/*/action.yml' '.github/actions/*/action.yaml' \
-                      '.gaia/cli/src/automation/templates/workflows/*.tmpl' \
-           | LC_ALL=C sort -z)
+# The scan surface comes from the shared library rather than from a read loop
+# here, so every gate consuming it discovers the same set the same way and a
+# widened pathspec cannot reach one of them and miss the others. The call fills
+# GAIA_GUARD_SCAN_FILES and returns non-zero on an empty surface, which is a
+# hard error rather than a clean tree; the status is read directly, because a
+# substitution would swallow it.
+gaia_guard_scan_files lint-collapsed-signal-trap shell husky workflows || exit 1
 
-# An empty scan set is a hard error, never a clean tree. The loop above reads
-# from a process substitution, whose failure `set -o pipefail` cannot see, so a
-# `git ls-files` that errors (run outside a repository, a broken object store)
-# leaves the array empty and every check below vacuously passes. This gate would
-# then print `clean` and exit 0 having scanned nothing, which is the lie-green
-# failure gates exist to stop. Every real tree carries tracked `*.sh`, so an
-# empty result means the discovery is wrong rather than the tree.
-if [ "${#scan_files[@]}" -eq 0 ]; then
-  echo "lint-collapsed-signal-trap: ERROR: no tracked shell, workflows, or workflow templates matched the scan surface; nothing was scanned" >&2
-  exit 1
-fi
-
-# A separate set from scan_files, never a widened pathspec: a tree carrying .sh
-# and no .bats must not pass clean carried by the rest of the surface.
+# A separate set from the scan surface above, never a widened pathspec: a tree
+# carrying .sh and no .bats must not pass clean carried by the rest of it.
 gaia_guard_bats_files lint-collapsed-signal-trap || exit 1
 
 # The class-detection program, concatenated after $GAIA_GUARD_AWK so it can call
@@ -339,7 +321,7 @@ scan_file() {
 }
 
 report=""
-for f in ${scan_files[@]+"${scan_files[@]}"}; do
+for f in ${GAIA_GUARD_SCAN_FILES[@]+"${GAIA_GUARD_SCAN_FILES[@]}"}; do
   [ -f "$f" ] || continue
   hits=$(scan_file "$f" 0)
   [ -z "$hits" ] || report+="$hits"$'\n'

--- a/.gaia/scripts/lint-errexit-status-read.sh
+++ b/.gaia/scripts/lint-errexit-status-read.sh
@@ -6,9 +6,15 @@
 # shellcheck disable=SC2016
 #
 # lint-errexit-status-read.sh: flag every read of `$?` that follows a bare
-# command-substitution assignment while errexit is armed. Exit 1 with a
-# file:line report on any hit, exit 0 when clean. Run it directly from the repo
-# root: `bash .gaia/scripts/lint-errexit-status-read.sh`.
+# command-substitution assignment while errexit is armed. Run it directly from
+# the repo root: `bash .gaia/scripts/lint-errexit-status-read.sh`.
+#
+# Exit 0 when clean, and 1 with a file:line report on any hit. Two statuses say
+# the gate never ran rather than that it found nothing: 2 when guard-awk-lib.sh
+# is missing beside this script or refuses one of this gate's calls to it, and 3
+# when a scan-set discovery failed. Every runner folds any non-zero into its own
+# failure today, so the split serves a person reading the output rather than a
+# caller branching on it.
 # gaia:maintainer-only:start
 #
 # Enforced by the sibling bats suite
@@ -1042,20 +1048,26 @@ sh_files=(${GAIA_GUARD_SCAN_FILES[@]+"${GAIA_GUARD_SCAN_FILES[@]}"})
 # That status and no other. Every other one the library returns says the call is
 # wrong or the discovery broke, and swallowing one here would leave this gate,
 # the only one arming the hooks as errexit-on, scanning no hook while printing
-# `clean`: the certified-clean surface the paragraph above names. The library's
-# own message went to /dev/null with the tolerated one, so this names the status
-# it refused with, which is what says which of the two happened.
+# `clean`: the certified-clean surface the paragraph above names.
+#
+# So the library's message is held rather than discarded, and replayed on every
+# status but the tolerated one. Discarding it outright would cost the operator
+# the only text that separates the causes sharing a status: status 3 is returned
+# for a failed discovery, a failed sort, and a scratch file that could not be
+# created, and the line held here is what names which.
 husky_files=()
-if gaia_guard_scan_files lint-errexit-status-read husky 2>/dev/null; then
+husky_err="$(mktemp -t gaia-errexit-husky-XXXXXX)"
+if gaia_guard_scan_files lint-errexit-status-read husky 2>"$husky_err"; then
   husky_files=(${GAIA_GUARD_SCAN_FILES[@]+"${GAIA_GUARD_SCAN_FILES[@]}"})
 else
   husky_status=$?
   if [ "$husky_status" -ne 1 ]; then
-    printf 'lint-errexit-status-read: ERROR: the husky discovery refused with status %s; nothing was scanned\n' \
-      "$husky_status" >&2
+    cat "$husky_err" >&2
+    rm -f "$husky_err"
     exit "$husky_status"
   fi
 fi
+rm -f "$husky_err"
 
 gaia_guard_scan_files lint-errexit-status-read workflows || exit 1
 yaml_files=(${GAIA_GUARD_SCAN_FILES[@]+"${GAIA_GUARD_SCAN_FILES[@]}"})

--- a/.gaia/scripts/lint-errexit-status-read.sh
+++ b/.gaia/scripts/lint-errexit-status-read.sh
@@ -9,12 +9,12 @@
 # command-substitution assignment while errexit is armed. Run it directly from
 # the repo root: `bash .gaia/scripts/lint-errexit-status-read.sh`.
 #
-# Exit 0 when clean, and 1 with a file:line report on any hit. Two statuses say
-# the gate never ran rather than that it found nothing: 2 when guard-awk-lib.sh
-# is missing beside this script or refuses one of this gate's calls to it, and 3
-# when a scan-set discovery failed. Every runner folds any non-zero into its own
-# failure today, so the split serves a person reading the output rather than a
-# caller branching on it.
+# Exit 0 when clean, and 1 either with a file:line report on any hit or on a
+# scan set that legitimately came back empty. Two statuses say the gate never
+# ran at all: 2 when guard-awk-lib.sh is missing beside this script or refuses
+# one of this gate's calls to it, and 3 when a scan-set discovery failed. Every
+# runner folds any non-zero into its own failure today, so the split serves a
+# person reading the output rather than a caller branching on it.
 # gaia:maintainer-only:start
 #
 # Enforced by the sibling bats suite
@@ -1029,7 +1029,7 @@ END {
 # substitution would swallow it.
 # Each set is copied out of the library's one global before the next call
 # overwrites it, because this gate arms the three differently below.
-gaia_guard_scan_files lint-errexit-status-read shell || exit 1
+gaia_guard_scan_files lint-errexit-status-read shell || exit $?
 sh_files=(${GAIA_GUARD_SCAN_FILES[@]+"${GAIA_GUARD_SCAN_FILES[@]}"})
 
 # The husky hooks are read as their own set because they ARM differently, not
@@ -1069,7 +1069,7 @@ else
 fi
 rm -f "$husky_err"
 
-gaia_guard_scan_files lint-errexit-status-read workflows || exit 1
+gaia_guard_scan_files lint-errexit-status-read workflows || exit $?
 yaml_files=(${GAIA_GUARD_SCAN_FILES[@]+"${GAIA_GUARD_SCAN_FILES[@]}"})
 
 # The bats set comes from the same library, and for the same reason: a change to

--- a/.gaia/scripts/lint-errexit-status-read.sh
+++ b/.gaia/scripts/lint-errexit-status-read.sh
@@ -10,9 +10,13 @@
 # the repo root: `bash .gaia/scripts/lint-errexit-status-read.sh`.
 #
 # Exit 0 when clean, and 1 either with a file:line report on any hit or on a
-# scan set that legitimately came back empty. Two statuses say the gate never
-# ran at all: 2 when guard-awk-lib.sh is missing beside this script or refuses
-# one of this gate's calls to it, and 3 when a scan-set discovery failed. Every
+# scan set that came back empty, which this gate reads as a broken discovery
+# rather than a clean tree. The husky hooks are the one surface where an empty
+# set is a legitimate tree, and they never reach this status: that status is
+# tolerated where the hooks are read, for the reason stated there. Two statuses
+# say the gate never ran at all: 2 when guard-awk-lib.sh is missing beside this
+# script or refuses one of this gate's calls to it, and 3 when a scan-set
+# discovery failed. Every
 # runner folds any non-zero into its own failure today, so the split serves a
 # person reading the output rather than a caller branching on it.
 # gaia:maintainer-only:start

--- a/.gaia/scripts/lint-errexit-status-read.sh
+++ b/.gaia/scripts/lint-errexit-status-read.sh
@@ -1015,66 +1015,44 @@ END {
 }
 '
 
-# `git ls-files` rather than a filesystem walk, so an untracked scratch script is
-# never scanned; the same discovery .gaia/tests/shell-lint.sh uses. Collected
-# with a read loop rather than `mapfile`, which is bash 4+, because these scripts
-# run on stock macOS /bin/bash (3.2.57). NUL-delimited and `core.quotepath=false`
-# so a path carrying a non-ASCII byte is not handed over C-quoted and silently
-# dropped by the `[ -f ]` test below.
-sh_files=()
-while IFS= read -r -d '' f; do
-  sh_files+=("$f")
-done < <(git -c core.quotepath=false ls-files -z '*.sh' ':(exclude).husky/*' | LC_ALL=C sort -z)
+# The scan surface comes from the shared library rather than from a read loop
+# here, so every gate consuming it discovers the same set the same way and a
+# widened pathspec cannot reach one of them and miss the others. The call fills
+# GAIA_GUARD_SCAN_FILES and returns non-zero on an empty surface, which is a
+# hard error rather than a clean tree; the status is read directly, because a
+# substitution would swallow it.
+# Each set is copied out of the library's one global before the next call
+# overwrites it, because this gate arms the three differently below.
+gaia_guard_scan_files lint-errexit-status-read shell || exit 1
+sh_files=(${GAIA_GUARD_SCAN_FILES[@]+"${GAIA_GUARD_SCAN_FILES[@]}"})
 
-# The husky hooks are collected separately from `*.sh` because they ARM
-# differently, not merely because the glob misses them. `.husky/_/h` invokes
-# every hook as `sh -e "$s"`, so errexit is on there whether or not the hook says
-# so, exactly as it is inside an Actions `run:` body; `.husky/pre-commit` carries
-# no `set -e` and is live for the class today. Reading them off-by-default with
-# the ordinary scripts is what left that whole surface certified clean.
+# The husky hooks are read as their own set because they ARM differently, not
+# merely because the `*.sh` glob misses them. `.husky/_/h` invokes every hook as
+# `sh -e "$s"`, so errexit is on there whether or not the hook says so, exactly as
+# it is inside an Actions `run:` body; `.husky/pre-commit` carries no `set -e` and
+# is live for the class today. Reading them off-by-default with the ordinary
+# scripts is what left that whole surface certified clean.
 #
-# The `*.sh` set EXCLUDES `.husky/*` explicitly. A git pathspec glob is matched
-# without FNM_PATHNAME, so its `*` crosses `/` and a `.husky/helper.sh` would
-# otherwise be returned by both sets, scanned once armed and once not, and
-# double-listed in the report. No such file exists today; the only tracked hook
-# is extensionless.
+# Alone among the sets this gate reads, an empty one is a legitimate tree rather
+# than a broken discovery: a repository can carry no tracked hook at all, and the
+# call above already proved `git ls-files` answers here. So the library's status
+# is read and tolerated, and its message, which would be wrong in that case, is
+# not surfaced as this gate's own error.
 husky_files=()
-while IFS= read -r -d '' f; do
-  husky_files+=("$f")
-done < <(git -c core.quotepath=false ls-files -z '.husky/*' | LC_ALL=C sort -z)
-
-yaml_files=()
-while IFS= read -r -d '' f; do
-  yaml_files+=("$f")
-done < <(git -c core.quotepath=false ls-files -z \
-                      '.github/workflows/*.yml' '.github/workflows/*.yaml' \
-                      '.github/actions/*/action.yml' '.github/actions/*/action.yaml' \
-                      '.gaia/cli/src/automation/templates/workflows/*.tmpl' \
-           | LC_ALL=C sort -z)
-
-# The bats set comes from the shared library rather than from a fourth read loop
-# here, so all three consuming gates discover the same surface the same way and
-# a change to that discovery cannot reach one of them and miss the others. The
-# call fills GAIA_GUARD_BATS_FILES and returns non-zero on an empty surface; the
-# status is read directly, because a process substitution would swallow it,
-# which is the hazard the loops above already carry a comment about.
-#
-# Deliberately NOT folded into the two-set precondition below: an operator whose
-# discovery broke needs to know WHICH surface came back empty, and the library
-# message names the bats one.
-gaia_guard_bats_files lint-errexit-status-read || exit 1
-
-# An empty scan set is a hard error, never a clean tree. The loops above read
-# from a process substitution, whose failure `set -o pipefail` cannot see, so a
-# `git ls-files` that errors (run outside a repository, a broken object store)
-# leaves the arrays empty and every check below vacuously passes. This gate would
-# then print `clean` and exit 0 having scanned nothing, which is the lie-green
-# failure gates exist to stop. Every real tree carries both sets, so an empty
-# result means the discovery is wrong rather than the tree.
-if [ "${#sh_files[@]}" -eq 0 ] || [ "${#yaml_files[@]}" -eq 0 ]; then
-  echo "lint-errexit-status-read: ERROR: no tracked *.sh or no tracked workflows matched the scan surface; nothing was scanned" >&2
-  exit 1
+if gaia_guard_scan_files lint-errexit-status-read husky 2>/dev/null; then
+  husky_files=(${GAIA_GUARD_SCAN_FILES[@]+"${GAIA_GUARD_SCAN_FILES[@]}"})
 fi
+
+gaia_guard_scan_files lint-errexit-status-read workflows || exit 1
+yaml_files=(${GAIA_GUARD_SCAN_FILES[@]+"${GAIA_GUARD_SCAN_FILES[@]}"})
+
+# The bats set comes from the same library, and for the same reason: a change to
+# that discovery cannot reach one consuming gate and miss the others.
+#
+# Deliberately its own call rather than a set folded into the ones above: an
+# operator whose discovery broke needs to know WHICH surface came back empty,
+# and each call's message names only the sets that call asked for.
+gaia_guard_bats_files lint-errexit-status-read || exit 1
 
 report=""
 for f in ${sh_files[@]+"${sh_files[@]}"}; do

--- a/.gaia/scripts/lint-errexit-status-read.sh
+++ b/.gaia/scripts/lint-errexit-status-read.sh
@@ -1035,12 +1035,26 @@ sh_files=(${GAIA_GUARD_SCAN_FILES[@]+"${GAIA_GUARD_SCAN_FILES[@]}"})
 #
 # Alone among the sets this gate reads, an empty one is a legitimate tree rather
 # than a broken discovery: a repository can carry no tracked hook at all, and the
-# call above already proved `git ls-files` answers here. So the library's status
-# is read and tolerated, and its message, which would be wrong in that case, is
-# not surfaced as this gate's own error.
+# call above already proved `git ls-files` answers here. So the library's
+# empty-surface status is tolerated, and its message, which would be wrong in
+# that case, is dropped rather than surfaced as this gate's own error.
+#
+# That status and no other. Every other one the library returns says the call is
+# wrong or the discovery broke, and swallowing one here would leave this gate,
+# the only one arming the hooks as errexit-on, scanning no hook while printing
+# `clean`: the certified-clean surface the paragraph above names. The library's
+# own message went to /dev/null with the tolerated one, so this names the status
+# it refused with, which is what says which of the two happened.
 husky_files=()
 if gaia_guard_scan_files lint-errexit-status-read husky 2>/dev/null; then
   husky_files=(${GAIA_GUARD_SCAN_FILES[@]+"${GAIA_GUARD_SCAN_FILES[@]}"})
+else
+  husky_status=$?
+  if [ "$husky_status" -ne 1 ]; then
+    printf 'lint-errexit-status-read: ERROR: the husky discovery refused with status %s; nothing was scanned\n' \
+      "$husky_status" >&2
+    exit "$husky_status"
+  fi
 fi
 
 gaia_guard_scan_files lint-errexit-status-read workflows || exit 1

--- a/.gaia/scripts/lint-grep-ere-escapes.sh
+++ b/.gaia/scripts/lint-grep-ere-escapes.sh
@@ -139,34 +139,16 @@ type gaia_guard_bats_files >/dev/null 2>&1 || {
   exit 2
 }
 
-# `git ls-files` rather than a filesystem walk, so an untracked scratch script
-# is never scanned; the same discovery .gaia/tests/shell-lint.sh uses. Collected
-# with a read loop rather than `mapfile`, which is bash 4+, because these
-# scripts run on stock macOS /bin/bash (3.2.57).
-scan_files=()
-while IFS= read -r -d '' f; do
-  scan_files+=("$f")
-done < <(git -c core.quotepath=false ls-files -z \
-                      '*.sh' '.husky/*' \
-                      '.github/workflows/*.yml' '.github/workflows/*.yaml' \
-                      '.github/actions/*/action.yml' '.github/actions/*/action.yaml' \
-                      '.gaia/cli/src/automation/templates/workflows/*.tmpl' \
-           | LC_ALL=C sort -z)
+# The scan surface comes from the shared library rather than from a read loop
+# here, so every gate consuming it discovers the same set the same way and a
+# widened pathspec cannot reach one of them and miss the others. The call fills
+# GAIA_GUARD_SCAN_FILES and returns non-zero on an empty surface, which is a
+# hard error rather than a clean tree; the status is read directly, because a
+# substitution would swallow it.
+gaia_guard_scan_files lint-grep-ere-escapes shell husky workflows || exit 1
 
-# An empty scan set is a hard error, never a clean tree. The loop above reads
-# from a process substitution, whose failure `set -o pipefail` cannot see, so a
-# `git ls-files` that errors (run outside a repository, a broken object store)
-# leaves the array empty and every check below vacuously passes. This gate would
-# then print `clean` and exit 0 having scanned nothing, which is the lie-green
-# failure gates exist to stop. Every real tree carries tracked `*.sh`, so an
-# empty result means the discovery is wrong rather than the tree.
-if [ "${#scan_files[@]}" -eq 0 ]; then
-  echo "lint-grep-ere-escapes: ERROR: no tracked shell, workflows, or workflow templates matched the scan surface; nothing was scanned" >&2
-  exit 1
-fi
-
-# A separate set from scan_files, never a widened pathspec: a tree carrying
-# .sh and no .bats must not pass clean carried by the rest of the surface.
+# A separate set from the scan surface above, never a widened pathspec: a tree
+# carrying .sh and no .bats must not pass clean carried by the rest of it.
 gaia_guard_bats_files lint-grep-ere-escapes || exit 1
 
 # scan_file <path>: print one `file:line: message` per divergent escape.
@@ -423,7 +405,7 @@ scan_file() {
 }
 
 report=""
-for f in ${scan_files[@]+"${scan_files[@]}"}; do
+for f in ${GAIA_GUARD_SCAN_FILES[@]+"${GAIA_GUARD_SCAN_FILES[@]}"}; do
   [ -f "$f" ] || continue
   hits=$(scan_file "$f" 0)
   [ -z "$hits" ] || report+="$hits"$'\n'

--- a/.gaia/scripts/lint-grep-ere-escapes.sh
+++ b/.gaia/scripts/lint-grep-ere-escapes.sh
@@ -6,9 +6,13 @@
 #
 # lint-grep-ere-escapes.sh: flag every backslash-escaped LETTER inside an
 # extended-regex grep pattern, across the framework's tracked shell, its CI
-# workflow and composite-action YAML, and the adopter workflow templates. Exit 1
-# with a file:line report on any hit, exit 0 when clean. Run it directly from
-# the repo root: `bash .gaia/scripts/lint-grep-ere-escapes.sh`.
+# workflow and composite-action YAML, and the adopter workflow templates. Run it
+# directly from the repo root: `bash .gaia/scripts/lint-grep-ere-escapes.sh`.
+#
+# Exit 0 when clean, and 1 either with a file:line report on any hit or on a
+# scan surface that came back empty. Two statuses say the gate never ran at
+# all: 2 when guard-awk-lib.sh is missing beside this script, and 3 when the
+# scan-surface discovery failed.
 # gaia:maintainer-only:start
 #
 # Enforced by the sibling bats suite
@@ -145,7 +149,12 @@ type gaia_guard_bats_files >/dev/null 2>&1 || {
 # GAIA_GUARD_SCAN_FILES and returns non-zero on an empty surface, which is a
 # hard error rather than a clean tree; the status is read directly, because a
 # substitution would swallow it.
-gaia_guard_scan_files lint-grep-ere-escapes shell husky workflows || exit 1
+#
+# The library's own status is carried out rather than flattened to 1: 1 says the
+# tree was read and held nothing, 3 says it was never read at all, and an
+# operator handed 1 for the second would look at the tree instead of the
+# discovery.
+gaia_guard_scan_files lint-grep-ere-escapes shell husky workflows || exit $?
 
 # A separate set from the scan surface above, never a widened pathspec: a tree
 # carrying .sh and no .bats must not pass clean carried by the rest of it.

--- a/.gaia/scripts/lint-workflow-run-interpolation.sh
+++ b/.gaia/scripts/lint-workflow-run-interpolation.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 # lint-workflow-run-interpolation.sh: flag every `${{ ... }}` expression that
-# sits inside a workflow `run:` block body. Exit 1 with a file:line report on
-# any hit, exit 0 when clean. Run it directly from the repo root:
+# sits inside a workflow `run:` block body. Run it directly from the repo root:
 # `bash .gaia/scripts/lint-workflow-run-interpolation.sh`.
+#
+# Exit 0 when clean, and 1 either with a file:line report on any hit or on a
+# scan surface that came back empty. Two statuses say the gate never ran at
+# all: 2 when guard-awk-lib.sh is missing beside this script, and 3 when the
+# scan-surface discovery failed.
 # gaia:maintainer-only:start
 #
 # Enforced by the sibling bats suite
@@ -123,7 +127,7 @@ type gaia_guard_scan_files >/dev/null 2>&1 || {
 # The library's one templates glob therefore reaches `partials/` and any
 # directory added under it later, which is why it needs no second glob for the
 # fragments this gate reads.
-gaia_guard_scan_files lint-workflow-run-interpolation workflows || exit 1
+gaia_guard_scan_files lint-workflow-run-interpolation workflows || exit $?
 
 # scan_file <path>: print one `file:line: message` per expression in a run body.
 #

--- a/.gaia/scripts/lint-workflow-run-interpolation.sh
+++ b/.gaia/scripts/lint-workflow-run-interpolation.sh
@@ -97,34 +97,33 @@
 
 set -euo pipefail
 
-# `git ls-files` rather than a filesystem walk, so an untracked scratch workflow
-# is never scanned; the same discovery .gaia/tests/shell-lint.sh uses. Collected
-# with a read loop rather than `mapfile`, which is bash 4+, because these
-# scripts run on stock macOS /bin/bash (3.2.57).
+# Script-relative, never cwd-relative: every fixture test runs this guard with
+# cwd inside a throwaway repo that carries no .gaia/scripts/. Bracketed with
+# set +e/-e because this file arms errexit itself, the shape
+# .gaia/scripts/lint-errexit-source-guard.sh demands for an unbracketed load in
+# an errexit-reachable file. This gate reads none of the library's awk, only its
+# scan-surface discovery.
+_gaia_guard_lib_dir="${BASH_SOURCE[0]%/*}"
+if [ "$_gaia_guard_lib_dir" = "${BASH_SOURCE[0]}" ]; then _gaia_guard_lib_dir="."; fi
+# shellcheck source=.gaia/scripts/guard-awk-lib.sh
+set +e; [ -f "$_gaia_guard_lib_dir/guard-awk-lib.sh" ] && . "$_gaia_guard_lib_dir/guard-awk-lib.sh" 2>/dev/null; set -e
+type gaia_guard_scan_files >/dev/null 2>&1 || {
+  printf 'lint-workflow-run-interpolation: guard-awk-lib.sh is missing beside this script\n' >&2
+  exit 2
+}
+
+# The scan surface comes from the shared library rather than from a read loop
+# here, so every gate consuming it discovers the same set the same way and a
+# widened pathspec cannot reach one of them and miss the others. The call fills
+# GAIA_GUARD_SCAN_FILES and returns non-zero on an empty surface, which is a
+# hard error rather than a clean tree; the status is read directly, because a
+# substitution would swallow it.
 #
 # A git pathspec glob is matched without FNM_PATHNAME, so its `*` crosses `/`.
-# The one templates glob therefore reaches `partials/` and any directory added
-# under it later, which is why there is no second glob for the fragments.
-scan_files=()
-while IFS= read -r -d '' f; do
-  scan_files+=("$f")
-done < <(git -c core.quotepath=false ls-files -z \
-                      '.github/workflows/*.yml' '.github/workflows/*.yaml' \
-                      '.github/actions/*/action.yml' '.github/actions/*/action.yaml' \
-                      '.gaia/cli/src/automation/templates/workflows/*.tmpl' \
-           | LC_ALL=C sort -z)
-
-# An empty scan set is a hard error, never a clean tree. The loop above reads
-# from a process substitution, whose failure `set -o pipefail` cannot see, so a
-# `git ls-files` that errors (run outside a repository, a broken object store)
-# leaves the array empty and every check below vacuously passes. This gate would
-# then print `clean` and exit 0 having scanned nothing, which is the lie-green
-# failure gates exist to stop. Every real tree carries tracked workflows, so an
-# empty result means the discovery is wrong rather than the tree.
-if [ "${#scan_files[@]}" -eq 0 ]; then
-  echo "lint-workflow-run-interpolation: ERROR: no tracked workflows, composite actions, or workflow templates matched the scan surface; nothing was scanned" >&2
-  exit 1
-fi
+# The library's one templates glob therefore reaches `partials/` and any
+# directory added under it later, which is why it needs no second glob for the
+# fragments this gate reads.
+gaia_guard_scan_files lint-workflow-run-interpolation workflows || exit 1
 
 # scan_file <path>: print one `file:line: message` per expression in a run body.
 #
@@ -240,7 +239,7 @@ scan_file() {
 }
 
 report=""
-for f in ${scan_files[@]+"${scan_files[@]}"}; do
+for f in ${GAIA_GUARD_SCAN_FILES[@]+"${GAIA_GUARD_SCAN_FILES[@]}"}; do
   [ -f "$f" ] || continue
   hits=$(scan_file "$f")
   [ -z "$hits" ] || report+="$hits"$'\n'

--- a/.gaia/scripts/tests/guard-awk-lib.bats
+++ b/.gaia/scripts/tests/guard-awk-lib.bats
@@ -663,6 +663,10 @@ scan_fixture_repo() {
   grep -qxF -- ".husky/helper.sh" <<<"$output" && return 1
   run bash -c "cd '$repo' && . '$LIB' && gaia_guard_scan_files probe shell husky && printf '%s\n' \"\${GAIA_GUARD_SCAN_FILES[@]}\""
   [ "$status" -eq 0 ]
+  # The exclude is the only thing keeping this at one. The union is not
+  # deduplicated, deliberately: `sort -u` there would be a second mechanism
+  # guaranteeing the same thing, and a suite cannot red on either one alone
+  # while the other still holds.
   [ "$(grep -cxF -- '.husky/helper.sh' <<<"$output")" -eq 1 ]
 }
 
@@ -674,7 +678,10 @@ scan_fixture_repo() {
   local repo
   repo="$(scan_fixture_repo)"
   run bash -c "cd '$repo' && . '$LIB' && gaia_guard_scan_files probe shell markdown"
-  [ "$status" -eq 1 ]
+  # Status 2, never 1: a caller may tolerate an empty surface where one is a
+  # legitimate tree, and must never tolerate a set name that resolved nothing
+  # because this library does not know it.
+  [ "$status" -eq 2 ]
   grep -qF -- "markdown" <<<"$output" || return 1
   grep -qF -- "probe: ERROR" <<<"$output" || return 1
 }
@@ -683,8 +690,21 @@ scan_fixture_repo() {
   local repo
   repo="$(scan_fixture_repo)"
   run bash -c "cd '$repo' && . '$LIB' && gaia_guard_scan_files probe"
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 2 ]
   grep -qF -- "probe: ERROR" <<<"$output" || return 1
+}
+
+# Run outside any repository, so `git ls-files` fails rather than answering
+# empty. Without a per-set status the `workflows` failure here would be
+# invisible: `shell` is populated, so the union clears the empty check and the
+# gate reports clean over a surface it never opened.
+@test "a set whose own discovery fails is distinguished from one that matched nothing" {
+  local outside="$TMP/not-a-repo"
+  mkdir -p "$outside"
+  run bash -c "cd '$outside' && . '$LIB' && gaia_guard_scan_files probe shell workflows"
+  [ "$status" -eq 3 ]
+  grep -qF -- "discovery failed" <<<"$output" || return 1
+  grep -qF -- "nothing was scanned" <<<"$output"
 }
 
 @test "the union across sets is sorted rather than concatenated set by set" {

--- a/.gaia/scripts/tests/guard-awk-lib.bats
+++ b/.gaia/scripts/tests/guard-awk-lib.bats
@@ -757,6 +757,22 @@ scan_fixture_repo() {
   true
 }
 
+# The array is emptied at the top of the function rather than on each return
+# path, and this is what holds that: a refusal reached after an earlier call
+# filled the array leaves the caller reading a surface nobody asked for while
+# the message says nothing was scanned. Two calls in one shell, because a single
+# refusing call cannot tell an emptied array from one that was never filled.
+@test "a refusal empties the surface a previous call left in the array" {
+  local repo
+  repo="$(scan_fixture_repo)"
+  run bash -c "cd '$repo' && . '$LIB' && gaia_guard_scan_files probe shell; gaia_guard_scan_files probe markdown; printf 'count=%s\n' \"\${#GAIA_GUARD_SCAN_FILES[@]}\""
+  grep -qxF -- "count=0" <<<"$output" || return 1
+  # The first call has to have filled it, or the assertion above is vacuous.
+  run bash -c "cd '$repo' && . '$LIB' && gaia_guard_scan_files probe shell; printf 'count=%s\n' \"\${#GAIA_GUARD_SCAN_FILES[@]}\""
+  grep -qxF -- "count=0" <<<"$output" && return 1
+  true
+}
+
 @test "the union across sets is sorted rather than concatenated set by set" {
   local repo
   repo="$(scan_fixture_repo)"
@@ -903,19 +919,33 @@ mutate() {
 # program of its own. A consumer reading only the scan-surface discovery has no
 # awk program to hold, so widening one roster into the other would red on a
 # guard that is conforming, which is why the two stay separate.
+#
+# That narrower roster is written down rather than derived, because the
+# permitted-awk-function check below needs a per-file expectation and there is
+# nowhere else for it to live. Writing it down is also how it fell behind the
+# predicate its own header states, so what holds it there is an equality check
+# against that predicate rather than a per-file grep, which a file missing from
+# the roster is never reached by.
 
 # Every tracked file carrying the library load line, plus nothing else. The
 # library itself does not carry it, so it excludes itself.
+#
+# One pathspec covers the test fixture as well as the guards: a git pathspec
+# glob is matched without FNM_PATHNAME, so its `*` crosses `/`, the property
+# guard-awk-lib.sh records for its own `shell` set. A second pathspec naming the
+# fixture directory returned the same paths and is left out rather than kept as
+# a decoration a reader would take for a widening.
 library_consumers() {
   local f
   while IFS= read -r f; do
     printf '%s\n' "$REPO_ROOT/$f"
   done < <(git -C "$REPO_ROOT" grep -l -- '_gaia_guard_lib_dir/guard-awk-lib.sh' \
-             '.gaia/scripts/*.sh' '.gaia/scripts/tests/fixtures/*.sh')
+             '.gaia/scripts/*.sh')
 }
 
 participating_files() {
   printf '%s\n' \
+    "$REPO_ROOT/.gaia/scripts/lint-collapsed-signal-trap.sh" \
     "$REPO_ROOT/.gaia/scripts/lint-git-path-quoting.sh" \
     "$REPO_ROOT/.gaia/scripts/lint-grep-ere-escapes.sh" \
     "$REPO_ROOT/.gaia/scripts/lint-errexit-status-read.sh" \
@@ -923,21 +953,28 @@ participating_files() {
     "$REPO_ROOT/.gaia/scripts/tests/fixtures/stub-guard.sh"
 }
 
+# The production guards are the participating files minus the one test fixture
+# among them, derived rather than re-listed: two hand-written rosters that must
+# agree is what left a guard out of both, and the second list bought nothing a
+# filter on the fixture path does not.
 production_guards() {
-  printf '%s\n' \
-    "$REPO_ROOT/.gaia/scripts/lint-git-path-quoting.sh" \
-    "$REPO_ROOT/.gaia/scripts/lint-grep-ere-escapes.sh" \
-    "$REPO_ROOT/.gaia/scripts/lint-errexit-status-read.sh" \
-    "$REPO_ROOT/.gaia/scripts/lint-stale-cardinals.sh"
+  participating_files | grep -v -- '/tests/fixtures/'
 }
 
-# A derivation that came back short would leave this asserting over a subset
-# while its name still says every, so the count is checked against the guards
-# known to load the library before the per-file loop runs.
-@test "every library consumer's shellcheck source= line carries the library's full repo-relative path" {
-  local f n
+# A derivation that came back short would leave a check asserting over a subset
+# while its name still says every, so both consumer checks confirm the count
+# against the guards known to load the library before their per-file loop runs.
+# The floor is the count the tree carries, not a slack figure: a floor below it
+# is a check that greens while consumers fall out of the derivation silently.
+assert_consumer_count() {
+  local n
   n="$(library_consumers | grep -c .)"
-  [ "$n" -ge 5 ]
+  [ "$n" -ge 7 ] || { echo "library_consumers returned $n, fewer than the 7 tracked consumers" >&2; return 1; }
+}
+
+@test "every library consumer's shellcheck source= line carries the library's full repo-relative path" {
+  local f
+  assert_consumer_count || return 1
   while IFS= read -r f; do
     grep -qF -- ".gaia/scripts/guard-awk-lib.sh" "$f" || { echo "$f: no shellcheck source= citation" >&2; return 1; }
   done < <(library_consumers)
@@ -949,17 +986,30 @@ production_guards() {
   # on the shellcheck source= directive line), so this checks the bracket
   # rather than a second copy of the path.
   local f load
+  assert_consumer_count || return 1
   load='set +e; [ -f "$_gaia_guard_lib_dir/guard-awk-lib.sh" ] && . "$_gaia_guard_lib_dir/guard-awk-lib.sh" 2>/dev/null; set -e'
   while IFS= read -r f; do
     grep -qF -- "$load" "$f" || { echo "$f: unbracketed or reworded library load" >&2; return 1; }
   done < <(library_consumers)
 }
 
-@test "each participating file concatenates GAIA_GUARD_AWK ahead of its own awk program" {
-  local f
+# Equality, not a per-file grep over the roster: the roster is what the awk
+# checks below iterate, so a consumer that grew an awk program and was never
+# added to it is invisible to any check the roster drives. This is the one
+# assertion that can see it, and it reds both ways -- a roster entry with no awk
+# program, and an awk-carrying consumer with no roster entry.
+@test "the participating roster is exactly the library consumers that concatenate GAIA_GUARD_AWK" {
+  local f derived
+  assert_consumer_count || return 1
+  derived=""
   while IFS= read -r f; do
-    grep -qF -- '$GAIA_GUARD_AWK' "$f" || { echo "$f: no GAIA_GUARD_AWK concatenation" >&2; return 1; }
-  done < <(participating_files)
+    if grep -qF -- '$GAIA_GUARD_AWK' "$f"; then
+      derived="$derived$f
+"
+    fi
+  done < <(library_consumers)
+  [ "$(printf '%s' "$derived" | LC_ALL=C sort)" = "$(participating_files | LC_ALL=C sort)" ] \
+    || { echo "the participating roster and the awk-carrying consumers differ" >&2; return 1; }
 }
 
 @test "the common entry points are called, not merely named, in every participating file" {
@@ -988,6 +1038,7 @@ production_guards() {
     grep -qF -- "gaia_scan_pragma_here(" "$f" || { echo "$f: never calls gaia_scan_pragma_here" >&2; return 1; }
   done < <(production_guards)
   grep -qF -- "gaia_scan_run_only(" "$REPO_ROOT/.gaia/scripts/lint-errexit-status-read.sh" || return 1
+  grep -qF -- "gaia_scan_run_only(" "$REPO_ROOT/.gaia/scripts/lint-collapsed-signal-trap.sh" && return 1
   grep -qF -- "gaia_scan_run_only(" "$REPO_ROOT/.gaia/scripts/lint-git-path-quoting.sh" && return 1
   grep -qF -- "gaia_scan_run_only(" "$REPO_ROOT/.gaia/scripts/lint-grep-ere-escapes.sh" && return 1
   grep -qF -- "gaia_scan_run_only(" "$REPO_ROOT/.gaia/scripts/lint-stale-cardinals.sh" && return 1
@@ -1044,6 +1095,14 @@ own_awk_functions() {
   # library's; that is a semantic claim no grep can make, so it is recorded
   # here rather than asserted.
   local actual expected
+
+  # The collapsed-trap gate's three private walks, all class detection: signal_words
+  # reads the signal list off one trap arm, in_command_position decides whether the
+  # word `trap` opens a command rather than sitting inside one, and collapsed is the
+  # verdict over the two. None of them tokenizes shell the library already reads.
+  actual="$(own_awk_functions "$REPO_ROOT/.gaia/scripts/lint-collapsed-signal-trap.sh")"
+  expected="$(printf '%s\n' collapsed in_command_position signal_words)"
+  [ "$actual" = "$expected" ]
 
   actual="$(own_awk_functions "$REPO_ROOT/.gaia/scripts/lint-git-path-quoting.sh")"
   [ "$actual" = "option_walk" ]

--- a/.gaia/scripts/tests/guard-awk-lib.bats
+++ b/.gaia/scripts/tests/guard-awk-lib.bats
@@ -695,9 +695,13 @@ scan_fixture_repo() {
 }
 
 # Run outside any repository, so `git ls-files` fails rather than answering
-# empty. Without a per-set status the `workflows` failure here would be
-# invisible: `shell` is populated, so the union clears the empty check and the
-# gate reports clean over a surface it never opened.
+# empty, and status 3 separates that from the empty surface a caller is allowed
+# to tolerate. EVERY named set fails in this fixture, because failing is a
+# property of the repository rather than of the pathspec, and no fixture can
+# make one set's `git ls-files` fail while another's answers. So this pins the
+# status and not the position of the check that returns it; the unknown-set test
+# below is what pins that, on the arm where a fixture can name a refusing set
+# ahead of a resolvable one.
 @test "a set whose own discovery fails is distinguished from one that matched nothing" {
   local outside="$TMP/not-a-repo"
   mkdir -p "$outside"
@@ -705,6 +709,51 @@ scan_fixture_repo() {
   [ "$status" -eq 3 ]
   grep -qF -- "discovery failed" <<<"$output" || return 1
   grep -qF -- "nothing was scanned" <<<"$output"
+}
+
+# The refusing set is named FIRST and a resolvable set follows it, which is what
+# makes this fail against a check hoisted out of the per-set loop. Reading only
+# the last named set's status leaves this call returning 0 with the `shell` set
+# in the array: a guard scanning a surface other than the one it asked for, and
+# reporting clean, which is the whole reason the status exists.
+@test "a refusing set is caught where a later named set would still resolve" {
+  local repo
+  repo="$(scan_fixture_repo)"
+  run bash -c "cd '$repo' && . '$LIB' && gaia_guard_scan_files probe markdown shell && printf '%s\n' \"\${GAIA_GUARD_SCAN_FILES[@]}\""
+  [ "$status" -eq 2 ]
+  grep -qF -- "markdown" <<<"$output" || return 1
+  grep -qxF -- "tool.sh" <<<"$output" && return 1
+  true
+}
+
+# The sort is the one stage whose failure no repository state can produce, so it
+# is driven through a stub ahead of it on PATH. Without its status read, a sort
+# that died would empty the array and surface as status 1, which is the status a
+# caller is told it may tolerate.
+@test "a sort that fails is not reported as an empty surface" {
+  local repo stub
+  repo="$(scan_fixture_repo)"
+  stub="$TMP/stubbin"
+  mkdir -p "$stub"
+  printf '#!/bin/sh\nexit 4\n' > "$stub/sort"
+  chmod +x "$stub/sort"
+  run bash -c "cd '$repo' && . '$LIB' && PATH=\"$stub:\\$PATH\" gaia_guard_scan_files probe shell"
+  [ "$status" -eq 3 ]
+  grep -qF -- "sorting the scan surface failed" <<<"$output" || return 1
+  grep -qF -- "nothing was scanned" <<<"$output"
+}
+
+# Naming a set twice is refused rather than concatenated, which is what makes the
+# result a union now that nothing downstream deduplicates it: every path in the
+# repeated set would otherwise be scanned twice and reported twice.
+@test "a set named twice is refused rather than returned twice" {
+  local repo
+  repo="$(scan_fixture_repo)"
+  run bash -c "cd '$repo' && . '$LIB' && gaia_guard_scan_files probe shell shell && printf '%s\n' \"\${GAIA_GUARD_SCAN_FILES[@]}\""
+  [ "$status" -eq 2 ]
+  grep -qF -- "named more than once" <<<"$output" || return 1
+  grep -qxF -- "tool.sh" <<<"$output" && return 1
+  true
 }
 
 @test "the union across sets is sorted rather than concatenated set by set" {

--- a/.gaia/scripts/tests/guard-awk-lib.bats
+++ b/.gaia/scripts/tests/guard-awk-lib.bats
@@ -562,6 +562,139 @@ EOF
   grep -qF -- "a.bats" <<<"$output" || return 1
 }
 
+# ---- the scan-surface discovery --------------------------------------------
+
+# scan_fixture_repo: a repo carrying one tracked member of every set the helper
+# knows, so a per-set assertion below can name what the set must NOT return as
+# well as what it must.
+scan_fixture_repo() {
+  local repo="$TMP/scanrepo"
+  mkdir -p "$repo/.husky" "$repo/.github/workflows" "$repo/.github/actions/probe"
+  mkdir -p "$repo/.gaia/cli/src/automation/templates/workflows"
+  git -C "$repo" init -q .
+  printf 'x\n' > "$repo/tool.sh"
+  printf 'x\n' > "$repo/.husky/pre-commit"
+  printf 'x\n' > "$repo/.github/workflows/ci.yml"
+  printf 'x\n' > "$repo/.github/actions/probe/action.yaml"
+  printf 'x\n' > "$repo/.gaia/cli/src/automation/templates/workflows/ci.yml.tmpl"
+  git -C "$repo" add -A
+  printf '%s' "$repo"
+}
+
+# Same contract as the bats discovery above: a pathspec matching nothing means
+# the discovery is wrong rather than the tree clean, and the caller reads that
+# as a status rather than through a substitution that would swallow it.
+@test "an empty scan surface is a hard error and a populated one fills the array" {
+  local repo="$TMP/repo"
+  mkdir -p "$repo"
+  git -C "$repo" init -q .
+  printf 'x\n' > "$repo/a.bats"
+  git -C "$repo" add -A
+  run bash -c "cd '$repo' && . '$LIB' && gaia_guard_scan_files probe shell"
+  [ "$status" -eq 1 ]
+  grep -qF -- "probe: ERROR" <<<"$output" || return 1
+  grep -qF -- "nothing was scanned" <<<"$output" || return 1
+  printf 'x\n' > "$repo/a.sh"
+  git -C "$repo" add -A
+  run bash -c "cd '$repo' && . '$LIB' && gaia_guard_scan_files probe shell && printf '%s\n' \"\${GAIA_GUARD_SCAN_FILES[@]}\""
+  [ "$status" -eq 0 ]
+  grep -qxF -- "a.sh" <<<"$output" || return 1
+}
+
+# The message names the sets that were asked for, because a caller asking for
+# more than one has no other way to learn which discovery came back empty.
+@test "the empty-surface error names the sets that were asked for" {
+  local repo="$TMP/repo"
+  mkdir -p "$repo"
+  git -C "$repo" init -q .
+  printf 'x\n' > "$repo/a.bats"
+  git -C "$repo" add -A
+  run bash -c "cd '$repo' && . '$LIB' && gaia_guard_scan_files probe husky workflows"
+  [ "$status" -eq 1 ]
+  grep -qF -- "(husky workflows)" <<<"$output" || return 1
+}
+
+@test "the shell set returns tracked *.sh and no workflow or hook" {
+  local repo
+  repo="$(scan_fixture_repo)"
+  run bash -c "cd '$repo' && . '$LIB' && gaia_guard_scan_files probe shell && printf '%s\n' \"\${GAIA_GUARD_SCAN_FILES[@]}\""
+  [ "$status" -eq 0 ]
+  grep -qxF -- "tool.sh" <<<"$output" || return 1
+  grep -qxF -- ".husky/pre-commit" <<<"$output" && return 1
+  grep -qxF -- ".github/workflows/ci.yml" <<<"$output" && return 1
+  true
+}
+
+@test "the husky set returns the extensionless hooks no extension glob matches" {
+  local repo
+  repo="$(scan_fixture_repo)"
+  run bash -c "cd '$repo' && . '$LIB' && gaia_guard_scan_files probe husky && printf '%s\n' \"\${GAIA_GUARD_SCAN_FILES[@]}\""
+  [ "$status" -eq 0 ]
+  grep -qxF -- ".husky/pre-commit" <<<"$output" || return 1
+  grep -qxF -- "tool.sh" <<<"$output" && return 1
+  true
+}
+
+# The workflow templates are `.tmpl` rather than `.yml`, so a set that returned
+# the workflows and missed them would still look populated.
+@test "the workflows set returns workflows, composite actions, and templates" {
+  local repo
+  repo="$(scan_fixture_repo)"
+  run bash -c "cd '$repo' && . '$LIB' && gaia_guard_scan_files probe workflows && printf '%s\n' \"\${GAIA_GUARD_SCAN_FILES[@]}\""
+  [ "$status" -eq 0 ]
+  grep -qxF -- ".github/workflows/ci.yml" <<<"$output" || return 1
+  grep -qxF -- ".github/actions/probe/action.yaml" <<<"$output" || return 1
+  grep -qxF -- ".gaia/cli/src/automation/templates/workflows/ci.yml.tmpl" <<<"$output" || return 1
+  grep -qxF -- "tool.sh" <<<"$output" && return 1
+  true
+}
+
+# A git pathspec glob is matched without FNM_PATHNAME, so `*.sh` crosses `/` and
+# reaches a script under .husky/. The shell set excludes the hook directory for
+# that reason: a caller asking for both sets must receive such a file once, or
+# it is scanned twice and reported twice.
+@test "a .sh under .husky belongs to the husky set alone and appears once in the union" {
+  local repo
+  repo="$(scan_fixture_repo)"
+  printf 'x\n' > "$repo/.husky/helper.sh"
+  git -C "$repo" add -A
+  run bash -c "cd '$repo' && . '$LIB' && gaia_guard_scan_files probe shell && printf '%s\n' \"\${GAIA_GUARD_SCAN_FILES[@]}\""
+  [ "$status" -eq 0 ]
+  grep -qxF -- ".husky/helper.sh" <<<"$output" && return 1
+  run bash -c "cd '$repo' && . '$LIB' && gaia_guard_scan_files probe shell husky && printf '%s\n' \"\${GAIA_GUARD_SCAN_FILES[@]}\""
+  [ "$status" -eq 0 ]
+  [ "$(grep -cxF -- '.husky/helper.sh' <<<"$output")" -eq 1 ]
+}
+
+# Unknown names are rejected before any read, because the reads run inside a
+# process substitution whose subshell cannot return a status to the caller. A
+# silently-dropped set is the discovery-stage failure these gates exist to stop:
+# the guard scans less than the rule it encodes governs and still reports clean.
+@test "an unknown set name is a hard error that names the set and scans nothing" {
+  local repo
+  repo="$(scan_fixture_repo)"
+  run bash -c "cd '$repo' && . '$LIB' && gaia_guard_scan_files probe shell markdown"
+  [ "$status" -eq 1 ]
+  grep -qF -- "markdown" <<<"$output" || return 1
+  grep -qF -- "probe: ERROR" <<<"$output" || return 1
+}
+
+@test "a call naming no set at all is a hard error rather than an empty surface" {
+  local repo
+  repo="$(scan_fixture_repo)"
+  run bash -c "cd '$repo' && . '$LIB' && gaia_guard_scan_files probe"
+  [ "$status" -eq 1 ]
+  grep -qF -- "probe: ERROR" <<<"$output" || return 1
+}
+
+@test "the union across sets is sorted rather than concatenated set by set" {
+  local repo
+  repo="$(scan_fixture_repo)"
+  run bash -c "cd '$repo' && . '$LIB' && gaia_guard_scan_files probe shell husky workflows && printf '%s\n' \"\${GAIA_GUARD_SCAN_FILES[@]}\""
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(LC_ALL=C sort <<<"$output")" ]
+}
+
 @test "the library sources twice in one shell without erroring under errexit" {
   run bash -c "set -euo pipefail; . '$LIB'; . '$LIB'; printf 'ok\n'"
   [ "$status" -eq 0 ]

--- a/.gaia/scripts/tests/guard-awk-lib.bats
+++ b/.gaia/scripts/tests/guard-awk-lib.bats
@@ -670,10 +670,11 @@ scan_fixture_repo() {
   [ "$(grep -cxF -- '.husky/helper.sh' <<<"$output")" -eq 1 ]
 }
 
-# Unknown names are rejected before any read, because the reads run inside a
-# process substitution whose subshell cannot return a status to the caller. A
-# silently-dropped set is the discovery-stage failure these gates exist to stop:
-# the guard scans less than the rule it encodes governs and still reports clean.
+# The set that names it is where an unknown name is refused, so a set ahead of it
+# has already been read and appended; nothing of it reaches the caller, because
+# the array is emptied before any return. A silently-dropped set is the
+# discovery-stage failure these gates exist to stop: the guard scans less than
+# the rule it encodes governs and still reports clean.
 @test "an unknown set name is a hard error that names the set and scans nothing" {
   local repo
   repo="$(scan_fixture_repo)"
@@ -737,7 +738,7 @@ scan_fixture_repo() {
   mkdir -p "$stub"
   printf '#!/bin/sh\nexit 4\n' > "$stub/sort"
   chmod +x "$stub/sort"
-  run bash -c "cd '$repo' && . '$LIB' && PATH=\"$stub:\\$PATH\" gaia_guard_scan_files probe shell"
+  run bash -c "cd '$repo' && . '$LIB' && PATH=\"$stub:\$PATH\" gaia_guard_scan_files probe shell"
   [ "$status" -eq 3 ]
   grep -qF -- "sorting the scan surface failed" <<<"$output" || return 1
   grep -qF -- "nothing was scanned" <<<"$output"
@@ -889,10 +890,29 @@ mutate() {
 # Section A: shared-entry-point conformance (UAT-010)
 # ============================================================================
 #
-# Every check below greps every participating file at once: each production
-# guard and the stub-guard fixture. The set is enumerated once in
-# participating_files() below and read from there, so a guard added to that
-# list is held to this whole section without editing any check in it.
+# Two rosters, because two kinds of check live here and they do not cover the
+# same files.
+#
+# The load-shape checks bind every file that loads the library at all, so their
+# roster is DERIVED from the load line rather than written down: a guard added
+# as a consumer is held to them without editing this suite, which is what the
+# hand-written list failed at twice, once for a guard added beside its siblings
+# and once for a guard that became a consumer by gaining the scan-surface call.
+#
+# The awk checks bind the narrower set that concatenates GAIA_GUARD_AWK into a
+# program of its own. A consumer reading only the scan-surface discovery has no
+# awk program to hold, so widening one roster into the other would red on a
+# guard that is conforming, which is why the two stay separate.
+
+# Every tracked file carrying the library load line, plus nothing else. The
+# library itself does not carry it, so it excludes itself.
+library_consumers() {
+  local f
+  while IFS= read -r f; do
+    printf '%s\n' "$REPO_ROOT/$f"
+  done < <(git -C "$REPO_ROOT" grep -l -- '_gaia_guard_lib_dir/guard-awk-lib.sh' \
+             '.gaia/scripts/*.sh' '.gaia/scripts/tests/fixtures/*.sh')
+}
 
 participating_files() {
   printf '%s\n' \
@@ -911,14 +931,19 @@ production_guards() {
     "$REPO_ROOT/.gaia/scripts/lint-stale-cardinals.sh"
 }
 
-@test "each participating file's shellcheck source= line carries the library's full repo-relative path" {
-  local f
+# A derivation that came back short would leave this asserting over a subset
+# while its name still says every, so the count is checked against the guards
+# known to load the library before the per-file loop runs.
+@test "every library consumer's shellcheck source= line carries the library's full repo-relative path" {
+  local f n
+  n="$(library_consumers | grep -c .)"
+  [ "$n" -ge 5 ]
   while IFS= read -r f; do
     grep -qF -- ".gaia/scripts/guard-awk-lib.sh" "$f" || { echo "$f: no shellcheck source= citation" >&2; return 1; }
-  done < <(participating_files)
+  done < <(library_consumers)
 }
 
-@test "each participating file brackets its library load with set +e and set -e on one line" {
+@test "every library consumer brackets its library load with set +e and set -e on one line" {
   # README C1.1's frozen block, verbatim. The load is script-relative by
   # design and does not itself carry the full path (which lives above it,
   # on the shellcheck source= directive line), so this checks the bracket
@@ -927,7 +952,7 @@ production_guards() {
   load='set +e; [ -f "$_gaia_guard_lib_dir/guard-awk-lib.sh" ] && . "$_gaia_guard_lib_dir/guard-awk-lib.sh" 2>/dev/null; set -e'
   while IFS= read -r f; do
     grep -qF -- "$load" "$f" || { echo "$f: unbracketed or reworded library load" >&2; return 1; }
-  done < <(participating_files)
+  done < <(library_consumers)
 }
 
 @test "each participating file concatenates GAIA_GUARD_AWK ahead of its own awk program" {

--- a/.gaia/scripts/tests/guard-awk-lib.bats
+++ b/.gaia/scripts/tests/guard-awk-lib.bats
@@ -930,17 +930,21 @@ mutate() {
 # Every tracked file carrying the library load line, plus nothing else. The
 # library itself does not carry it, so it excludes itself.
 #
-# One pathspec covers the test fixture as well as the guards: a git pathspec
-# glob is matched without FNM_PATHNAME, so its `*` crosses `/`, the property
-# guard-awk-lib.sh records for its own `shell` set. A second pathspec naming the
-# fixture directory returned the same paths and is left out rather than kept as
-# a decoration a reader would take for a widening.
+# Searched tree-wide rather than under the guards' own directory. The load is
+# script-relative, and the fixture already resolves it two levels up, so nothing
+# stops a consumer being added under .claude/hooks/ or .github/audit/; a
+# directory-scoped search would leave such a file outside all three load-shape
+# checks while this comment claimed it was held.
+#
+# The one exclusion is the suite surface, which carries the load line as the
+# literal the bracket check below compares against. That is data this file
+# reads, not a load it performs.
 library_consumers() {
   local f
   while IFS= read -r f; do
     printf '%s\n' "$REPO_ROOT/$f"
   done < <(git -C "$REPO_ROOT" grep -l -- '_gaia_guard_lib_dir/guard-awk-lib.sh' \
-             '.gaia/scripts/*.sh')
+             -- ':(exclude)*.bats')
 }
 
 participating_files() {

--- a/.gaia/scripts/tests/lint-collapsed-signal-trap.bats
+++ b/.gaia/scripts/tests/lint-collapsed-signal-trap.bats
@@ -307,6 +307,19 @@ trapdoor EXIT INT'
   grep -qF -- "the scan surface (shell husky workflows)" <<<"$output"
 }
 
+# The `|| exit $?` on the discovery call is the whole mechanism here. `|| exit 1`
+# folds a discovery that never ran into the status this gate uses for a tree it
+# read and found nothing in, and an operator handed that would go looking at the
+# tree. Run outside any repository, so `git ls-files` fails rather than answering
+# empty; that is the one discovery failure a fixture can produce without a stub.
+@test "a discovery that never ran exits distinctly from a surface that came back empty" {
+  TMP="$(mktemp -d -t collapsed-trap-lint-XXXXXX)"
+  run bash -c "cd '$TMP' && bash '$LINTER' 2>&1"
+  [ "$status" -eq 3 ]
+  grep -qF -- "discovery failed" <<<"$output" || return 1
+  grep -qF -- "nothing was scanned" <<<"$output"
+}
+
 @test "a tree with tracked shell but no bats suite is a hard error" {
   fixture_repo_bare
   fixture_script 'true'

--- a/.gaia/scripts/tests/lint-collapsed-signal-trap.bats
+++ b/.gaia/scripts/tests/lint-collapsed-signal-trap.bats
@@ -299,7 +299,12 @@ trapdoor EXIT INT'
   fixture_repo_bare
   run_linter
   [ "$status" -eq 1 ]
-  grep -qF -- "nothing was scanned" <<<"$output"
+  grep -qF -- "nothing was scanned" <<<"$output" || return 1
+  # Names the sets this gate asked for, not the phrase every empty-surface
+  # message carries: the bats error below carries it too, and would other-
+  # wise green this test over a scan discovery that reported clean over
+  # nothing.
+  grep -qF -- "the scan surface (shell husky workflows)" <<<"$output"
 }
 
 @test "a tree with tracked shell but no bats suite is a hard error" {

--- a/.gaia/scripts/tests/lint-errexit-status-read.bats
+++ b/.gaia/scripts/tests/lint-errexit-status-read.bats
@@ -1136,9 +1136,12 @@ echo done'
 
 # --- the gate refuses to report clean over nothing -------------------------
 
-# Each of the three messages carries `nothing was scanned`, so a grep for that
+# Every empty-surface message carries `nothing was scanned`, so a grep for that
 # phrase alone would green whichever precondition happened to fire first. Each
-# assertion below names the half it is about, or it pins the wrong surface.
+# assertion below names the set it is about, or it pins the wrong surface.
+#
+# A tree carrying no tracked hook is NOT among them: the husky set is the one
+# this gate reads tolerantly, because a repository legitimately has no hooks.
 
 @test "errors rather than passing when no tracked shell matches" {
   fixture_repo_bare
@@ -1146,7 +1149,7 @@ echo done'
   seed_bats
   run_linter
   [ "$status" -eq 1 ]
-  grep -qF -- 'no tracked *.sh or no tracked workflows' <<<"$output"
+  grep -qF -- 'the scan surface (shell)' <<<"$output"
 }
 
 @test "errors rather than passing when no tracked workflow matches" {
@@ -1155,7 +1158,7 @@ echo done'
   seed_bats
   run_linter
   [ "$status" -eq 1 ]
-  grep -qF -- 'no tracked *.sh or no tracked workflows' <<<"$output"
+  grep -qF -- 'the scan surface (workflows)' <<<"$output"
 }
 
 @test "errors rather than passing when no tracked bats suite matches" {

--- a/.gaia/scripts/tests/lint-errexit-status-read.bats
+++ b/.gaia/scripts/tests/lint-errexit-status-read.bats
@@ -1171,6 +1171,26 @@ echo done'
   grep -qF -- 'nothing was scanned' <<<"$output"
 }
 
+# The `|| exit $?` on each discovery call is the whole mechanism here. `|| exit 1`
+# folds a discovery that never ran into the status the empty-surface tests above
+# use for a surface this gate read and found nothing in, and an operator handed
+# that would go looking at the tree. Run outside any repository, so git fails rather
+# than answering empty; that is the one discovery failure a fixture can produce
+# without a stub.
+#
+# It reaches this gate's FIRST discovery call and no later one. Failing is a
+# property of the repository rather than of the pathspec, so no fixture can make
+# one set's discovery fail while another's answers, and the first failure exits
+# before the rest are asked. What the later calls rely on is the library reading
+# each set's own status, which guard-awk-lib.bats pins on its own terms.
+@test "a discovery that never ran exits distinctly from a surface that came back empty" {
+  TMP="$(mktemp -d -t errexit-status-lint-XXXXXX)"
+  run bash -c "cd '$TMP' && bash '$LINTER' 2>&1"
+  [ "$status" -eq 3 ]
+  grep -qF -- 'discovery failed' <<<"$output" || return 1
+  grep -qF -- 'nothing was scanned' <<<"$output"
+}
+
 # --- the prefix matrix, differential against a real shell -------------------
 #
 # Four defects landed on the env-prefix exclusion across four review rounds,

--- a/.gaia/scripts/tests/lint-grep-ere-escapes.bats
+++ b/.gaia/scripts/tests/lint-grep-ere-escapes.bats
@@ -484,7 +484,12 @@ grep -qE "a\tb" input.txt
   fixture_repo_bare
   run_linter
   [ "$status" -eq 1 ]
-  grep -qF -- "nothing was scanned" <<<"$output"
+  grep -qF -- "nothing was scanned" <<<"$output" || return 1
+  # Names the sets this gate asked for, not the phrase every empty-surface
+  # message carries: the bats error below carries it too, and would other-
+  # wise green this test over a scan discovery that reported clean over
+  # nothing.
+  grep -qF -- "the scan surface (shell husky workflows)" <<<"$output"
 }
 
 # An empty *.bats surface is its own hard error, distinct from the empty

--- a/.gaia/scripts/tests/lint-grep-ere-escapes.bats
+++ b/.gaia/scripts/tests/lint-grep-ere-escapes.bats
@@ -492,6 +492,19 @@ grep -qE "a\tb" input.txt
   grep -qF -- "the scan surface (shell husky workflows)" <<<"$output"
 }
 
+# The `|| exit $?` on the discovery call is the whole mechanism here. `|| exit 1`
+# folds a discovery that never ran into the status this gate uses for a tree it
+# read and found nothing in, and an operator handed that would go looking at the
+# tree. Run outside any repository, so `git ls-files` fails rather than answering
+# empty; that is the one discovery failure a fixture can produce without a stub.
+@test "a discovery that never ran exits distinctly from a surface that came back empty" {
+  TMP="$(mktemp -d -t grep-ere-lint-XXXXXX)"
+  run bash -c "cd '$TMP' && bash '$LINTER' 2>&1"
+  [ "$status" -eq 3 ]
+  grep -qF -- "discovery failed" <<<"$output" || return 1
+  grep -qF -- "nothing was scanned" <<<"$output"
+}
+
 # An empty *.bats surface is its own hard error, distinct from the empty
 # shell/workflow surface above: a tree with tracked shell and no bats must not
 # pass clean carried by the rest of the scan.

--- a/.gaia/scripts/tests/lint-workflow-run-interpolation.bats
+++ b/.gaia/scripts/tests/lint-workflow-run-interpolation.bats
@@ -397,7 +397,8 @@ jobs:
   fixture_repo
   run_linter
   [ "$status" -eq 1 ]
-  grep -qF -- "nothing was scanned" <<<"$output"
+  grep -qF -- "nothing was scanned" <<<"$output" || return 1
+  grep -qF -- "the scan surface (workflows)" <<<"$output"
 }
 
 @test "the real repository tree is clean" {

--- a/.gaia/scripts/tests/lint-workflow-run-interpolation.bats
+++ b/.gaia/scripts/tests/lint-workflow-run-interpolation.bats
@@ -401,6 +401,20 @@ jobs:
   grep -qF -- "the scan surface (workflows)" <<<"$output"
 }
 
+# The `|| exit $?` on the discovery call is the whole mechanism here. `|| exit 1`
+# folds a discovery that never ran into the status the test above uses for a
+# surface this gate read and found nothing in, and an operator handed that would
+# go looking at the tree. Run outside any repository, so `git ls-files` fails
+# rather than answering empty; that is the one discovery failure a fixture can
+# produce without a stub.
+@test "a discovery that never ran exits distinctly from a surface that came back empty" {
+  TMP="$(mktemp -d -t run-interp-lint-XXXXXX)"
+  run bash -c "cd '$TMP' && bash '$LINTER' 2>&1"
+  [ "$status" -eq 3 ]
+  grep -qF -- "discovery failed" <<<"$output" || return 1
+  grep -qF -- "nothing was scanned" <<<"$output"
+}
+
 @test "the real repository tree is clean" {
   run bash -c "cd '$REPO_ROOT' && bash '$LINTER' 2>&1"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Closes #1720

## The gap

Four shell guards discovered the same scan surface and each carried its own verbatim copy of the discovery: the `git ls-files` pathspec, the NUL-delimited read loop filling `scan_files`, and the empty-set hard error that refuses to report clean over nothing.

- `.gaia/scripts/lint-collapsed-signal-trap.sh`
- `.gaia/scripts/lint-errexit-status-read.sh`
- `.gaia/scripts/lint-grep-ere-escapes.sh`
- `.gaia/scripts/lint-workflow-run-interpolation.sh`

Widening the surface had to land at four sites, and the copy nobody edited would scan less than the rule it encodes governs while still printing `clean` — the discovery-stage failure `.claude/rules/guards-must-fail.md` names. The asymmetry is what made it worth repairing: the sibling half of the same discovery, the `*.bats` set, was already shared as `gaia_guard_bats_files`, so one half was extracted and the other was copied.

## The fix

`gaia_guard_scan_files <label> <set>...` sits beside `gaia_guard_bats_files` in `.gaia/scripts/guard-awk-lib.sh`, fills `GAIA_GUARD_SCAN_FILES`, and carries the empty-set error, mirroring the existing helper's status-returning call convention.

**It takes named sets rather than the one frozen pathspec the issue sketched**, because the four copies turned out not to be interchangeable: two carry the full union, `lint-workflow-run-interpolation.sh` reads the workflows alone, and `lint-errexit-status-read.sh` splits shell from hooks because it arms the two differently. A single fixed pathspec would have served two of the four sites and left the workflow glob — the one the issue's own `git grep` verification keys on — duplicated at the other two. Naming `shell`, `husky`, and `workflows` gives each pathspec exactly one definition and lets each gate compose the sets it arms, which is what actually collapses a widening to one site.

Two implementation notes worth reading:

- One `git ls-files` runs per set. A `:(exclude)` pathspec applies to the whole call, so `shell`'s exclude would otherwise empty a `husky` set asked for in the same breath.
- Each `case` pattern carries the optional leading `(`. Without it, stock macOS /bin/bash 3.2.57 reads the `)` closing a pattern as the one closing the process substitution and fails to parse the file. Caught by shell-lint's bash-3.2 parse leg, not by anything on this machine's bash 5.

## Behaviour changes

Both are maintainer-facing diagnostics on release-excluded files.

- `lint-errexit-status-read.sh`'s single combined `no tracked *.sh or no tracked workflows` message becomes one message per set, naming the set that came back empty. Its own suite's header already claimed its two assertions distinguished those halves; they greped the same string, so they did not. They do now.
- `lint-workflow-run-interpolation.sh` never loaded the shared library at all and now does, so it exits 2 when the library is missing beside it, the same as its siblings. It reads none of the library's awk, only its discovery.

The errexit gate keeps reading its hook set tolerantly rather than through the hard error: alone among the sets it reads, an empty one is a legitimate tree rather than a broken discovery, and the `shell` call ahead of it has already proved `git ls-files` answers. Its fixtures rely on that, and tightening it would have been scope the finding does not carry.

## Proving the extraction can fail

The issue asked for exactly this, and asking for it was right — the assertions did not hold up.

Three suites' empty-scan-set tests greped only for `nothing was scanned`, a phrase every empty-surface message in these gates carries. In the two whose gate also reads the bats set, the bats error stood in for the scan-surface one: **a discovery reporting clean over nothing still greened the test named for it.** Each assertion now names the sets its own call asked for.

Two mutations, both applied to the shared helper and both reverted:

1. Neuter the empty-surface hard error so it reports success over nothing → every named test reds (all four guards, plus the library's own).
2. Drop `:(exclude).husky/*` from the `shell` set, the silent-widening case → the library's union test and the errexit gate's `a .sh under .husky is scanned once` test both red.

## Verification

- `bash .gaia/tests/shell-lint.sh` → passed (its bash-3.2 parse and `lint-hook-array-guard` legs each caught a real defect in an earlier draft)
- `bash .gaia/tests/whole-tree-invariants.sh` → all invariants pass
- The five affected bats suites under bash 5 (`.gaia/scripts/bats5.sh`) → 298 passed, 0 failed
- Quality Gate: skipped by its own rule — no staged `.ts|tsx|js|jsx|mjs|cjs|css` and no gate-affecting config. The check ran and answered empty.

## CHANGELOG

No `## [Unreleased]` entry. These files are release-excluded (absent from `.gaia/manifest.json`), no adopter clone runs them, and the guards catch exactly the set they caught before; the only observable changes are the two maintainer diagnostics above. Nothing here has anything adopter-facing to say.

## Out of scope, deliberately

Six other guards keep their own `scan_files` discovery (`lint-git-path-quoting.sh`, `lint-stale-cardinals.sh`, `lint-shipped-issue-refs.sh`, `lint-hook-array-guard.sh`, `lint-oracle-blind-invocations.sh`, `lint-errexit-source-guard.sh`). Those are genuinely different surfaces rather than copies of this one — different pathspecs, and in one case a set derived from the release manifest — which is why the issue's `git grep` over the shared workflow-template pathspec returned four files and not ten.

`lint-collapsed-signal-trap.sh` is still absent from `guard-awk-lib.bats`'s hand-enumerated `participating_files()` / `production_guards()` rosters, a gap that arrived with the guard itself in #1719 and is untouched here.
