### PR TITLE
debt(hooks): give local-janitor's main-root-lib source a directive that covers it

### DIFF
--- a/.claude/hooks/local-janitor.sh
+++ b/.claude/hooks/local-janitor.sh
@@ -279,7 +279,7 @@ root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
 
 main_root_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." 2>/dev/null && pwd)/.gaia/scripts/main-root-lib.sh"
 if [ -f "$main_root_lib" ]; then
-  # shellcheck disable=SC1091
+  # shellcheck source=/dev/null
   . "$main_root_lib" 2>/dev/null || true
 fi
 main_root=""


### PR DESCRIPTION
## What

`.claude/hooks/local-janitor.sh` guarded its `main-root-lib.sh` source with `# shellcheck disable=SC1091`. The source path there is the bare variable `$main_root_lib`, which shellcheck reports as **SC1090** (non-constant source), not SC1091. The directive named a code shellcheck never raises on that line, so the warning it existed to silence still stood, and a reader who trusted the directive believed the line was covered when it was not.

Swapped for the `# shellcheck source=/dev/null` form the nine sibling hooks sourcing the same library already use (`audit-disposition-check.sh`, `block-main-destructive-git.sh`, `block-rm-rf.sh`, `block-serena-cross-tree-activation.sh`, `block-spec-plan-chain.sh`, `block-worktree-path-mismatch.sh`, `capture-red-observations.sh`, `debt-sentinel-touch.sh`, `debt-session-reconcile.sh`).

## Why the second SC1091 in the same file is left alone

`local-janitor.sh:724` carries its own `# shellcheck disable=SC1091`, and that one is load-bearing. Verified empirically: its source path ends in a **literal** suffix (`$(cd ... && pwd)/.gaia/scripts/state-registry-lib.sh`), which shellcheck partially resolves to a relative path and reports as SC1091 ("Not following"). Removing that directive reproduces the warning; it stays.

## Verification

- Before: `shellcheck -s bash .claude/hooks/local-janitor.sh` → SC1090 at the source line, exit 1.
- After: same command → clean, exit 0.
- `bash .gaia/tests/shell-lint.sh` → passed (every lens clean).
- All six `local-janitor*.bats` suites under bash 5 → 176/176 pass.
- `bash .gaia/tests/whole-tree-invariants.sh` → all invariants pass.

No behavior change: `.gaia/tests/shell-lint.sh` excludes both SC1090 and SC1091 repo-wide as tooling artifacts, so no gate moved in either direction. What changes is that a bare `shellcheck` run over this one file is now clean, matching every sibling.

## CHANGELOG

No `## [Unreleased]` entry: the change is a comment directive with no behavioral or adopter-visible effect.

Closes #1746

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Audit disposition

`code-audit-maintainer-shell` cleared this diff (earned marker, zero Critical, zero Important) and surfaced one out-of-scope Suggestion: `.github/audit/resolve-audit-base.sh:457` sources a non-constant path with no directive and emits `SC1090`, now the only remaining `SC1090` across all 242 tracked `*.sh`.

Filed as #1801 rather than waived. The path is gate machinery (`.github/audit/**`), so it meets the waive rule's path term, but this PR is what leaves that site as the last one of its class, and a waive's record does not survive the squash merge. A tracked destination is the better disposition for a verified one-line defect.
