### PR TITLE
debt(tests): pin the audit digest's recipe-version sentinel (#1727)

### DIFF
--- a/.gaia/tests/hooks/audit-digest-lib.bats
+++ b/.gaia/tests/hooks/audit-digest-lib.bats
@@ -78,6 +78,35 @@ mutate_commit() {
 }
 
 # ---------------------------------------------------------------------------
+# The recipe-version sentinel, pinned as a literal.
+#
+# Editing this string does not rotate a digest the way an ordinary machinery
+# edit does. It moves the whole audit key space at once: every clearance
+# marker, stamped trailer, and posted status already in the wild becomes
+# unfindable rather than stale, and there is no version field, no migration,
+# and no grace window that would let a reader tell the two apart. A typo, a
+# reflexive v1 -> v2 bump carried along by an unrelated edit, or a
+# search-and-replace that happens to catch the string would do that with the
+# whole suite still green, and the damage surfaces later as markers nobody
+# can find, with nothing pointing back at the edit.
+#
+# So the constant gets exactly one intentional edit path: change it and this
+# reds, saying what the change costs. The pin is at the hash-input site, not
+# anywhere in the file, because that is the occurrence that decides the key
+# space -- a lingering mention in this lib's own header comment must not keep
+# a moved sentinel looking pinned. The second assertion holds that site
+# singular, which is the "single derive point" this suite's header claims:
+# a copied digest computation would give the sentinel a second feed that the
+# first assertion alone would never have looked at.
+# ---------------------------------------------------------------------------
+
+@test "the recipe-version sentinel feeding the digest hash is gaia-audit-digest-v1" {
+  grep -qF -- "printf 'gaia-audit-digest-v1\0'" "$DIGEST_LIB" || return 1
+  sites="$(grep -cF -- "printf 'gaia-audit-digest-v1\0'" "$DIGEST_LIB")"
+  [ "$sites" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
 # audit_digests_all: one line per roster member, each a 64-hex digest.
 # ---------------------------------------------------------------------------
 

--- a/.gaia/tests/hooks/audit-digest-lib.bats
+++ b/.gaia/tests/hooks/audit-digest-lib.bats
@@ -96,13 +96,20 @@ mutate_commit() {
 # space -- a lingering mention in this lib's own header comment must not keep
 # a moved sentinel looking pinned. The second assertion holds that site
 # singular, which is the "single derive point" this suite's header claims:
-# a copied digest computation would give the sentinel a second feed that the
-# first assertion alone would never have looked at.
+# a digest computation copied within this lib would give the sentinel a
+# second feed that the first assertion alone would never have looked at.
+#
+# The singularity claim reaches this file and no further. A recipe copied
+# into a DIFFERENT file is outside both assertions, deliberately: what may
+# derive a digest is the ownership classifier's and the machinery matcher's
+# answer, and restating it here would be a second list nobody recounts.
+# `grep -oF | wc -l` rather than `grep -cF`, because -c counts matching
+# LINES: a duplicate appended to the existing line would read as one site.
 # ---------------------------------------------------------------------------
 
 @test "the recipe-version sentinel feeding the digest hash is gaia-audit-digest-v1" {
   grep -qF -- "printf 'gaia-audit-digest-v1\0'" "$DIGEST_LIB" || return 1
-  sites="$(grep -cF -- "printf 'gaia-audit-digest-v1\0'" "$DIGEST_LIB")"
+  sites="$(grep -oF -- "printf 'gaia-audit-digest-v1\0'" "$DIGEST_LIB" | wc -l | tr -d ' ')"
   [ "$sites" -eq 1 ]
 }
 


### PR DESCRIPTION
Closes #1727

## What

`gaia-audit-digest-v1` is the recipe-version sentinel, the first field fed into every Code Audit Team member's content digest. It is one of the few things that moves the whole audit **key space** rather than merely rotating a digest: change it and every clearance marker, stamped trailer, and posted audit status already in the wild becomes *unfindable* rather than stale. There is no version field, no migration path, and no grace window that lets a reader tell an orphaned marker from a missing one.

Nothing in the tree pinned the literal. Its only two occurrences were both inside `.claude/hooks/lib/audit-digest.sh` (a header gloss and the `printf` feeding the hash), so a typo, a reflexive `v1 -> v2` bump carried along by an unrelated edit, or a search-and-replace that happened to catch the string would have rotated the key space for the whole repository **with the entire suite still green**. The damage surfaces much later, as markers nobody can find and audit rounds that have to be redone, with nothing pointing back at the edit that caused it.

## The change

One test in `.gaia/tests/hooks/audit-digest-lib.bats`, giving the constant exactly one intentional edit path.

Two deliberate choices in how it pins:

- **At the hash-input site, not anywhere in the file.** The `printf` is the occurrence that decides the key space. Pinning the bare string would let a lingering mention in the lib's own header comment keep a *moved* sentinel looking pinned.
- **That site held singular.** This is the "single per-member content-digest derive point" the suite's own header already claims. A copied digest computation would give the sentinel a second feed that the first assertion alone would never have looked at.

## Proving it can fail

Per `.claude/rules/guards-must-fail.md`, both assertions were driven into their red state before being relied on:

| Adversarial fixture | Result |
| --- | --- |
| Bump the sentinel to `gaia-audit-digest-v2` at the hash-input site | `not ok 1` on the literal assertion |
| Add a second `printf 'gaia-audit-digest-v1\0'` site | `not ok 1` on the count assertion |

In **both** cases tests 2-19 stayed green. That is precisely the blind spot #1727 reports: the sentinel could move and no existing test noticed.

Restored and re-confirmed green: 19/19 under bash 5.

## Side effect worth noting

`wiki/decisions/Code Audit Team.md` offers this as the digest-surface bats census:

```
git grep -ln 'audit_member_digest\|audit_digests_all\|gaia-audit-digest-v1' -- '*.bats'
```

The third alternative matched nothing, so the census had been resting silently on the other two. It now matches this suite.

## Checks

- `.gaia/tests/hooks/audit-digest-lib.bats` — 19/19 under bash 5 (via `.gaia/scripts/bats5.sh`)
- `.gaia/tests/whole-tree-invariants.sh` — pass
- `.gaia/tests/shell-lint.sh` — pass (shellcheck over 233 scripts + 256 suites, and every deterministic lint clean)
- Quality Gate — skipped on a positive answer: no staged `.ts|tsx|js|jsx|mjs|cjs|css` and no gate-affecting config
- CHANGELOG — no entry owed. `.gaia/tests` is release-excluded and absent from `.gaia/manifest.json`, so nothing here reaches an adopter

## Batch note

This run was asked to batch #1727 with #1729 and #1730. Both were released at the fix-time staleness screen and are **not** part of this PR: each was filed off PR #1664's branch and its premise does not hold on `main`.

- **#1729** — sweep 9's header says "Three off-pattern writers" and on `main` the list beneath it names exactly three. The fourth (`audit/*.scope.json`) arrives with #1664. Draining it here would rewrite a correct sentence.
- **#1730** — cites `.gaia/scripts/check-scope-digest-adoption.sh`, which does not exist on `main` at all.

Both issues carry a comment recording why, keep their `in-progress` claim stripped, and re-offer on the next drain once #1664 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
