### PR TITLE
debt(commands): drop /distribution-audit's main-only worktree refusal

### DIFF
--- a/.claude/commands/distribution-audit.md
+++ b/.claude/commands/distribution-audit.md
@@ -9,19 +9,6 @@ Maintainer-only. Thin orchestrator over `.gaia/cli/gaia-maintainer`, which owns 
 
 `.gaia/release-exclude` is the distribution boundary: a file ships to adopters if and only if git tracks it and no line in that file masks it. `.gaia/manifest.json` is the update policy `/update-gaia` consumes, and incidentally the ledger of which shipping files a maintainer has acknowledged. A file that git tracks, that no exclude line masks, and that the manifest does not yet list is "unanswered": it would ship, but nobody has said so on purpose.
 
-## Pre-flight: Worktree check
-
-This command drives the release CLI's manifest regeneration and answers the shipping boundary for the clone. If invoked from a linked worktree, reject hard: `gaia_refuse_if_worktree` (`.gaia/scripts/main-only-lib.sh`) asks the shared resolver which tree this is and refuses out loud, naming the main checkout, when the answer is a worktree.
-
-Detection (run this first, before anything else):
-
-```bash
-. .gaia/scripts/main-only-lib.sh
-gaia_refuse_if_worktree "/distribution-audit" || exit 1
-```
-
-If the detection does not fire, fall through to `## Step 1. Find the unanswered files` below.
-
 ## Step 1. Find the unanswered files
 
 ```bash

--- a/.gaia/scripts/tests/main-only-lib.bats
+++ b/.gaia/scripts/tests/main-only-lib.bats
@@ -334,11 +334,12 @@ CALL_SITE_FLOW_NAMES=(
 # release path's main-only property is enforced at /gaia-release's own call
 # site above, not here.
 #
-# Deliberately not resting that on main-only-lib.sh's docblock, which reads as
-# the criterion and is not one: three flows above (/gaia-serena-sync,
-# /gaia-react-perf, /gaia-fitness) carry the refusal while matching none of the
-# limbs it names. CALL_SITE_FILES is the roster; the docblock records the
-# original motivating case.
+# That warrant stands on its own and deliberately does not rest on
+# main-only-lib.sh's docblock, which reads like the classification criterion
+# and is not one. Taking the docblock at face value reaches the same verdict
+# anyway: its sentence is a conjunction, a VERSION/lockfile/cache-state write
+# AND opening or driving a PR, and /distribution-audit satisfies neither half.
+# CALL_SITE_FILES is the roster, and tests 14 and 15 are what enforce it.
 NO_CALL_SITE_FILES=(
   ".claude/commands/distribution-audit.md"
   ".claude/commands/gaia-plan.md"

--- a/.gaia/scripts/tests/main-only-lib.bats
+++ b/.gaia/scripts/tests/main-only-lib.bats
@@ -282,11 +282,10 @@ install_libs() {
 # hardcoded here instead, with this comment naming where the classification
 # itself lives.
 
-# The fourteen classified flows, and each one's flow-name literal at the
-# same array index. Order matches the RUNBOOK.md classification's own
-# ordering, not alphabetical.
+# The classified flows that carry the refusal, and each one's flow-name
+# literal at the same array index. Order matches the RUNBOOK.md
+# classification's own ordering, not alphabetical.
 CALL_SITE_FILES=(
-  ".claude/commands/distribution-audit.md"
   ".claude/commands/gaia-audit.md"
   ".claude/commands/gaia-debt.md"
   ".claude/commands/gaia-fitness.md"
@@ -302,7 +301,6 @@ CALL_SITE_FILES=(
   ".claude/skills/update-gaia/SKILL.md"
 )
 CALL_SITE_FLOW_NAMES=(
-  "/distribution-audit"
   "/gaia-audit"
   "/gaia-debt"
   "/gaia-fitness"
@@ -318,13 +316,25 @@ CALL_SITE_FLOW_NAMES=(
   "/update-gaia"
 )
 
-# The six flows that must never carry the refusal: each provisions or drives
+# The flows that must never carry the refusal: each provisions or drives
 # its own worktree mid-flow (gaia-plan, gaia-debt's fix path) or must stay
 # reachable from inside one (gaia-spec, gaia-forensics, gaia-handoff,
 # gaia-pickup, file-tech-debt). This half is what catches a future drive-by
 # adding the refusal to one of these, e.g. onto /gaia-plan, which would break
 # plan execution the moment the flow enters the worktree it just created.
+#
+# distribution-audit joins them on a different warrant, and one worth stating
+# because the refusal did sit on it. main-only-lib.sh's own docblock scopes
+# the refusal to flows that write `.gaia/VERSION`, a lockfile, or cache state
+# and open or drive a PR. /distribution-audit does none of those: it writes
+# `.gaia/manifest.json` and `.gaia/release-exclude`, git-tracked branch-scoped
+# files a linked worktree isolates correctly. Meanwhile the `gh pr create`
+# distribution pre-flight demands that answer land on the worktree's own
+# branch, which the main checkout cannot supply, so a refusal here made the
+# hook's own remediation unfollowable. The release path's main-only property
+# is enforced at /gaia-release's own call site above, not here.
 NO_CALL_SITE_FILES=(
+  ".claude/commands/distribution-audit.md"
   ".claude/commands/gaia-plan.md"
   ".claude/commands/gaia-spec.md"
   ".claude/commands/gaia-forensics.md"
@@ -333,7 +343,7 @@ NO_CALL_SITE_FILES=(
   ".claude/skills/file-tech-debt/SKILL.md"
 )
 
-# Seven of the fourteen are thin dispatchers: a "Read `.claude/..." line
+# Seven of the call-site roster are thin dispatchers: a "Read `.claude/..." line
 # sends the agent to a reference file, and a refusal call placed BELOW that
 # line greps as present but never runs, because the agent follows the
 # reference instead of reading the rest of the file. This is the frozen set
@@ -374,7 +384,7 @@ extract_block() {
 
 # ---------- roster census ----------
 
-@test "call-site roster: each of the fourteen classified flows carries exactly one line-anchored invocation" {
+@test "call-site roster: every classified flow carries exactly one line-anchored invocation" {
   local f count
   for f in "${CALL_SITE_FILES[@]}"; do
     count=$(grep -c '^[[:space:]]*gaia_refuse_if_worktree "' "$REPO_ROOT/$f" || true)
@@ -382,7 +392,7 @@ extract_block() {
   done
 }
 
-@test "call-site roster: the six worktree-callable flows carry none" {
+@test "call-site roster: the worktree-callable flows carry none" {
   local f count
   for f in "${NO_CALL_SITE_FILES[@]}"; do
     count=$(grep -c '^[[:space:]]*gaia_refuse_if_worktree "' "$REPO_ROOT/$f" || true)
@@ -411,7 +421,7 @@ extract_block() {
 
 # ---------- per-call-site execution, under the shell the call site really uses ----------
 
-@test "call-site execution: all fourteen extracted blocks refuse correctly under bash, from a real linked worktree" {
+@test "call-site execution: every extracted block refuses correctly under bash, from a real linked worktree" {
   make_repo
   install_libs "$REPO"
   make_worktree "$REPO" mol-bash mol-bash-branch
@@ -437,7 +447,7 @@ extract_block() {
   return 0
 }
 
-@test "call-site execution: all fourteen extracted blocks refuse correctly under zsh, from a real linked worktree" {
+@test "call-site execution: every extracted block refuses correctly under zsh, from a real linked worktree" {
   command -v zsh >/dev/null 2>&1 || skip "zsh not installed"
   make_repo
   install_libs "$REPO"

--- a/.gaia/scripts/tests/main-only-lib.bats
+++ b/.gaia/scripts/tests/main-only-lib.bats
@@ -1,8 +1,8 @@
 #!/usr/bin/env bats
 #
 # Conformance suite for .gaia/scripts/main-only-lib.sh (task 5.3): the shared
-# main-only-flow refusal helper /update-gaia, /update-deps, and /gaia-release
-# source instead of each carrying its own copy-pasted detection.
+# main-only-flow refusal helper the classified flows source instead of each
+# carrying its own copy-pasted detection. CALL_SITE_FILES below is the roster.
 #
 # Run under bash 5 (bash 3.2's `[[ ]]` skip-under-set-e gap is real; see
 # .claude/rules/bats-assertions.md): `source .gaia/scripts/bats5.sh && bats5
@@ -192,8 +192,8 @@ gaia_refuse_if_worktree "/update-gaia" my_state
 
 # ---------- as the call sites actually invoke it ----------
 #
-# Every test above sources $LIB by ABSOLUTE path under bash. The three call
-# sites do neither: they are markdown blocks an agent runs through its shell
+# Every test above sources $LIB by ABSOLUTE path under bash. The call sites
+# do neither: they are markdown blocks an agent runs through its shell
 # tool, so the sourcing shell is that machine's login shell (zsh on a stock
 # Mac, not bash as a settings.json-registered hook gets), and the line they run
 # is the repo-relative `. .gaia/scripts/main-only-lib.sh` from a checkout root.
@@ -324,15 +324,21 @@ CALL_SITE_FLOW_NAMES=(
 # plan execution the moment the flow enters the worktree it just created.
 #
 # distribution-audit joins them on a different warrant, and one worth stating
-# because the refusal did sit on it. main-only-lib.sh's own docblock scopes
-# the refusal to flows that write `.gaia/VERSION`, a lockfile, or cache state
-# and open or drive a PR. /distribution-audit does none of those: it writes
-# `.gaia/manifest.json` and `.gaia/release-exclude`, git-tracked branch-scoped
-# files a linked worktree isolates correctly. Meanwhile the `gh pr create`
-# distribution pre-flight demands that answer land on the worktree's own
-# branch, which the main checkout cannot supply, so a refusal here made the
-# hook's own remediation unfollowable. The release path's main-only property
-# is enforced at /gaia-release's own call site above, not here.
+# because the refusal did sit on it. What decides it is what the flow writes:
+# /distribution-audit writes `.gaia/manifest.json` and `.gaia/release-exclude`,
+# git-tracked branch-scoped files a linked worktree isolates correctly, and it
+# writes nothing under `.gaia/local`, so a worktree run collides with no shared
+# state. Meanwhile the `gh pr create` distribution pre-flight demands that
+# answer land on the worktree's own branch, which the main checkout cannot
+# supply, so a refusal here made the hook's own remediation unfollowable. The
+# release path's main-only property is enforced at /gaia-release's own call
+# site above, not here.
+#
+# Deliberately not resting that on main-only-lib.sh's docblock, which reads as
+# the criterion and is not one: three flows above (/gaia-serena-sync,
+# /gaia-react-perf, /gaia-fitness) carry the refusal while matching none of the
+# limbs it names. CALL_SITE_FILES is the roster; the docblock records the
+# original motivating case.
 NO_CALL_SITE_FILES=(
   ".claude/commands/distribution-audit.md"
   ".claude/commands/gaia-plan.md"


### PR DESCRIPTION
Closes #1665

## What

`/distribution-audit` carried `gaia_refuse_if_worktree`, so it refused outright from a linked worktree. Meanwhile `.claude/hooks/distribution-preflight-check.sh` denies `gh pr create` whenever a newly-shipping file on the branch has no answer in `.gaia/manifest.json`, and its remediation says to run `/distribution-audit` and commit the regenerated manifest **to this branch**. On any worktree-mode run that adds a shipping file those two instructions could not both be followed: the worktree holds the file and the branch, the main checkout the guard redirects to holds neither.

## Why direction 2

The design decision was settled on the issue (see its pinned comment) and is not re-opened here.

`main-only-lib.sh`'s own docblock scopes the refusal to flows that write `.gaia/VERSION`, a lockfile, or cache state and open or drive a PR. `/distribution-audit` matches none of those limbs: it writes `.gaia/manifest.json` and `.gaia/release-exclude`, git-tracked branch-scoped files a linked worktree isolates correctly. The refusal reached it by roster membership, not by the property the roster protects. The release path's main-only requirement is enforced independently at `/gaia-release`'s own call site, which this PR does not touch.

The shared helper is **not** edited: no new arm, no flow-aware conditional, no new parameter.

## Changes

- `.claude/commands/distribution-audit.md`: delete the `## Pre-flight: Worktree check` section (prose, detection block, and its fall-through sentence).
- `.gaia/scripts/tests/main-only-lib.bats`: move the command from `CALL_SITE_FILES` to `NO_CALL_SITE_FILES` (with a warrant comment for why it joins them on different grounds than the others), drop its `CALL_SITE_FLOW_NAMES` entry, and replace the roster's now-stale cardinals with set names per the name-the-set convention.

Two prose sites the issue flagged as possibly needing to agree with the fix already agree and are unchanged: the pre-flight hook's remediation text, and `wiki/concepts/Release Workflow.md`'s per-PR distribution gate. Both become executable as written once the refusal is gone.

## Verification

- The census test reds on the roster move before the block is deleted (`expected no gaia_refuse_if_worktree invocation in .claude/commands/distribution-audit.md, found 1`), then greens after: the guard can fail.
- `main-only-lib.bats`: 20/20 pass under bash 5.
- From this PR's own linked worktree, `gaia-maintainer release manifest --check --json` returns a payload instead of the refusal.
- `.gaia/tests/shell-lint.sh` and `.gaia/tests/whole-tree-invariants.sh` both pass.
- The dispatcher-split placement test derives its own split at runtime and still agrees with the frozen seven; `EXPECTED_DISPATCHER_FILES` never listed this command.

Both touched files are release-excluded and absent from `.gaia/manifest.json`, so there is no adopter-visible change and no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Audit rounds

Three rounds, two members (`code-audit-maintainer-prose`, `code-audit-maintainer-shell`). Round 2 was a **refusal**, and it was correct.

- **Round 1** — both clean on the change. Both independently flagged that the new warrant comment cited `main-only-lib.sh`'s docblock as the rule scoping the refusal, and that the docblock does not describe the roster. Fixed in `f2ebc170`, which also dropped two stale cardinals the same suite still carried over the same roster.
- **Round 2** — `code-audit-maintainer-shell` withheld its marker. The round-1 repair had replaced a misapplied criterion with a **wrong fact**: it asserted `/gaia-serena-sync`, `/gaia-react-perf` and `/gaia-fitness` match none of the docblock's limbs, and each matches one (the first two write under `.gaia/local/cache`; `/gaia-fitness` runs `gh pr create` and `gh pr merge`). Verified independently, then fixed in `787b422f`: the comment now makes no claim about any other flow and rests on `/distribution-audit` satisfying neither half of the docblock's conjunction. Issue #1802 carried the same false claim and was corrected in place.
- **Round 3** — both clean. Digests rotated only because a catch-up merge from `origin/main` brought a one-line change to `.claude/hooks/local-janitor.sh`, which is gate machinery.

## Out-of-scope findings filed

Both on `.gaia/scripts/main-only-lib.sh`, a file this PR deliberately leaves untouched (its settled direction edits no shared helper). Neither is a gate-machinery path nor a file this PR changes, so neither is waive-eligible.

- **#1802** — the docblock states a criterion that no longer describes the roster. Its sentence is a conjunction (a `.gaia/VERSION`/lockfile/cache-state write **and** opening or driving a PR); it describes its three original subjects correctly, and roster members added since satisfy only one half. `severity:important`, `difficulty:hard`.
- **#1803** — the docblock names three consumers of a helper thirteen files source. `severity:suggestion`, `difficulty:easy`.

## Out-of-scope machinery findings (recorded, not filed)

Each is either on a gate-machinery path or on a file this PR already changes, and each clears both disqualifiers: none is an inconsistency this change authors, and none is named by a pointer in shipped content.

- `.claude/commands/distribution-audit.md:74` — the bullet ends `...the same violation as using it directly, a single sentence pointing there would need no flag and no new file, so there is no reason to.` The trailing clause has no verb to complete and no pinnable antecedent, so a reader cannot tell whether it forbids routing through the release command, adding a flag, or adding a file. Pre-existing, in a section this PR does not touch.
  <!-- gaia-debt-key: v1 class=holistic/unclassified path=.claude/commands/distribution-audit.md line=74 -->
  <!-- gaia-debt-origin: branch=worktree-debt+1665-distribution-audit-worktree-refusal mode=drain unit=1665 changed=1 head=ea3a7cf8ea776684e329beb206e0e830310a4054 -->
- `.claude/rules/bats-assertions.md:16` — prescribes `source .gaia/scripts/bats5.sh`, then `bats5 <file>` as the local spelling for running bats under bash 5. A worktree-isolated session refuses that construct, so the prescribed spelling is unrunnable in a supported mode; the direct-execution form `.gaia/scripts/bats5.sh <file>`, which the same line mentions parenthetically, works. Both audit members hit this independently, as did this PR's own author.
  <!-- gaia-debt-key: v1 class=holistic/unclassified path=.claude/rules/bats-assertions.md line=16 -->
  <!-- gaia-debt-origin: branch=worktree-debt+1665-distribution-audit-worktree-refusal mode=drain unit=1665 changed=0 head=ea3a7cf8ea776684e329beb206e0e830310a4054 -->
- `.claude/agents/code-audit-maintainer-prose.md:327` — the findings-sidecar guidance anticipates the worktree refusal a heredoc triggers, but not the one a `git`-naming string inside the finding text triggers. A member whose finding quotes a git command hits a refusal its own prose does not predict, and the failure mode is a lost report.
  <!-- gaia-debt-key: v1 class=holistic/incomplete-enumeration path=.claude/agents/code-audit-maintainer-prose.md line=327 -->
  <!-- gaia-debt-origin: branch=worktree-debt+1665-distribution-audit-worktree-refusal mode=drain unit=1665 changed=0 head=ea3a7cf8ea776684e329beb206e0e830310a4054 -->

## Accepted residual

`.gaia/scripts/tests/main-only-lib.bats:342` — the sentence `CALL_SITE_FILES is the roster, and tests 14 and 15 are what enforce it` names two tests by positional ordinal. Both ordinals are correct today and the member graded it a Suggestion with no live wrong outcome, but inserting a `@test` above them would shift both with nothing recounting them.

Accepted rather than fixed. It is a finding on the previous round's own repair, which is the pre-committed accept-and-note branch in `wiki/concepts/PR Merge Workflow.md`, and the three-round session cap is spent: any content edit here rotates the shell member's digest and would need a fourth wave that `block-fourth-audit-round.sh` denies. Worth folding into the next change that touches this suite, most naturally the one that drains #1802.
