### PR TITLE
debt(tests): pin audit-scratch-dir.bats's acting tree, so CI and a worktree agree

### DIFF
--- a/.gaia/scripts/tests/audit-scratch-dir.bats
+++ b/.gaia/scripts/tests/audit-scratch-dir.bats
@@ -13,6 +13,13 @@
 # test resolves a real main checkout or writes anywhere under the repo's own
 # .gaia/local.
 #
+# TWO HALVES, and which tree each assumes is stated rather than left to be
+# inferred. Everything down to the registry-conformance case assumes a PLAIN
+# checkout, and setup() pins one so that assumption is a fixture rather than
+# an accident of where bats was launched. The `mint/populate asymmetry` block
+# at the foot wants the other answer and builds its own linked worktree per
+# case. Nothing in between straddles the two.
+#
 # Assertion style: bash-3.2-safe per .claude/rules/bats-assertions.md.
 #
 # Run under bash 5 (bash 3.2's `[[ ]]` skip-under-set-e gap is real):
@@ -36,9 +43,35 @@ setup() {
   : >"$REPO/f"
   git -C "$REPO" add f
   git -C "$REPO" commit -qm init
+
+  # Pin the ACTING tree, not only the key's tree. Every case below hands $REPO
+  # to the script as <dir>, which is the tree gaia_audit_key reads -- but the
+  # script separately consults gaia_is_linked_worktree with NO argument, and
+  # that reads the PROCESS WORKING DIRECTORY. Left ambient, that is whatever
+  # tree bats happened to be launched from, which no case here controls and
+  # every case here has an opinion about.
+  #
+  # Unpinned, running the suite from a linked worktree fires the mint's
+  # advisory note on stderr; `run` captures "$@" 2>&1, so $output becomes the
+  # two note lines PLUS the path, and every `[ -d "$output" ]` is asserting
+  # against a three-line string. That is gaia-react/gaia#1780: 29/29 from a
+  # plain checkout, 25/29 from a worktree, at one commit, with CI only ever
+  # reporting the first. The mint itself was never at fault -- the directory
+  # is on disk in both environments.
+  #
+  # Deliberately NOT a guard or a skip on the four assertions: that would
+  # leave them unrun in a worktree, which is the same invisibility pointed
+  # the other way. The `mint/populate asymmetry` cases want the worktree
+  # answer and cd into their own, in their own subshells, so this does not
+  # reach them.
+  cd "$REPO" || return 1
 }
 
 teardown() {
+  # Leave the fixture before deleting it: setup() left the cwd inside $TMP,
+  # and a shell whose cwd has been unlinked emits its own diagnostics on the
+  # next command that needs one.
+  cd "$BATS_TEST_DIRNAME" 2>/dev/null || cd / || true
   [ -n "${TMP:-}" ] && rm -rf "$TMP"
   true
 }

--- a/.gaia/scripts/tests/audit-scratch-dir.bats
+++ b/.gaia/scripts/tests/audit-scratch-dir.bats
@@ -74,6 +74,21 @@ teardown() {
   true
 }
 
+# --- the fixture itself ------------------------------------------------------
+
+@test "setup pins the acting tree, so no case inherits the tree bats was launched from" {
+  # setup()'s cd is this file's whole answer to gaia-react/gaia#1780, and on
+  # its own it is unarmed: delete it and every case still passes from a plain
+  # checkout, which is the only environment CI runs, while a developer running
+  # from a linked worktree is back to the original red. Asserting the fixture
+  # makes that deletion visible from ANY tree.
+  #
+  # This is not the guard the note in setup() rules out. That one would have
+  # gated the assertions that red, leaving them unrun in a worktree; this
+  # leaves every case running and asserts only the tree they run in.
+  [ "$PWD" = "$REPO" ]
+}
+
 # --- path shape --------------------------------------------------------------
 
 @test "the minted path carries the audit key AND the member name" {

--- a/.gaia/scripts/tests/audit-scratch-dir.bats
+++ b/.gaia/scripts/tests/audit-scratch-dir.bats
@@ -53,7 +53,7 @@ setup() {
   #
   # Unpinned, running the suite from a linked worktree fires the mint's
   # advisory note on stderr; `run` captures "$@" 2>&1, so $output becomes the
-  # note lines PLUS the path, and every `[ -d "$output" ]` above is then
+  # note lines PLUS the path, and every `[ -d "$output" ]` in the file is then
   # asserting against a multi-line string. That is gaia-react/gaia#1780: the
   # suite was green from a plain checkout and red from a worktree at one
   # commit, and CI only ever runs the first. The mint itself was never at
@@ -68,10 +68,6 @@ setup() {
 }
 
 teardown() {
-  # Leave the fixture before deleting it: setup() left the cwd inside $TMP,
-  # and a shell whose cwd has been unlinked emits its own diagnostics on the
-  # next command that needs one.
-  cd "$BATS_TEST_DIRNAME" 2>/dev/null || cd / || true
   [ -n "${TMP:-}" ] && rm -rf "$TMP"
   true
 }

--- a/.gaia/scripts/tests/audit-scratch-dir.bats
+++ b/.gaia/scripts/tests/audit-scratch-dir.bats
@@ -13,14 +13,14 @@
 # test resolves a real main checkout or writes anywhere under the repo's own
 # .gaia/local.
 #
-# TWO HALVES, and which tree each assumes is stated rather than left to be
-# inferred. Everything down to the registry-conformance case assumes a PLAIN
-# checkout, and setup() pins one so that assumption is a fixture rather than
-# an accident of where bats was launched. The `mint/populate asymmetry` block
-# at the foot chooses its own tree per case instead, each in its own subshell:
-# most build a linked worktree, and its closing negative control deliberately
-# takes the plain fixture, because what that case pins is the note staying
-# SILENT off a worktree. Nothing in between straddles the two.
+# WHICH TREE A CASE RUNS IN is stated here rather than left to be inferred,
+# because the subject reads it from the process working directory and this
+# file has cases on both sides of that. setup() pins a PLAIN checkout, so a
+# case that says nothing about trees gets one, and that is a fixture rather
+# than an accident of where bats was launched. A case needing a different
+# answer cds there itself and the pin decides nothing for it; the
+# `mint/populate asymmetry` block at the foot is where those live, and it
+# carries both answers rather than one.
 #
 # Assertion style: bash-3.2-safe per .claude/rules/bats-assertions.md.
 #
@@ -46,12 +46,13 @@ setup() {
   git -C "$REPO" add f
   git -C "$REPO" commit -qm init
 
-  # Pin the ACTING tree, not only the key's tree. Every case below hands $REPO
-  # to the script as <dir>, which is the tree gaia_audit_key reads -- but the
-  # script separately consults gaia_is_linked_worktree with NO argument, and
-  # that reads the PROCESS WORKING DIRECTORY. Left ambient, that is whatever
-  # tree bats happened to be launched from, which no case here controls and
-  # every case here has an opinion about.
+  # Pin the ACTING tree, not only the key's tree. The script takes its KEY
+  # tree from the <dir> positional, which defaults to the process working
+  # directory, and its ACTING tree from gaia_is_linked_worktree with NO
+  # argument, which is that working directory and nothing else. So a case can
+  # name the first and nothing but this cd names the second. Left ambient the
+  # second is whatever tree bats happened to be launched from, which no case
+  # here controls.
   #
   # Unpinned, running the suite from a linked worktree fires the mint's
   # advisory note on stderr; `run` captures "$@" 2>&1, so $output becomes the
@@ -63,9 +64,8 @@ setup() {
   #
   # Deliberately NOT a guard or a skip on the assertions that red: that would
   # leave them unrun in a worktree, which is the same invisibility pointed
-  # the other way. The `mint/populate asymmetry` cases each choose their own
-  # tree in their own subshell, worktree or plain, so this pin does not reach
-  # any of them.
+  # the other way. A case that cds for itself overrides this pin by doing so,
+  # so nothing below has to be exempted from it by hand.
   cd "$REPO" || return 1
 }
 

--- a/.gaia/scripts/tests/audit-scratch-dir.bats
+++ b/.gaia/scripts/tests/audit-scratch-dir.bats
@@ -53,13 +53,13 @@ setup() {
   #
   # Unpinned, running the suite from a linked worktree fires the mint's
   # advisory note on stderr; `run` captures "$@" 2>&1, so $output becomes the
-  # two note lines PLUS the path, and every `[ -d "$output" ]` is asserting
-  # against a three-line string. That is gaia-react/gaia#1780: 29/29 from a
-  # plain checkout, 25/29 from a worktree, at one commit, with CI only ever
-  # reporting the first. The mint itself was never at fault -- the directory
-  # is on disk in both environments.
+  # note lines PLUS the path, and every `[ -d "$output" ]` above is then
+  # asserting against a multi-line string. That is gaia-react/gaia#1780: the
+  # suite was green from a plain checkout and red from a worktree at one
+  # commit, and CI only ever runs the first. The mint itself was never at
+  # fault -- the directory is on disk in both environments.
   #
-  # Deliberately NOT a guard or a skip on the four assertions: that would
+  # Deliberately NOT a guard or a skip on the assertions that red: that would
   # leave them unrun in a worktree, which is the same invisibility pointed
   # the other way. The `mint/populate asymmetry` cases want the worktree
   # answer and cd into their own, in their own subshells, so this does not

--- a/.gaia/scripts/tests/audit-scratch-dir.bats
+++ b/.gaia/scripts/tests/audit-scratch-dir.bats
@@ -17,8 +17,10 @@
 # inferred. Everything down to the registry-conformance case assumes a PLAIN
 # checkout, and setup() pins one so that assumption is a fixture rather than
 # an accident of where bats was launched. The `mint/populate asymmetry` block
-# at the foot wants the other answer and builds its own linked worktree per
-# case. Nothing in between straddles the two.
+# at the foot chooses its own tree per case instead, each in its own subshell:
+# most build a linked worktree, and its closing negative control deliberately
+# takes the plain fixture, because what that case pins is the note staying
+# SILENT off a worktree. Nothing in between straddles the two.
 #
 # Assertion style: bash-3.2-safe per .claude/rules/bats-assertions.md.
 #
@@ -61,9 +63,9 @@ setup() {
   #
   # Deliberately NOT a guard or a skip on the assertions that red: that would
   # leave them unrun in a worktree, which is the same invisibility pointed
-  # the other way. The `mint/populate asymmetry` cases want the worktree
-  # answer and cd into their own, in their own subshells, so this does not
-  # reach them.
+  # the other way. The `mint/populate asymmetry` cases each choose their own
+  # tree in their own subshell, worktree or plain, so this pin does not reach
+  # any of them.
   cd "$REPO" || return 1
 }
 


### PR DESCRIPTION
## What this fixes

`.gaia/scripts/tests/audit-scratch-dir.bats` passed from a plain checkout and failed from a linked
worktree at one commit. CI runs on a plain checkout, so the only environment that reports this
suite reported green, while the environment its subject was most recently changed to serve was red.

## The issue's diagnosis is wrong, and the measurement is the substance of this PR

`#1780` offers two arms. **Both are wrong as stated**, and the settled reasoning is on the issue
(issuecomment-5551563454) so a later reader does not inherit the false premise from the body.

**Arm 1, "the swallowed `mkdir -p ... || return 0` is a real defect", is falsified.** Probed from
inside a real linked worktree using the suite's own fixture and scratch root:

```
STATUS=0
LINES=3
STDOUT_ONLY<</…/mutation-scratch/deadbeef.work.code-audit-frontend>>
MKDIR_OK=yes
```

The `mkdir` succeeds and the directory is on disk. Nothing in `audit-scratch-dir.sh` is broken.

**The mechanism is the test harness.** bats `run` captures `"$@" 2>&1`, so `$output` is stdout
**and** stderr merged. `audit-scratch-dir.sh:254` consults `gaia_is_linked_worktree` with **no
argument**, which reads the **process working directory** — the tree bats was launched from — not
the `$REPO` fixture each case builds and hands the script as `<dir>`. Launched from a worktree, the
mint's advisory note lands on stderr, `run` folds it into `$output`, and every `[ -d "$output" ]`
assertion is testing a multi-line string.

That is exactly why those cases and no others: they are the only ones spelling `[ -d "$output" ]`
after a `run`. Case 1 and case 9's `grep -qF` survive the extra lines by luck, and **case 23
*relies* on the merge** to read `could not create` off stderr, so the merge is deliberate elsewhere
in the file and must not be undone wholesale.

**Arm 2's first half is also wrong.** A worktree guard or a skip on the failing assertions would
leave them unrun in a worktree, which is the same invisibility this issue is about, pointed the
other way.

## The fix

Arm 2's second half: pin the suite's acting tree to the plain-checkout fixture `setup()` already
builds. **Two hunks in one file**: one `cd` with the comment that says why, and a header note
stating which half of the file assumes which tree — the unmarked split is the confusion the issue
names.

It fixes the class rather than the instances: every present and future case reads a plain checkout
unless it explicitly `cd`s elsewhere, which the `mint/populate asymmetry` cases already do in their
own subshells.

**The worktree property was already pinned and nothing was added for it.** That case mints from a
real linked worktree, captures stdout alone, and asserts the path is a directory. It passed in both
environments before this change and still does.

**The pin is armed, so deleting it cannot pass silently.** One case asserts the fixture itself.
That matters here more than usual: on its own the pin was unarmed, and removing it left every case
green from a plain checkout, which is the only environment CI runs, while a developer running from a
linked worktree was back to the original red. That is this issue's own failure mode, silently
reintroducible. With the assertion in place, deleting the pin **reds from a plain checkout**. It is
not the guard the comment in `setup()` rules out: that one would have gated the assertions that red,
leaving them unrun in a worktree, where this leaves every case running and asserts only the tree
they run in.

## Audit rounds

Three, all by `code-audit-maintainer-shell`, all clean verdicts with zero Critical and zero
Important. Every finding was verified independently before being acted on.

- **Round 1** — two Suggestions. One fixed (`55b0b332`); one filed as **#1806**, since it lands in
  `audit-scratch-dir.sh`, which this PR does not touch, so the touched-file waive was unavailable.
- **Round 2** — two Suggestions, both fixed in `81a3572a`. Both were false claims in prose this PR
  had added, and **round 1's own repair produced one of them.** The reading taken is that they are
  one finding: every wrong claim these comments carried was a claim about *which cases do what*. So
  the repair is a **narrowing** rather than another correction. The comments now state the rule and
  nothing about the roster, which is why a third round of the same kind was not bought.
- **Round 3** — one Suggestion, the armed-pin gap above, fixed in `c88be4b0`. It is the only finding
  in three rounds about the fix rather than about prose describing it.
- **Round 4** — clean, in a fresh session after the three-round cap. Zero Critical, zero Important,
  and **nothing at all on this PR's own changed file**, which is the round that says the sweep has
  converged. Its three Suggestions all landed on files this PR does not change and that reached the
  branch only through the round's own catch-up merge, and all three were already disposed; see
  below. The round also re-verified the fix independently: with `setup()`'s `cd` neutered in a
  scratch copy, only the new fixture test reds from a plain checkout, and tests 1, 3, 10, 12 and 13
  red from a linked worktree, reproducing `#1780`'s exact signature.

  The round cost two dispatches at one tree. The first completed its review and then forfeited its
  clearance write on an unspent scope capture left behind by round 3's interrupted session; the
  scope machinery documents that case and prices it at exactly one round. The second derived a
  fresh capture and cleared.

Round 3's marker was **forfeited by an external event, not by the member**: a peer session's
post-merge cleanup took the feature-branch arm in the shared main checkout and moved HEAD off this
branch mid-review. The member had completed its review, correctly declined to write a marker or
sidecar under a key that would attribute a branch review to `main`, and said so. Nothing was lost
but the round. Filed as **#1807**, because the precondition against exactly this shipped earlier the
same day (#1788) and the next wave violated it anyway, which is the evidence that prose is the wrong
instrument for it.

## Verification

- **Green in both environments now**, exit 0 from a plain checkout and exit 0 from inside a linked
  worktree, where it previously red.
- **The pin is load-bearing (mutation 1).** Deleting the `cd` from `setup()` reproduces the issue's
  exact signature from a worktree: the same cases, on the same assertion.
- **The pinned assertions still bite (mutation 2).** Neutering the script's `mkdir -p` reds those
  cases plus their siblings, **identically in both environments**. That is the property this change
  exists to establish: the environment dependence is gone and the power to fail is not.
- Both mutations used a `cp` aside / `cp` back restore, with the tree confirmed identical to HEAD
  afterwards.
- **Every bats root `audit-ci-tests.yml` runs, all exit 0, zero `not ok`:** `.github/audit/tests`
  328, `.gaia/scripts/tests` 2805 (the root this diff sits in), `.gaia/tests/hooks` 2092,
  `.gaia/tests/lib` 713, `.gaia/tests/statusline` 41. Plus `shell-lint.sh` and
  `whole-tree-invariants.sh`, both clean.
- **A `teardown()` guard was written and then removed rather than shipped.** It cd'd out of the
  fixture before deleting it, against a shell diagnostic that could not be reproduced: without it
  the suite is still green in both environments with no noise, since each bats test is its own
  process and exits right after teardown. Shipping it would have left a comment asserting
  behaviour nobody executed.
- Caught up to `main` before the final round. Rounds 1-3 deliberately did not, because the branch
  held a valid marker and a catch-up would have rotated the digest to re-buy a round for nothing.
  Round 4 opened with no clearance at all, so absorbing `origin/main` (#1797) cost nothing and is
  what the merge workflow asks for before a first dispatch. The catch-up brought
  `.claude/commands/distribution-audit.md` and `.gaia/scripts/tests/main-only-lib.bats`, neither of
  which this PR changes.
- **Quality Gate skipped on a positive answer**: the only changed path is a `.bats` file, and the
  gate page's own `-z`-safe grep ran and matched nothing.
- **No CHANGELOG entry owed, measured**: `grep -c` for the path against `.gaia/manifest.json`
  returns 0, so nothing here reaches an adopter.

## Round 4's dispositions: nothing new filed

All three Suggestions are out of scope (none names a file this PR changes) and none is
waive-eligible (no path among them is gate machinery), so each is filed rather than waived. Each was
already open when the round reported it:

- `.gaia/scripts/tests/main-only-lib.bats:342`, the `CALL_SITE_FILES` roster comment naming its
  enforcing tests by ordinal position → **#1808**. Filed independently from another branch 45
  seconds before this row's own filing reached `gh issue create`; the pre-create dedup re-check
  matched it on `path`+`line` and suppressed the duplicate.
- `.gaia/scripts/main-only-lib.sh:7`, the docblock naming three consumers of a helper thirteen files
  source → **#1803**, with **#1802** covering the same docblock's criterion sentence.
- 35 info-level shellcheck hits on `main-only-lib.bats` (SC2016 on deliberate single-quoted
  `bash -c` bodies, SC2317/SC2329 from shellcheck parsing a bats file as plain bash) → **no
  disposition owed**. Zero delta against the base, and the member's own recommended fix is "none
  required". `audit-scratch-dir.bats` is shellcheck-clean.

## New debt filed


**#1807**, `severity:important` / `surface:adopter` / `handler:plan` / `difficulty:hard`: the merge
workflow's main-checkout cleanup precondition is prose only, and nothing fails when it is not
followed. Second occurrence, and the first one is what put the precondition in the page.

**#1806**, `severity:suggestion` / `surface:maintainer` / `handler:prompt` / `difficulty:medium`:
`audit-scratch-dir.sh:254` resolves the acting tree from cwd while the key tree comes from the
`<dir>` positional. The subject-side general form of this issue, on a file this PR does not change.

**#1804**, `severity:suggestion` / `surface:maintainer` / `handler:plan` / `difficulty:hard`: no CI
leg runs the bats corpus from a linked worktree, so a suite that reds only there is invisible. Filed
rather than fixed because it is a property this change never claimed. The evidence is that the class
has now fired twice and been found by hand both times — **#1367** (`state-registry-lib.bats`, closed
2026-08-13) and this issue — and that the ambient-acting-tree surface is small and enumerable: only
`audit-scratch-dir.sh:254` and `main-only-lib.sh:111` read it without an argument, and
`main-only-lib.bats` already pins cwd per case with a `run_in <dir>` helper, which is the model this
fix followed.

## Note for the queue

The row cell's *"treat it as known-red for worktree rows"* advice is retired by this change. Nothing
was owed in `DRAIN.md`'s known-red table, which is empty and is a plan surface rather than a step
one.

Closes #1780

