### PR TITLE
debt(tests): tighten the provision-worktree PATH rebuild predicate and drop its intermediate array

### DIFF
--- a/.gaia/tests/hooks/provision-worktree.bats
+++ b/.gaia/tests/hooks/provision-worktree.bats
@@ -704,16 +704,17 @@ SH
   # gone: the Node install for the node-dependent RED suites runs on this leg,
   # ahead of the bats step. A test must not depend on a tool being absent from
   # the environment by accident.
+  # `-x` alone is true for a searchable *directory* named `pnpm`, which would
+  # drop that PATH entry and every real tool it provides; `-f` first restricts
+  # the test to what `command -v` will accept as a command. The here-string
+  # feeds this loop in the current shell, not a subshell, so `filtered_path`
+  # is appended to directly and no intermediate array is needed.
   filtered_path=""
-  path_dirs=()
   while IFS= read -r path_dir; do
-    path_dirs+=("$path_dir")
-  done <<<"${PATH//:/$'\n'}"
-  for path_dir in ${path_dirs[@]+"${path_dirs[@]}"}; do
     [ -n "$path_dir" ] || continue
-    [ -x "$path_dir/pnpm" ] && continue
+    [ -f "$path_dir/pnpm" ] && [ -x "$path_dir/pnpm" ] && continue
     filtered_path="${filtered_path:+$filtered_path:}$path_dir"
-  done
+  done <<<"${PATH//:/$'\n'}"
 
   PATH="$filtered_path" run bash "$HOOK_ABS" "$WT"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Drains #1763 and #1764 together. Both findings sit six lines apart in the same block of `.gaia/tests/hooks/provision-worktree.bats`, both came out of round 2 of the audit gate on #1748, and both were filed rather than fixed in place for one stated reason: editing this file rotates the shell audit member's content digest and buys a full further round for a change with no live failure mode. Their own reports recommended folding them into a future edit of this file. This is that edit, so the round it buys is spent once instead of twice.

## What changed

The `pnpm`-stripping loop that rebuilds `PATH` for the "pnpm absent from PATH" test:

- **#1763** tested only `-x`, which is true for a searchable *directory* named `pnpm`, not only an executable file. A `PATH` entry holding such a directory was dropped along with every real tool it provided. Adding `-f` ahead of it restricts the test to what `command -v` will accept as a command.
- **#1764** built a `path_dirs` array only to re-walk it, and that array was the sole reason the `${path_dirs[@]+"${path_dirs[@]}"}` unset-guard existed at all. The `while IFS= read -r` loop is fed by a here-string, which bash runs in the current shell rather than a subshell, so `filtered_path` is appended to directly and both the array and its guard are gone.

## Verification

- Reproduced the #1763 premise directly: `[ -x <dir>/pnpm ]` is true for a directory; the tightened `[ -f ] && [ -x ]` correctly rejects it.
- Behavioral check of the merged loop against three synthetic `PATH` entries (one holding a real executable `pnpm`, one holding a directory named `pnpm`, one clean): the executable-bearing entry is stripped, the directory-bearing entry is kept, and `pnpm` is unresolvable through the rebuilt `PATH` either way, which is what the test asserts.
- `errexit` behavior of the two-test `&&` chain confirmed non-aborting on both bash 3.2.57 and 5.3.
- `.gaia/tests/hooks/provision-worktree.bats` under bash 5: **32/32 pass**, including test 30, the one containing the edited block.
- `.gaia/tests/shell-lint.sh`: clean (all 10 lints).
- `.gaia/tests/whole-tree-invariants.sh`: all pass.

## Scope notes

Test-only, no behavior change. `.gaia/tests` is release-excluded wholesale (`.gaia/release-exclude:205`), so nothing here reaches an adopter bundle and no CHANGELOG entry is owed.

Closes #1763
Closes #1764

🤖 Generated with [Claude Code](https://claude.com/claude-code)
