### PR TITLE
debt(comments): drop sweep 9's writer count and let its list count itself (#1729)

### DIFF
--- a/.claude/hooks/local-janitor.sh
+++ b/.claude/hooks/local-janitor.sh
@@ -221,9 +221,9 @@
 #      registry. The sweep never recurses below maxdepth-1 -- the three
 #      zones it walks never include telemetry/, red-ledger/, handoff/,
 #      plans/, specs/, debt/, forensics/, or harden/ -- and
-#      never follows a symlinked scope root from a linked worktree. Three
-#      off-pattern writers still get their own dedicated reap arms
-#      elsewhere, unrelated to this sweep's registry consultation:
+#      never follows a symlinked scope root from a linked worktree. The
+#      off-pattern writers named below still get their own dedicated reap
+#      arms elsewhere, unrelated to this sweep's registry consultation:
 #      audit/*.findings.json and audit/*.scope.json attached to sweep #2,
 #      sharing one knob because they share one lifetime, per round per member
 #      (GAIA_AUDIT_FINDINGS_RETENTION_HOURS, default 72, floor 24),


### PR DESCRIPTION
Sweep 9's header sentence in `.claude/hooks/local-janitor.sh` claimed three off-pattern writers over a list that names four. The scope-digest carry (`audit/*.scope.json`) joined the list when PR #1664 landed without the count moving, so a reader counting the names finds four against a stated three and cannot tell which half is wrong.

## What changed

The header no longer counts the set; it points at the list beneath it.

```
-#      never follows a symlinked scope root from a linked worktree. Three
-#      off-pattern writers still get their own dedicated reap arms
-#      elsewhere, unrelated to this sweep's registry consultation:
+#      never follows a symlinked scope root from a linked worktree. The
+#      off-pattern writers named below still get their own dedicated reap
+#      arms elsewhere, unrelated to this sweep's registry consultation:
```

## Why not just correct the number to four

The issue offered that as its first suggestion, and `.claude/rules/code-comments.md` (`## Counts`) rules it out where the enumeration is adjacent: "correcting a stale one without adding the recount restarts the same decay from a fresher number." The enumeration is directly beneath the sentence, and the arm grouping the number would carry (findings and scope sharing one knob because they share one lifetime) is already stated in that prose. So the number says nothing the list does not, and dropping it leaves nothing to go stale and nothing new owed a recount.

`lint-stale-cardinals.sh` never saw this instance and still will not: it fires only on a **definite** determiner, and the bare-subject spelling is on its documented fail-open list. Widening that narrowing is a deliberate design change to the gate, out of scope here.

## Verification

- `bash .gaia/tests/shell-lint.sh` - passed, `lint-stale-cardinals` clean
- `bash .gaia/tests/whole-tree-invariants.sh` - all invariants pass
- `bats5` over the four janitor suites (`local-janitor`, `local-janitor-outlier-sweep`, `local-janitor-wiki-doc`, `local-janitor-mutation-scratch-reap`) - 120/120 pass, including the wiki-doc suite's AC-4 agreement check over this sweep's scope and knobs
- Quality Gate: skipped, no staged file it can inspect (one `.sh` comment change)
- No CHANGELOG entry: comment-only, no behavior change, nothing an adopter acts on

## Accepted residuals (audit round 1, `code-audit-maintainer-shell`)

Verdict was clean: no Critical, no Important. Two Suggestions, both pre-existing and outside this PR's changed line ranges. Both accepted-and-noted rather than folded: the member's marker is already earned and nothing else rotates its digest, so a fold would buy a fresh audit round for content nothing is reviewing.

- `.claude/hooks/local-janitor.sh:280` - the source directive suppresses `SC1091` where shellcheck emits `SC1090`, so it covers nothing; nine sibling hooks use `source=/dev/null`. Filed as #1746.
- `.gaia/tests/hooks/local-janitor-wiki-doc.bats:121` - AC-4's knob floor asserts two where its own derivation returns three, so a silent collapse to two still passes the check that exists to catch one. Filed as #1747.

No cross-remit findings.

Closes #1729

🤖 Generated with [Claude Code](https://claude.com/claude-code)
