### PR TITLE
debt(tests): pin the consumer derivation's reach and recount its floor (#1724 #1725 #1726)

### DIFF
--- a/.gaia/scripts/guard-awk-lib.sh
+++ b/.gaia/scripts/guard-awk-lib.sh
@@ -822,6 +822,11 @@ _gaia_guard_scan_set() {
 # caller reads it directly (`gaia_guard_scan_files <label> <set>... || exit 1`)
 # rather than through a substitution that would swallow it.
 #
+# On any status but 0 the array is empty, never the surface a previous call left
+# in it. That is a property of every refusing status below rather than of any one
+# of them, which is why it is stated ahead of the list rather than beside an
+# entry in it.
+#
 #   0  the union is non-empty and the array holds it.
 #   1  every named set resolved and the union came back empty. A hard error
 #      rather than a clean tree, for the reason gaia_guard_bats_files states
@@ -831,9 +836,6 @@ _gaia_guard_scan_set() {
 #      named at all, or one named twice. Either way the guard would scan a
 #      surface other than the one it asked for and still report clean, which is
 #      the discovery-stage failure `.claude/rules/guards-must-fail.md` names.
-# On any status but 0 the array is empty, never the surface a previous call
-# left in it.
-#
 #   3  the discovery machinery failed: a named set's own `git ls-files`, the
 #      sort, or the scratch file each of them needs. Distinct from 1 because
 #      the repairs differ, and distinct from a partial result because a set

--- a/.gaia/scripts/tests/guard-awk-lib.bats
+++ b/.gaia/scripts/tests/guard-awk-lib.bats
@@ -939,12 +939,54 @@ mutate() {
 # The one exclusion is the suite surface, which carries the load line as the
 # literal the bracket check below compares against. That is data this file
 # reads, not a load it performs.
+#
+# Parameterized on a repo root, the way scan_fixture_repo parameterizes the
+# discovery tests above, so the reach itself can be driven against a fixture.
+# Over the real tree the widened pathspec and the directory-scoped form it
+# replaced return the same paths, so no assertion here can red on a revert of
+# the widening; the fixture test below is what does.
 library_consumers() {
-  local f
+  local root="${1:-$REPO_ROOT}" f
   while IFS= read -r f; do
-    printf '%s\n' "$REPO_ROOT/$f"
-  done < <(git -C "$REPO_ROOT" grep -l -- '_gaia_guard_lib_dir/guard-awk-lib.sh' \
+    printf '%s\n' "$root/$f"
+  done < <(git -C "$root" grep -l -- '_gaia_guard_lib_dir/guard-awk-lib.sh' \
              -- ':(exclude)*.bats')
+}
+
+# consumer_fixture_repo: a repo carrying a tracked consumer inside the guards'
+# own directory and another outside it, plus a tracked non-consumer, so the
+# derivation can be asserted to reach past .gaia/scripts/ and to stop at a file
+# that does not carry the load line.
+consumer_fixture_repo() {
+  local repo="$TMP/consumerrepo" load
+  load='set +e; [ -f "$_gaia_guard_lib_dir/guard-awk-lib.sh" ] && . "$_gaia_guard_lib_dir/guard-awk-lib.sh" 2>/dev/null; set -e'
+  mkdir -p "$repo/.gaia/scripts" "$repo/.claude/hooks"
+  git -C "$repo" init -q .
+  printf '%s\n' "$load" > "$repo/.gaia/scripts/lint-probe.sh"
+  printf '%s\n' "$load" > "$repo/.claude/hooks/probe-hook.sh"
+  printf 'x\n' > "$repo/.gaia/scripts/not-a-consumer.sh"
+  git -C "$repo" add -A
+  printf '%s' "$repo"
+}
+
+# The tree-wide pathspec is the whole claim the comment above makes, and the
+# real tree cannot hold it: the directory-scoped form the widening replaced
+# returns the same paths today, so reverting it leaves every check here green.
+# A fixture carrying a consumer outside the guards' own directory is what makes
+# the reach the thing under test rather than a count both forms agree on.
+@test "the consumer derivation reaches a consumer outside the guards' own directory" {
+  local repo
+  repo="$(consumer_fixture_repo)"
+  run library_consumers "$repo"
+  [ "$status" -eq 0 ]
+  grep -qxF -- "$repo/.claude/hooks/probe-hook.sh" <<<"$output" || return 1
+  # Non-vacuity: the same call reaches the in-directory consumer, so an empty
+  # derivation cannot satisfy the assertion above. And it stops at a tracked
+  # file carrying no load line, so a derivation returning everything cannot
+  # satisfy it either.
+  grep -qxF -- "$repo/.gaia/scripts/lint-probe.sh" <<<"$output" || return 1
+  grep -qxF -- "$repo/.gaia/scripts/not-a-consumer.sh" <<<"$output" && return 1
+  true
 }
 
 participating_files() {
@@ -966,14 +1008,30 @@ production_guards() {
 }
 
 # A derivation that came back short would leave a check asserting over a subset
-# while its name still says every, so both consumer checks confirm the count
-# against the guards known to load the library before their per-file loop runs.
-# The floor is the count the tree carries, not a slack figure: a floor below it
-# is a check that greens while consumers fall out of the derivation silently.
+# while its name still says every, so every consumer check confirms the count
+# before its per-file loop runs.
+#
+# Equality against a second walk of the same tracked files, rather than a floor
+# written down here. A floor is exact only until the consumer set grows, after
+# which it goes slack and a derivation regressing back to it still passes; a
+# recount has no such moment, because no number survives between runs. The two
+# walks reach the tree by different routes, `git grep`'s pathspec against a
+# filter over `git ls-files`, so a derivation that narrows its own pathspec
+# disagrees with the tree rather than agreeing with a literal.
+#
+# The emptiness check is separate and is not redundant with the equality: two
+# walks that both come back empty agree, and a per-element claim over nothing
+# is true without covering anything.
 assert_consumer_count() {
-  local n
-  n="$(library_consumers | grep -c .)"
-  [ "$n" -ge 7 ] || { echo "library_consumers returned $n, fewer than the 7 tracked consumers" >&2; return 1; }
+  local derived recount
+  derived="$(library_consumers | grep -c . || true)"
+  recount="$(git -C "$REPO_ROOT" ls-files -z -- ':(exclude)*.bats' \
+    | xargs -0 grep -l -- '_gaia_guard_lib_dir/guard-awk-lib.sh' \
+    | grep -c . || true)"
+  [ "$derived" -gt 0 ] \
+    || { echo "library_consumers returned nothing" >&2; return 1; }
+  [ "$derived" -eq "$recount" ] \
+    || { echo "library_consumers returned $derived, the tree carries $recount" >&2; return 1; }
 }
 
 @test "every library consumer's shellcheck source= line carries the library's full repo-relative path" {
@@ -985,10 +1043,15 @@ assert_consumer_count() {
 }
 
 @test "every library consumer brackets its library load with set +e and set -e on one line" {
-  # README C1.1's frozen block, verbatim. The load is script-relative by
-  # design and does not itself carry the full path (which lives above it,
-  # on the shellcheck source= directive line), so this checks the bracket
-  # rather than a second copy of the path.
+  # The bracket verbatim, because it is frozen rather than merely
+  # conventional: `.gaia/scripts/lint-errexit-source-guard.sh`'s header owns
+  # the two accepted shapes and states why a file that arms errexit itself
+  # takes this flat one while a library takes the state-preserving form. A
+  # reworded load would still satisfy that guard and silently stop being the
+  # shape this suite reports on, so the literal is what holds it. The load is
+  # script-relative by design and does not itself carry the full path (which
+  # lives above it, on the shellcheck source= directive line), so this checks
+  # the bracket rather than a second copy of the path.
   local f load
   assert_consumer_count || return 1
   load='set +e; [ -f "$_gaia_guard_lib_dir/guard-awk-lib.sh" ] && . "$_gaia_guard_lib_dir/guard-awk-lib.sh" 2>/dev/null; set -e'

--- a/.gaia/scripts/tests/guard-awk-lib.bats
+++ b/.gaia/scripts/tests/guard-awk-lib.bats
@@ -1025,7 +1025,15 @@ production_guards() {
 assert_consumer_count() {
   local derived recount
   derived="$(library_consumers | grep -c . || true)"
-  recount="$(git -C "$REPO_ROOT" ls-files -z -- ':(exclude)*.bats' \
+  # Anchored to REPO_ROOT rather than to the ambient cwd. `git ls-files` prints
+  # paths relative to the repository it walks, and the grep consuming them
+  # resolves each one against wherever bats was started from, so a run from a
+  # subdirectory opens none of them. The worse case is the one that does not
+  # error: this repo keeps worktrees under .claude/worktrees/, and a run from a
+  # sibling checkout would grep that other tree and could agree with a
+  # derivation over this one. The `cd` is confined to the substitution's own
+  # subshell, so no cwd reaches the rest of the test.
+  recount="$(cd "$REPO_ROOT" && git ls-files -z -- ':(exclude)*.bats' \
     | xargs -0 grep -l -- '_gaia_guard_lib_dir/guard-awk-lib.sh' \
     | grep -c . || true)"
   [ "$derived" -gt 0 ] \


### PR DESCRIPTION
Drains three suggestion-grade findings on the `guard-awk-lib` surface, all filed off the clearing round of #1721.

Closes #1724
Closes #1725
Closes #1726

## What changed

**#1724, the consumer derivation's reach and its floor.** `library_consumers`' pathspec is tree-wide with the suite surface excluded, and the comment above it claims a consumer added anywhere is held by the three load-shape checks. Nothing red if that reach were taken away: the directory-scoped `'.gaia/scripts/*.sh'` form it replaced returns the same paths today, so reverting the widening left the suite at 78 ok / 0 not ok. The derivation is now parameterized on a repo root, the way `scan_fixture_repo` already parameterizes the discovery tests in the same suite, and a new fixture repo carrying a consumer under `.claude/hooks/` alongside one under `.gaia/scripts/` makes the reach the thing under test rather than a count both pathspec forms agree on. The test carries its own non-vacuity control on the model of `a refusal empties the surface a previous call left in the array`: it also asserts the in-directory consumer comes back and the tracked non-consumer does not, so neither an empty derivation nor an all-files one satisfies it.

`assert_consumer_count`'s hand-written `[ "$n" -ge 7 ]` floor gives way to an equality against a second walk of the same tracked files, reached by a different route (`git ls-files` plus a filter, against `git grep`'s pathspec). The floor was exact today and would have gone slack the moment an eighth consumer landed; a recount has no such moment because no number survives between runs. A separate emptiness check stands beside the equality, since two walks that both come back empty agree while covering nothing.

**#1725, the array-emptying promise.** It sat unindented between the `2` and `3` entries of `gaia_guard_scan_files`' exit-code list, so a reader working down the list took it as a note on status 2. It holds for 1, 2 and 3 alike. It now leads the list as a preamble and says so.

**#1726, the dangling `README C1.1` citation.** No tracked file carries that section; it named a plan README that is gone. The comment now points at `.gaia/scripts/lint-errexit-source-guard.sh`, whose header owns the two accepted bracket shapes and why a file that arms errexit itself takes the flat one, and states why the block is matched as a literal rather than leaving the reader an unresolvable id.

## Verification

- `.gaia/scripts/tests/guard-awk-lib.bats` under bash 5: 79 ok, 0 not ok (was 78; the new fixture test is the addition).
- Sibling consumer suites under bash 5: `lint-collapsed-signal-trap`, `lint-errexit-status-read`, `lint-grep-ere-escapes`, `lint-git-path-quoting`, `lint-stale-cardinals`, `lint-workflow-run-interpolation`, `lint-errexit-source-guard`, 435 tests, 0 failures.
- `bash .gaia/tests/shell-lint.sh`, clean. `bash .gaia/tests/whole-tree-invariants.sh`, exit 0.
- Quality Gate: skipped on a positive answer. The staged set is `.sh` and `.bats` only, so the gate's own check returns nothing.

### Both new guards proven red before being relied on

Per `.claude/rules/guards-must-fail.md`:

- Reverting `library_consumers`' pathspec to the directory-scoped form reds `not ok 59 the consumer derivation reaches a consumer outside the guards' own directory` and nothing else, which reproduces the finding's claim and shows the new test is what pins the reach.
- Excluding one consumer from the derivation reds the recount with `library_consumers returned 6, the tree carries 7`.
- Staging an eighth consumer and then shortening the derivation to 7 reds with `library_consumers returned 7, the tree carries 8`, which is exactly the regression the old `-ge 7` floor would have passed.

## CHANGELOG

No `## [Unreleased]` entry. `guard-awk-lib.sh` and `.gaia/scripts/tests/` are both release-excluded, no adopter clone runs any of this, and nothing here changes behavior: the library edit is a comment, and the suite edit strengthens a test. #1720, a much larger change on this same library, took the same decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Audit gate

Round 1 refused with one Important finding, and it was a real one this branch introduced. The recount half of `assert_consumer_count` took its file list from `git -C "$REPO_ROOT" ls-files`, which prints repository-relative paths, and handed it to a `grep` with no root of its own, so every path resolved against whatever directory bats was started from. A run from a subdirectory opened none of them and reported the derivation short against a bug that does not exist; the worse case is the one that does not error, since this repo keeps worktrees under `.claude/worktrees/` and a run from a sibling checkout would grep that tree and could satisfy the equality over a tree the suite is not testing. Pre-dispatch verification missed it because every local run was from the repo root, which is exactly where it is invisible. Fixed in `0efc9cd7` with a `cd` confined to the command substitution, the idiom `setup()` already uses, and re-verified green from `.gaia/scripts/` as well as from the root.

Round 2 cleared.

**Accepted residual, no change:** shellcheck SC2016 (info) on `consumer_fixture_repo`'s single-quoted load literal. The non-expansion is the whole point, since the fixture must write the byte sequence the guard later greps for, and the identical pre-existing literal in the bracket assertion carries no disable directive either, so adding one here would diverge from the file's own convention. `.gaia/tests/shell-lint.sh` holds `*.bats` at `severity=warning`, so the info never reaches the gate.
