### PR TITLE
debt(tests): model the maintainer-only strip on the shipped parser (#1283)

### DIFF
--- a/.gaia/scripts/tests/verify-audit-roster.bats
+++ b/.gaia/scripts/tests/verify-audit-roster.bats
@@ -26,6 +26,8 @@ setup() {
   WRITER="$REPO_ROOT/.gaia/scripts/write-audit-remits.sh"
   REMIT_START='<!-- gaia:audit-remit:start -->'
   REMIT_END='<!-- gaia:audit-remit:end -->'
+  MAINTAINER_START='# gaia:maintainer-only:start'
+  MAINTAINER_END='# gaia:maintainer-only:end'
   # A hard failure, not a skip: a `skip` here would silently retire all 69+
   # tests in this suite to skipped-and-green if either committed script ever
   # went missing, which is the opposite of what a missing file should do.
@@ -41,6 +43,28 @@ setup() {
 
 assert_contains() {
   grep -qF -- "$1" <<<"$output"
+}
+
+# Strips maintainer-only blocks from the file named by $1, writing the result to
+# stdout. One copy, used by every lockstep test that needs a stripped script.
+#
+# This models `stripMarkerBlocks` in `.gaia/cli/src/release/marker-strip.ts`,
+# the parser the release scrub actually runs, and models it by substring
+# (`index`) because that is what the shipped parser does (`line.includes`).
+# Matching only at column 0 would be a narrower second implementation, free to
+# reject a block the release strips cleanly; the branches below cover the same
+# cases the shipped state machine does, including a start and end on one line
+# and an end with no open block (which the shipped parser keeps).
+strip_maintainer_only() {
+  awk -v s="$MAINTAINER_START" -v e="$MAINTAINER_END" '
+    {
+      has_s = index($0, s) > 0
+      has_e = index($0, e) > 0
+      if (!skip && has_s) { if (!has_e) skip = 1; next }
+      if (skip) { if (has_e) skip = 0; next }
+      print
+    }
+  ' "$1"
 }
 
 # Scaffolds a fixture root: the roster arrives on stdin, and the agent files and
@@ -1109,21 +1133,45 @@ YAML
   assert_contains "builtin-fallback-lockstep"
 }
 
+# The lockstep tests below strip with `strip_maintainer_only`, this suite's model
+# of the shipped scrub (`.gaia/cli/src/release/marker-strip.ts`). This one pins
+# the model to the shipped semantics rather than to a convenient subset of them:
+# the real parser recognizes a marker by substring, so it strips an indented
+# pair, and indented pairs are legitimate and already in the tree wherever a
+# block sits inside an `if` or an `else`. A model that only matched at column 0
+# would leave the maintainer-only text in the "stripped" copy, failing every
+# test below it on a file the release scrubs correctly.
+@test "lockstep: the marker model strips an indented pair, as the shipped stripper does" {
+  local f="$BATS_TEST_TMPDIR/indented-pair.sh"
+  # Built from the same constants the model matches on, so the fixture cannot
+  # drift into being a third spelling of the marker.
+  {
+    printf 'before=1\n'
+    printf '  %s\n' "$MAINTAINER_START"
+    printf '  maintainer_only=1\n'
+    printf '  %s\n' "$MAINTAINER_END"
+    printf 'after=1\n'
+  } > "$f"
+  run strip_maintainer_only "$f"
+  [ "$status" -eq 0 ]
+  assert_contains "before=1"
+  assert_contains "after=1"
+  grep -qF "maintainer_only=1" <<<"$output" && return 1
+  grep -qF "gaia:maintainer-only" <<<"$output" && return 1
+  true
+}
+
 @test "lockstep: the maintainer-only markers balance" {
   local starts ends
-  starts="$(grep -c '^# gaia:maintainer-only:start$' "$SCRIPT")"
-  ends="$(grep -c '^# gaia:maintainer-only:end$' "$SCRIPT")"
+  starts="$(grep -cF -- "$MAINTAINER_START" "$SCRIPT")"
+  ends="$(grep -cF -- "$MAINTAINER_END" "$SCRIPT")"
   [ "$starts" -ge 1 ]
   [ "$starts" -eq "$ends" ]
 }
 
 @test "lockstep: the script is valid bash with the maintainer-only block stripped" {
   local stripped="$BATS_TEST_TMPDIR/stripped.sh"
-  awk '
-    /^# gaia:maintainer-only:start$/ { skip = 1; next }
-    /^# gaia:maintainer-only:end$/ { skip = 0; next }
-    !skip
-  ' "$SCRIPT" > "$stripped"
+  strip_maintainer_only "$SCRIPT" > "$stripped"
   grep -qF "gaia:maintainer-only" "$stripped" && return 1
   bash -n "$stripped"
 }
@@ -1133,11 +1181,7 @@ YAML
   # the stripped copy's own script-relative library resolution is exercised too.
   local sb="$BATS_TEST_TMPDIR/stripped-sandbox"
   mkdir -p "$sb/.gaia/scripts" "$sb/.claude/hooks/lib"
-  awk '
-    /^# gaia:maintainer-only:start$/ { skip = 1; next }
-    /^# gaia:maintainer-only:end$/ { skip = 0; next }
-    !skip
-  ' "$SCRIPT" > "$sb/.gaia/scripts/verify-audit-roster.sh"
+  strip_maintainer_only "$SCRIPT" > "$sb/.gaia/scripts/verify-audit-roster.sh"
   cp "$REPO_ROOT/.claude/hooks/lib/audit-scope.sh" "$sb/.claude/hooks/lib/audit-scope.sh"
 
   local r="$BATS_TEST_TMPDIR/stripped-fixture"


### PR DESCRIPTION
Closes #1283

## The divergence

The lockstep tests guarding `.gaia/scripts/verify-audit-roster.sh` re-implemented the maintainer-only marker strip instead of modelling the shipped one, and the two disagreed:

- **Shipped** (`.gaia/cli/src/release/marker-strip.ts`): `line.includes(marker)`, so a marker is recognized anywhere on the line, indented included.
- **Tests**: `/^# gaia:maintainer-only:start$/` (awk, twice) and `grep -c '^# gaia:maintainer-only:start$'`, so a marker was recognized only at column 0.

An indented pair strips cleanly at release but survived the tests' narrower model, leaving maintainer-only text in the "stripped" copy and tripping the no-residue assertion. That is not hypothetical: it happened on #1282, where a pair indented because it sat inside an `else` passed the real scrub and the full distribution harness, and reddened this suite.

Indented pairs are legitimate and already in the tree (`.claude/hooks/lib/audit-scope.sh`, and several in `.gaia/audit-ci.yml`).

## The fix

One `strip_maintainer_only` helper replaces both open-coded awk strippers, modelling the shipped state machine by substring rather than by anchor, and covering the same cases it does (a start and end on one line, and an end with no open block, which the shipped parser keeps). `setup()` now defines `MAINTAINER_START` / `MAINTAINER_END` alongside the existing remit constants, and the balance count reads them too, so the suite carries one spelling of the marker where it carried three.

This follows the reasoning `scaffold_root`'s own docblock already states for the remit regions: a hand-rolled second implementation is free to drift from the one that ships.

## Verification

- The new lockstep test was written against the anchored model first and **failed** on it (`grep -qF "maintainer_only=1" ... failed`), then passed once the model became substring-based.
- Adversarially indented a real marker pair in `verify-audit-roster.sh` and re-ran the suite: green, where the anchored model would have failed the balance, `bash -n`, and stripped-run tests.
- Full suite green; `.gaia/tests/shell-lint.sh` and `.gaia/tests/whole-tree-invariants.sh` both pass.

## Not done, deliberately

The issue also floats relaxing the no-residue assertion so a comment that merely *spells* the marker does not trip it. No such comment exists in the script today, and narrowing that assertion weakens a check that is doing real work, so it is left alone.

## CHANGELOG

No `## [Unreleased]` entry: `.gaia/scripts/tests/` is release-excluded, so this reaches no adopter bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Audit gate

`code-audit-maintainer-shell` (the one member the oracle dispatched): **clean** — no Critical, no Important, one Suggestion. It independently confirmed the model is faithful, running a differential harness under `tsx` that imports the real `stripMarkerBlocks` and shells out to the exact awk program from this diff, over nine fixtures (plain pair, indented pair, start and end on one line, end without start, nested start, unterminated start, marker inside a quoted string, marker with trailing text, two blocks): all nine agree. It also reverted the model to the anchored form in a scratch copy and confirmed the new test goes red.

Its Suggestion, that nothing pins the awk model to the TypeScript parser, is **filed as #1742** rather than waived. It is latent at the fork point and names four sibling sites this PR never touches, so it outlives this branch and a PR-body waive would not survive the squash-merge. Its fix also has to first retire the design decision #1283 settled (the suite is deliberately standalone bash with no CLI dependency), which is not this PR's call to make.
