### PR TITLE
debt(tests): name the CALL_SITE_FILES enforcers by title, not ordinal

### DIFF
--- a/.gaia/scripts/tests/main-only-lib.bats
+++ b/.gaia/scripts/tests/main-only-lib.bats
@@ -339,7 +339,8 @@ CALL_SITE_FLOW_NAMES=(
 # and is not one. Taking the docblock at face value reaches the same verdict
 # anyway: its sentence is a conjunction, a VERSION/lockfile/cache-state write
 # AND opening or driving a PR, and /distribution-audit satisfies neither half.
-# CALL_SITE_FILES is the roster, and tests 14 and 15 are what enforce it.
+# CALL_SITE_FILES is the roster, and the `call-site roster:` census tests are
+# what enforce it.
 NO_CALL_SITE_FILES=(
   ".claude/commands/distribution-audit.md"
   ".claude/commands/gaia-plan.md"


### PR DESCRIPTION
## What

`.gaia/scripts/tests/main-only-lib.bats:342` closed the `NO_CALL_SITE_FILES` warrant with a pointer to its two enforcing tests by **ordinal position**:

> `CALL_SITE_FILES` is the roster, and tests 14 and 15 are what enforce it.

Insert a `@test` anywhere above line 394 and both ordinals shift. Nothing recounts them, and `lint-stale-cardinals` does not model test ordinals, so the sentence keeps reading as correct while sending a reader to two unrelated tests. That is worse than a pointer that visibly broke.

## The fix

Point at the two tests by their shared title prefix instead:

> `CALL_SITE_FILES` is the roster, and the `call-site roster:` census tests are what enforce it.

The `call-site roster:` prefix is unique to exactly those two `@test` names, it is greppable, and it survives an insertion above them. Dropping the cardinal entirely also satisfies `.claude/rules/code-comments.md`'s **Counts** rule ("prefer the set to its cardinality"), rather than restating a smaller number that nothing recounts.

## Verification

- `.gaia/scripts/bats5.sh .gaia/scripts/tests/main-only-lib.bats` — 20/20 pass
- `bash .gaia/tests/shell-lint.sh` — passed (`lint-stale-cardinals` clean)
- `bash .gaia/tests/whole-tree-invariants.sh` — all invariants pass
- Quality Gate skipped: the only staged file is `.bats`, no source or gate-affecting config
- No CHANGELOG entry: `.gaia/scripts/tests` is release-excluded, so nothing here reaches an adopter

Closes #1808