### PR TITLE
debt(ci): stop the node-dependent RED suites reporting a skip as a pass (#1748)

### DIFF
--- a/.gaia/tests/hooks/capture-red-observations.bats
+++ b/.gaia/tests/hooks/capture-red-observations.bats
@@ -26,10 +26,11 @@
 setup() {
   . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   REPO_ROOT=$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)
-  # The hook recomputes RED signals via the Node helper, which resolves
-  # `typescript` from node_modules; skip where deps aren't installed (e.g. the
-  # lean audit-ci-tests CI box) so this suite's shard stays green there.
-  [ -d "$REPO_ROOT/node_modules/typescript" ] || skip "typescript not installed (node-dependent RED suite)"
+  # The Node helpers this suite drives resolve `typescript` from node_modules.
+  # The gate fails rather than skips on a CI runner, where the dependency is a
+  # precondition the job installs; see the helper for why.
+  . "$BATS_TEST_DIRNAME/helpers/require-node-typescript.sh"
+  require_node_typescript "$REPO_ROOT"
   HOOK="$REPO_ROOT/.claude/hooks/capture-red-observations.sh"
   FIX_REL=".gaia/tests/hooks/fixtures/red-ledger"
   JSON_REL="$FIX_REL/json"

--- a/.gaia/tests/hooks/helpers/require-node-typescript.sh
+++ b/.gaia/tests/hooks/helpers/require-node-typescript.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Shared dependency gate for the node-dependent RED suites under
+# .gaia/tests/hooks: red-ledger-lib, capture-red-observations,
+# red-verify-commit-check, red-verify-e2e and worthiness-presence-check.
+#
+# All five drive .gaia/scripts/red-ledger/extract-test-signals.mjs and
+# .gaia/scripts/classifier/classify-determinism.mjs, each of which resolves
+# `typescript` through createRequire against the repo root's node_modules. With
+# that absent the suites cannot answer at all.
+#
+# Source it from `setup()`, never `setup_file()`, for the reason run-hook.sh
+# beside it gives: bats runs setup_file in a separate process, so a function
+# defined there is invisible to test bodies -- including the gate's own
+# self-test, which calls this function directly.
+#
+#   setup() {
+#     REPO_ROOT=$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)
+#     . "$BATS_TEST_DIRNAME/helpers/require-node-typescript.sh"
+#     require_node_typescript "$REPO_ROOT"
+#   }
+#
+# WHY THE CI BRANCH FAILS RATHER THAN SKIPPING, which is the whole point of
+# this file. These five suites previously spelled the gate inline as
+#
+#   [ -d "$ROOT/node_modules/typescript" ] || skip "typescript not installed ..."
+#
+# and bats reports a skip as `ok ... # skip`. The bats shards install no Node
+# dependencies, so all five reported green on every PR while asserting nothing,
+# and a stale cardinal inside one of them survived every run of the check that
+# exists to catch it -- found only by a human running the suite locally. That
+# is gaia-react/gaia#1748.
+#
+# So the CI branch returns non-zero, matching `require_yaml_parser` in
+# .gaia/scripts/tests/retrigger-reachability.bats, whose comment states the
+# same argument for the same reason: on CI the dependency is a precondition
+# rather than a maybe, because the job that runs the suite installs it. Off CI
+# the skip stands -- a checkout that has not run `pnpm install` is not the
+# environment this gate is making a claim about.
+#
+# The complement is .github/workflows/audit-ci-tests.yml's
+# "Setup Node for the node-dependent RED suites" step, gated to the exchange
+# group holding these five. Dropping either half without the other reds those
+# legs, which is the intended direction: the failure this file exists to
+# prevent is a green one.
+#
+# `skip` and the bats-provided environment are resolved at runtime by the suite
+# sourcing this, not by this file; it is a `.sh` held to the strictest
+# shell-lint severity floor (see .gaia/tests/shell-lint.sh) rather than a
+# `.bats`, so the linter cannot see them.
+
+# require_node_typescript <repo-root>
+#
+# Returns 0 when the dependency is present. On a CI runner without it, returns
+# non-zero after naming the install step, which fails the calling setup() and
+# reds the leg. Anywhere else, skips.
+require_node_typescript() {
+  local root="$1"
+
+  if [ -d "$root/node_modules/typescript" ]; then
+    return 0
+  fi
+
+  if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    # No `::error::` prefix: bats prints a test's stderr prefixed with `# `,
+    # and Actions parses a workflow command only at column 0, so the
+    # annotation that spelling promises would never render. The `return 1` is
+    # what gates.
+    echo "typescript is not installed under $root on a CI runner; this node-dependent RED suite would skip to green. Check the 'Setup Node for the node-dependent RED suites' step in .github/workflows/audit-ci-tests.yml." >&2
+    return 1
+  fi
+
+  skip "typescript not installed (node-dependent RED suite)"
+}

--- a/.gaia/tests/hooks/helpers/require-node-typescript.sh
+++ b/.gaia/tests/hooks/helpers/require-node-typescript.sh
@@ -20,26 +20,34 @@
 #   }
 #
 # WHY THE CI BRANCH FAILS RATHER THAN SKIPPING, which is the whole point of
-# this file. These five suites previously spelled the gate inline as
+# this file. Each of the suites above previously spelled the gate inline as
 #
 #   [ -d "$ROOT/node_modules/typescript" ] || skip "typescript not installed ..."
 #
 # and bats reports a skip as `ok ... # skip`. The bats shards install no Node
-# dependencies, so all five reported green on every PR while asserting nothing,
-# and a stale cardinal inside one of them survived every run of the check that
-# exists to catch it -- found only by a human running the suite locally. That
-# is gaia-react/gaia#1748.
+# dependencies, so every one of them reported green on every PR while
+# asserting nothing, and a stale cardinal inside one of them survived every
+# run of the check that exists to catch it -- found only by a human running
+# the suite locally. That is gaia-react/gaia#1748.
 #
-# So the CI branch returns non-zero, matching `require_yaml_parser` in
+# So the CI branch returns non-zero, matching the YAML-parser gate in
 # .gaia/scripts/tests/retrigger-reachability.bats, whose comment states the
 # same argument for the same reason: on CI the dependency is a precondition
 # rather than a maybe, because the job that runs the suite installs it. Off CI
 # the skip stands -- a checkout that has not run `pnpm install` is not the
 # environment this gate is making a claim about.
 #
+# That gate's name is deliberately not spelled out above. W10 in
+# .gaia/tests/lib/audit-ci-shards.bats derives the apt step's leg list by
+# grepping each shard's suites AND their helper directories for the literal
+# names of the zsh/YAML gates, over-inclusively and on purpose. This file sits
+# in the helper directory every hooks suite shares, so spelling that name here
+# puts an apt install on hooks-1 -- a leg drawing neither package -- to satisfy
+# a comment. The pointer above says which gate without tripping the scan.
+#
 # The complement is .github/workflows/audit-ci-tests.yml's
 # "Setup Node for the node-dependent RED suites" step, gated to the exchange
-# group holding these five. Dropping either half without the other reds those
+# group holding them. Dropping either half without the other reds those
 # legs, which is the intended direction: the failure this file exists to
 # prevent is a green one.
 #

--- a/.gaia/tests/hooks/provision-worktree.bats
+++ b/.gaia/tests/hooks/provision-worktree.bats
@@ -686,20 +686,34 @@ SH
   stub_typegen
   WT="$(add_worktree feat-nopnpm)"
 
-  # Strip only the directory the resolved `pnpm` binary lives in, leaving
-  # every other tool the hook needs (bash, git, jq, coreutils) resolvable --
-  # a curated allowlist would have to name every tool the hook and its
-  # libraries call and rot the moment one more is added. When pnpm is already
-  # absent (as it is at this point in CI, before the dependency-install
-  # steps later in the job), stripping is a no-op and the case is already
-  # naturally in effect.
-  pnpm_path="$(command -v pnpm 2>/dev/null)" || pnpm_path=""
-  filtered_path="$PATH"
-  if [ -n "$pnpm_path" ]; then
-    pnpm_dir="$(dirname "$pnpm_path")"
-    filtered_path="${filtered_path//"$pnpm_dir":/}"
-    filtered_path="${filtered_path%:"$pnpm_dir"}"
-  fi
+  # Strip EVERY directory providing a `pnpm`, leaving every other tool the
+  # hook needs (bash, git, jq, coreutils) resolvable -- a curated allowlist
+  # would have to name every tool the hook and its libraries call and rot the
+  # moment one more is added.
+  #
+  # Every such directory, not just the one `command -v` resolves first: a leg
+  # that has run pnpm/action-setup can carry pnpm in more than one directory,
+  # and removing only the first leaves the hook able to find it, so the case
+  # this test is named for never arises and the assertion below fails on a
+  # green hook. Rebuilding the list is also what makes the single-entry and
+  # first-entry positions fall out for free, where a substitution has to spell
+  # each position separately.
+  #
+  # This used to strip one directory and read the residue as safe, on the
+  # stated ground that CI reaches here with no pnpm at all. That ground is
+  # gone: the Node install for the node-dependent RED suites runs on this leg,
+  # ahead of the bats step. A test must not depend on a tool being absent from
+  # the environment by accident.
+  filtered_path=""
+  path_dirs=()
+  while IFS= read -r path_dir; do
+    path_dirs+=("$path_dir")
+  done <<<"${PATH//:/$'\n'}"
+  for path_dir in ${path_dirs[@]+"${path_dirs[@]}"}; do
+    [ -n "$path_dir" ] || continue
+    [ -x "$path_dir/pnpm" ] && continue
+    filtered_path="${filtered_path:+$filtered_path:}$path_dir"
+  done
 
   PATH="$filtered_path" run bash "$HOOK_ABS" "$WT"
   [ "$status" -eq 0 ]

--- a/.gaia/tests/hooks/red-ledger-lib.bats
+++ b/.gaia/tests/hooks/red-ledger-lib.bats
@@ -12,10 +12,11 @@
 
 setup() {
   REPO_ROOT=$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)
-  # This suite runs the Node signal helper, which resolves `typescript` from
-  # node_modules; skip where deps aren't installed (e.g. the lean
-  # audit-ci-tests CI box) so this suite's shard stays green there.
-  [ -d "$REPO_ROOT/node_modules/typescript" ] || skip "typescript not installed (node-dependent RED suite)"
+  # The Node helpers this suite drives resolve `typescript` from node_modules.
+  # The gate fails rather than skips on a CI runner, where the dependency is a
+  # precondition the job installs; see the helper for why.
+  . "$BATS_TEST_DIRNAME/helpers/require-node-typescript.sh"
+  require_node_typescript "$REPO_ROOT"
   HELPER="$REPO_ROOT/.gaia/scripts/red-ledger/extract-test-signals.mjs"
   LIB="$REPO_ROOT/.claude/hooks/lib/red-ledger.sh"
 
@@ -427,6 +428,51 @@ run_lib() {
   true
 }
 
+# --- the dependency gate itself ---
+
+# The one test in this file that asserts about the gate rather than through it.
+# Every other test here is gated by setup(), so weakening
+# require_node_typescript back to a bare `skip` would retire all of them in
+# silence -- `ok ... # skip` greens a leg having asserted nothing, which is the
+# defect (gaia-react/gaia#1748) this gate was written to end. This test is what
+# makes that weakening red.
+#
+# It cannot escape its own setup(), which calls the gate before any test body
+# runs. That is the same shape `require_repo_path` takes in
+# .gaia/scripts/tests/retrigger-reachability.bats, and its comment states the
+# reading this inherits: "what the test catches is the weakening, not the
+# condition." The condition is covered by the other half of the fix instead --
+# the workflow now installs the dependency on this suite's leg, so on CI
+# setup() passes and this test runs.
+@test "the typescript gate fails on a CI runner and still skips off CI" {
+  # A directory that provably lacks the dependency, rather than one that
+  # happens to: pointing the gate at a real root would make this test's result
+  # depend on whether the machine running it had installed deps.
+  local bare="$BATS_TEST_TMPDIR/no-typescript"
+  mkdir -p "$bare/node_modules"
+  local rc
+
+  # Calling the gate in a subshell is what keeps its `skip` arm from marking
+  # THIS test skipped: bats' `skip` exits 0, so the subshell's status is
+  # exactly the discriminator wanted here -- non-zero is the CI failure arm, 0
+  # is the off-CI skip arm.
+  # `export` rather than a bare assignment: the gate reads GITHUB_ACTIONS out
+  # of the environment, which is the "used externally" case SC2034 asks for.
+  rc=0
+  ( export GITHUB_ACTIONS=true; require_node_typescript "$bare" ) >/dev/null 2>&1 || rc=$?
+  [ "$rc" -ne 0 ] || {
+    echo "the gate skipped on a CI runner with no typescript; five suites would report green" >&2
+    return 1
+  }
+
+  rc=0
+  ( unset GITHUB_ACTIONS; require_node_typescript "$bare" ) >/dev/null 2>&1 || rc=$?
+  [ "$rc" -eq 0 ] || {
+    echo "the gate failed off CI, where a missing dependency must still skip" >&2
+    return 1
+  }
+}
+
 # --- signal helper: corpus standing check over the union glob set ---
 
 @test "the helper over the whole union glob set has no duplicate signal per file, and pins its file/record counts" {
@@ -456,9 +502,12 @@ run_lib() {
     '.playwright/**/*.test.ts' '.playwright/**/*.test.tsx')
 
   # Refresh both by re-running the git ls-files command above and summing the
-  # helper's output line count across the result.
+  # helper's output line count across the result. Re-derive rather than
+  # adjusting the old number by the diff's test count: the two cardinals move
+  # independently, and #1748 was a `record_count` that drifted while
+  # `file_count` stayed put.
   [ "$file_count" -eq 32 ]
-  [ "$record_count" -eq 134 ]
+  [ "$record_count" -eq 135 ]
 
   local bad_signal
   bad_signal=$(jq -r '.signal' "$corpus" | grep -vE '^sha256:[0-9a-f]{64}$' || true)

--- a/.gaia/tests/hooks/red-ledger-lib.bats
+++ b/.gaia/tests/hooks/red-ledger-lib.bats
@@ -461,7 +461,7 @@ run_lib() {
   rc=0
   ( export GITHUB_ACTIONS=true; require_node_typescript "$bare" ) >/dev/null 2>&1 || rc=$?
   [ "$rc" -ne 0 ] || {
-    echo "the gate skipped on a CI runner with no typescript; five suites would report green" >&2
+    echo "the gate skipped on a CI runner with no typescript; every suite behind it would report green" >&2
     return 1
   }
 

--- a/.gaia/tests/hooks/red-verify-commit-check.bats
+++ b/.gaia/tests/hooks/red-verify-commit-check.bats
@@ -28,10 +28,11 @@
 setup() {
   . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HOME_ROOT=$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)
-  # The hook recomputes RED signals via the Node helper, which resolves
-  # `typescript` from node_modules; skip where deps aren't installed (e.g. the
-  # lean audit-ci-tests CI box) so this suite's shard stays green there.
-  [ -d "$HOME_ROOT/node_modules/typescript" ] || skip "typescript not installed (node-dependent RED suite)"
+  # The Node helpers this suite drives resolve `typescript` from node_modules.
+  # The gate fails rather than skips on a CI runner, where the dependency is a
+  # precondition the job installs; see the helper for why.
+  . "$BATS_TEST_DIRNAME/helpers/require-node-typescript.sh"
+  require_node_typescript "$HOME_ROOT"
   HOOK_ABS="$HOME_ROOT/.claude/hooks/red-verify-commit-check.sh"
   HELPER="$HOME_ROOT/.gaia/scripts/red-ledger/extract-test-signals.mjs"
 

--- a/.gaia/tests/hooks/red-verify-e2e.bats
+++ b/.gaia/tests/hooks/red-verify-e2e.bats
@@ -29,10 +29,11 @@
 setup() {
   . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HOME_ROOT=$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)
-  # Both hooks recompute RED signals via the Node helper, which resolves
-  # `typescript` from node_modules; skip where deps aren't installed (e.g. the
-  # lean audit-ci-tests CI box) so this suite's shard stays green there.
-  [ -d "$HOME_ROOT/node_modules/typescript" ] || skip "typescript not installed (node-dependent RED suite)"
+  # The Node helpers this suite drives resolve `typescript` from node_modules.
+  # The gate fails rather than skips on a CI runner, where the dependency is a
+  # precondition the job installs; see the helper for why.
+  . "$BATS_TEST_DIRNAME/helpers/require-node-typescript.sh"
+  require_node_typescript "$HOME_ROOT"
   CAPTURE_HOOK="$HOME_ROOT/.claude/hooks/capture-red-observations.sh"
   CHECK_HOOK="$HOME_ROOT/.claude/hooks/red-verify-commit-check.sh"
   BARE_TEST_HOOK="$HOME_ROOT/.claude/hooks/block-bare-test.sh"

--- a/.gaia/tests/hooks/worthiness-presence-check.bats
+++ b/.gaia/tests/hooks/worthiness-presence-check.bats
@@ -30,11 +30,11 @@
 setup() {
   . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HOME_ROOT=$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)
-  # The hook (and this suite's seed helpers) recompute signals via the Node
-  # helper, which resolves `typescript` from node_modules; skip where deps
-  # aren't installed (e.g. the lean audit-ci-tests CI box) so this suite's
-  # shard stays green there.
-  [ -d "$HOME_ROOT/node_modules/typescript" ] || skip "typescript not installed (node-dependent RED suite)"
+  # The Node helpers this suite drives resolve `typescript` from node_modules.
+  # The gate fails rather than skips on a CI runner, where the dependency is a
+  # precondition the job installs; see the helper for why.
+  . "$BATS_TEST_DIRNAME/helpers/require-node-typescript.sh"
+  require_node_typescript "$HOME_ROOT"
   HOOK_ABS="$HOME_ROOT/.claude/hooks/worthiness-presence-check.sh"
   HELPER="$HOME_ROOT/.gaia/scripts/red-ledger/extract-test-signals.mjs"
 

--- a/.gaia/tests/lib/audit-ci-shards.bats
+++ b/.gaia/tests/lib/audit-ci-shards.bats
@@ -86,12 +86,17 @@ setup() {
   # The reasoning behind the four, and behind excluding bare `python3`, is in
   # the W10 header below.
   PKG_PATTERN='command -v zsh|zsh -c|require_yaml_parser|import yaml'
-  # The two workflow lines the adversarial cases doctor, addressed by shape
-  # rather than by text so a repack that rewrites either list stays a one-site
-  # edit in the workflow. Each matches exactly one line today, which
-  # sole_line_matching re-checks on every use; the reasoning for deriving them
-  # is above that helper.
-  APT_GATE_PATTERN='^ *- if: contains\(fromJSON\('
+  # The matrix line the adversarial cases doctor, addressed by shape rather
+  # than by text so a repack that rewrites the list stays a one-site edit in
+  # the workflow. It matches exactly one line today, which sole_line_matching
+  # re-checks on every use; the reasoning for deriving it is above that helper.
+  #
+  # The apt gate has no pattern here and is reached through gate_line_for_step
+  # instead. A shape pattern for it addressed the step as "the only `if:`
+  # carrying a contains(fromJSON(...)) gate", which is a property of how many
+  # such steps the workflow happens to have rather than of the apt step, and a
+  # second one made it ambiguous. Naming the step stays true as steps are
+  # added.
   MATRIX_SHARD_PATTERN='^ *shard: \['
 
   require_repo_path -f "$WORKFLOW" "audit-ci-tests.yml" || return 1
@@ -483,6 +488,46 @@ sole_line_matching() {
     return 1
   }
   printf '%s' "${hits#*:}"
+}
+
+# Prints the `- if:` line that opens the step named $2 in $1, so a case can
+# doctor that step's gate. Locates the step by name, then takes the last YAML
+# list-item line at or above it, and refuses when that opening line is not an
+# `if:` -- a step whose gate this returns must actually have one, and a step
+# that opens some other way would otherwise hand back the PREVIOUS step's gate
+# and doctor the wrong one.
+#
+# Fails on zero or several matches for the name, for the same reason
+# sole_line_matching does: either means the workflow changed shape, which this
+# suite has to see rather than doctor a line it did not mean to.
+gate_line_for_step() {
+  local src="$1" step="$2" hits count name_no open_no open_line
+  hits="$(grep -nF -- "name: $step" "$src")" || {
+    echo "gate_line_for_step: no step named '$step' in $src" >&2
+    return 1
+  }
+  count="$(printf '%s\n' "$hits" | grep -c '')"
+  [ "$count" -eq 1 ] || {
+    echo "gate_line_for_step: 'name: $step' matches $count lines in $src, expected exactly 1" >&2
+    printf '%s\n' "$hits" >&2
+    return 1
+  }
+  name_no="${hits%%:*}"
+  # Numbered against the head, whose line numbers are the file's own.
+  open_no="$(head -n "$name_no" "$src" | grep -nE '^ *- ' | tail -1 | cut -d: -f1)"
+  [ -n "$open_no" ] || {
+    echo "gate_line_for_step: the step named '$step' opens no list item in $src" >&2
+    return 1
+  }
+  open_line="$(sed -n "${open_no}p" "$src")"
+  case "$open_line" in
+    *"- if: "*) printf '%s' "$open_line" ;;
+    *)
+      echo "gate_line_for_step: the step named '$step' does not open with an if: gate" >&2
+      printf '%s\n' "$open_line" >&2
+      return 1
+      ;;
+  esac
 }
 
 # Fails when the transform in $2 left $1 unchanged, naming it as $3. replace_line
@@ -1249,7 +1294,7 @@ EOF
   local doctored="$BATS_TEST_TMPDIR/dropped.yml" declared needed line mutated
   require_yaml_parser
 
-  line="$(sole_line_matching "$WORKFLOW" "$APT_GATE_PATTERN")" || return 1
+  line="$(gate_line_for_step "$WORKFLOW" 'Install the YAML parser and zsh')" || return 1
   # Only the final id is followed by the closing bracket, so this drops one
   # leg rather than the tail of the list.
   mutated="$(printf '%s' "$line" | sed 's/, "[^"]*"\]/]/')"
@@ -1593,7 +1638,7 @@ copy_sharder_without_group() {
   # the file would not parse at all, which is a different failure from the one
   # under test. normalize() strips the wrapper, so the gate reaches the reader
   # exactly as GitHub would evaluate it.
-  line="$(sole_line_matching "$WORKFLOW" "$APT_GATE_PATTERN")" || return 1
+  line="$(gate_line_for_step "$WORKFLOW" 'Install the YAML parser and zsh')" || return 1
   mutated="$(printf '%s' "$line" | sed 's/- if: \(.*\)$/- if: ${{ !\1 }}/')"
   assert_doctored "$line" "$mutated" "negating the gate" || return 1
   replace_line "$WORKFLOW" "$line" "$mutated" "$doctored"

--- a/.github/workflows/audit-ci-tests.yml
+++ b/.github/workflows/audit-ci-tests.yml
@@ -825,7 +825,7 @@ jobs:
       - if: matrix.shard == 'sandbox' && (steps.filter.outputs.sandbox == 'true' || github.event_name == 'workflow_dispatch')
         name: Install bats
         run: bash .gaia/tests/install-bats.sh
-      # TWO installs across this job, not one, and the reason is structural:
+      # TWO installs on THIS leg, not one, and the reason is structural:
       # .gaia/cli is deliberately its own isolated pnpm workspace
       # (.gaia/cli/pnpm-workspace.yaml), so a repo-root install does not reach
       # it. The root install is what C4-04 and C4-07 need (their node helpers
@@ -834,11 +834,21 @@ jobs:
       # .gaia/cli/node_modules, which is gitignored and so absent on a fresh
       # checkout). Skipping either flips a landed, green scenario red for want
       # of an npm install, which would read as a regression in the number this
-      # program is judged by rather than as the environment gap it is. Scoped
-      # to the `concurrency` leg alone: no bats suite in any other shard
-      # depends on a Node runtime or an installed workspace dependency, which
-      # is what makes it safe for those legs to run on a box that never sets
-      # Node up at all.
+      # program is judged by rather than as the environment gap it is.
+      #
+      # This step is scoped to the `concurrency` leg, but Node itself is NOT
+      # this leg's alone. It used to say so -- "no bats suite in any other
+      # shard depends on a Node runtime or an installed workspace dependency,
+      # which is what makes it safe for those legs to run on a box that never
+      # sets Node up at all" -- and that was false the whole time: a group of
+      # suites under .gaia/tests/hooks drives the RED signal helper and the
+      # determinism classifier, both of which resolve `typescript` from the
+      # repo root.
+      # They did not red those legs, they SKIPPED, and a skip reports `ok`, so
+      # the belief and the evidence for it were the same silence.
+      # gaia-react/gaia#1748. The step below this one is what they need; keep
+      # the two separate rather than widening this one's `if:`, because they
+      # install different things for different reasons.
       - if: matrix.shard == 'concurrency' && (steps.filter.outputs.code == 'true' || github.event_name == 'workflow_dispatch')
         name: Setup Node and install both workspaces
         uses: ./.github/actions/gaia-setup-node
@@ -849,6 +859,51 @@ jobs:
           cache-dependency-path: |
             pnpm-lock.yaml
             .gaia/cli/pnpm-lock.yaml
+      # The root workspace for the node-dependent RED suites: red-ledger-lib,
+      # capture-red-observations, red-verify-commit-check, red-verify-e2e and
+      # worthiness-presence-check. Each drives
+      # .gaia/scripts/red-ledger/extract-test-signals.mjs and/or
+      # .gaia/scripts/classifier/classify-determinism.mjs, and both resolve
+      # `typescript` through createRequire against the repo root. Root only:
+      # none of them reaches into .gaia/cli. The list is spelled out rather
+      # than counted; the suites are the authority on how many there are.
+      #
+      # THE LEG LIST IS A WHOLE EXCHANGE GROUP, which is what makes it safe to
+      # write here. Every one of them lives in HOOKS_DIR and none is pinned, so
+      # bats-shards.sh assigns them across HOOKS_GREEDY_IDS -- hooks-2, hooks-3
+      # and hooks-4 -- and a reshuffle moves a file BETWEEN those three and
+      # never out of them. The apt step above rounds its list up to whole
+      # groups for exactly this reason and needs W10 to recompute it; this one
+      # is already at that closure, so it cannot drift under a reshuffle.
+      #
+      # AND IT HAS NO W-CHECK OF ITS OWN, DELIBERATELY. W10's header states the
+      # criterion: it exists because zsh-gated tests skip silently, while "the
+      # parser-gated suites fail loudly under GITHUB_ACTIONS, so a leg that
+      # lost python3-yaml reds. Only the first is invisible." The suites named
+      # above now fail loudly too --
+      # .gaia/tests/hooks/helpers/require-node-typescript.sh returns non-zero
+      # rather than skipping when GITHUB_ACTIONS is set -- so a leg that needs
+      # this step and does not get it reds on its own, and a derived list would
+      # be checking something already self-announcing. Dropping this step reds
+      # the legs named above; that is the intended direction.
+      #
+      # The cost is bounded by something already on this job rather than by an
+      # estimate: it is the same composite action the `concurrency` leg runs,
+      # asked for LESS work (one workspace, not both), with the pnpm store
+      # cached the same way. Those legs' own runtimes sit far enough under this
+      # job's `timeout-minutes` that adding one install plus the suites it
+      # unblocks does not approach it. The leg that is genuinely close to the
+      # cap is scripts-1, and it draws neither this step nor any of these
+      # suites.
+      - if: contains(fromJSON('["hooks-2", "hooks-3", "hooks-4"]'), matrix.shard) && (steps.filter.outputs.code == 'true' || github.event_name == 'workflow_dispatch')
+        name: Setup Node for the node-dependent RED suites
+        uses: ./.github/actions/gaia-setup-node
+        with:
+          install: root
+          # Root lockfile only: this step runs no .gaia/cli install, so keying
+          # the store cache on that workspace's lockfile too would rebuild the
+          # cache on bumps this leg does not consume.
+          cache-dependency-path: pnpm-lock.yaml
       # `${{ matrix.shard }}` reaches the script only through `env:`, never
       # interpolated into the run: body text itself -- the shape this repo's
       # workflows auditor checks, and what keeps it true when a future edit


### PR DESCRIPTION
Closes #1748

Five bats suites under `.gaia/tests/hooks/` drive the RED signal helper and the determinism classifier, both of which resolve `typescript` from the repo root. Each gated itself on that dependency and `skip`ped when it was absent. The bats shards install no Node dependencies, so every one of them reported `ok ... # skip` on every pull request while asserting nothing, and a stale cardinal inside one of them survived every run of the check that exists to catch it. It was found by a human running the suite locally.

## What changed

**The pin.** `record_count` in `red-ledger-lib.bats` was `134` against a helper emitting `135`; `file_count` was correct at `32`. Re-derived with the test's own `git ls-files` recipe rather than incremented, since the two cardinals move independently and that independence is what produced the drift.

**The gate.** The inline `|| skip` in all five suites becomes a shared `require_node_typescript` helper: dependency present, run; absent under `GITHUB_ACTIONS`, return non-zero naming the install step; absent off CI, skip. That is the shape the YAML-parser gate in `retrigger-reachability.bats` already uses, for the reason its own comment gives, and it comes with a both-arms self-test.

**The install.** One `gaia-setup-node` step with `install: root`, scoped to `hooks-2`/`hooks-3`/`hooks-4`. That set is a whole `bats-shards.sh` exchange group, so a weighted reshuffle moves files between those legs and never out of them, and the list cannot drift the way the apt step's can.

The comment beside the `concurrency` leg's Node install claimed no shard outside it depends on a Node runtime. That was false for as long as these suites have skipped, and it is corrected here.

## Two things found while making the change

**W10's locator.** Its adversarial cases addressed the apt step as the workflow's only `- if: contains(fromJSON(...))` line. That was a property of how many such steps the file happened to have rather than of the apt step, and a second one made it ambiguous. It failed closed and said so. Replaced with `gate_line_for_step`, which locates a step by name and refuses when the step does not open with an `if:`, so it can never hand back a neighbour's gate.

**An over-match from a comment.** `shard_package_needs` greps each shard's suites *and their helper directories* for the literal gate identifiers, deliberately over-inclusively. Naming the sibling gate in the new helper's docblock therefore pulled `hooks-1` into the derived apt leg set, for a comment. The pointer now names the gate's file instead, with a note saying why.

## Verification

Every bats root `audit-ci-tests.yml` runs, plus `shell-lint.sh`, `whole-tree-invariants.sh` and the `cli-tests.yml` distribution harness: all exit 0, zero failures, run under bash 5. `bats .gaia/tests/hooks/` passing is this change's own evidence, since that root was the red one.

Five mutants confirm the new guards can fail: the gate's CI arm made unreachable, its off-CI arm hard-failing, the pin restored to `134`, and the apt step renamed all red with the intended diagnostic. Deleting the install step is caught by no bats guard, by design; it reds those three legs at run time instead, which the workflow comment states.

## No CHANGELOG entry

None of the four changed files is in `.gaia/manifest.json`. All are release-excluded maintainer-only test and CI infrastructure, so there is nothing here an adopter would read.

## Audit gate: two rounds, four Suggestions, all filed

Round 1 dispatched `code-audit-github-workflows` and `code-audit-maintainer-shell`; both cleared with
no Critical and no Important. Its two Suggestions were filed rather than fixed (#1761, #1762): the
round was already clean, so repairing them would have *bought* a fresh round rather than ridden one
already being paid.

Round 1 also surfaced a CI red neither member could see, because it is a runtime interaction rather
than a reviewable defect: `shard hooks-4` failed on `provision-worktree.bats`'s "pnpm absent from
PATH" test. That test stripped only the directory `command -v pnpm` resolved first, on the stated
ground that CI reaches it with no pnpm at all. The Node install this pull request adds to those legs
falsifies exactly that ground. Reproduced in both directions on bash 3.2 and bash 5 before the fix,
which rebuilds `PATH` from the directories providing no `pnpm` instead of substituting one out.
Waiting for those shards before merging is what caught it.

Round 2 re-dispatched `code-audit-maintainer-shell` alone, since only its digest rotated. Clean: no
Critical, no Important, two Suggestions, both on the round-1 repair and both filed.

| Finding | Disposition |
|---|---|
| `provision-worktree.bats:714` the `-x` test also matches a *directory* named `pnpm`, over-stripping a PATH entry | Filed **#1763** |
| `provision-worktree.bats:708` the `path_dirs` array is an unnecessary intermediate | Filed **#1764** |

Neither has a live failure mode. The over-strip's direction is safe and its consequence is loud (the
next assertion reds), and the array finding is structure only. Both were filed rather than fixed
under this branch's pre-committed stopping rule: the pull request was already clean and already
marked, so a logic edit to that file rotates the member's digest and buys a further full round for a
change nothing can observe. Neither is waive-eligible, since both sit inside this change's own diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
