### PR TITLE
debt(tests): name the wiki-doc suite's knob set, not its cardinality

### DIFF
--- a/.gaia/tests/hooks/local-janitor-wiki-doc.bats
+++ b/.gaia/tests/hooks/local-janitor-wiki-doc.bats
@@ -5,10 +5,11 @@
 # wiki/concepts/Local Working State.md must enumerate one bullet per janitor
 # sweep, its stated count numeral must equal both the enumerated bullet count
 # and the sweep count derived from .claude/hooks/local-janitor.sh source, and
-# the outlier sweep's own documentation must name its three retention knobs
-# and state the maxdepth-1 scope and never-traverse zones. This mechanically
-# enforces the agreement so the enumeration cannot silently drift when a
-# sweep is added, removed, or renumbered.
+# the outlier sweep's own documentation must name the retention knobs
+# source_sweep9_knobs derives from that sweep's own paragraph in the janitor
+# source, and state the maxdepth-1 scope and never-traverse zones. This
+# mechanically enforces the agreement so the enumeration cannot silently
+# drift when a sweep is added, removed, or renumbered.
 #
 # Assertion style: .claude/rules/bats-assertions.md.
 


### PR DESCRIPTION
The `local-janitor-wiki-doc.bats` file header said the outlier sweep's own documentation "must name its **three** retention knobs". The cardinal was accurate, and unrecounted in the direction that matters.

## The decay

`source_sweep9_knobs` derives the knob names from sweep 9's paragraph in `.claude/hooks/local-janitor.sh`; the AC-4 floor beneath it is `-ge 3`. A floor is one-directional: it reds when the derivation collapses and stays green when it grows. So a fourth knob added to the source paragraph leaves AC-4 green while the header silently understates the set the guard requires, and nothing in the file reads the header at all.

That direction is the one a header is least able to defend, and a file header is what a reader consults to learn what a suite is for before reading any assertion that could correct them.

## The repair

Prefer the set to its cardinality, per `.claude/rules/code-comments.md` ("Counts") and `.claude/rules/bats-assertions.md`. The header now names `source_sweep9_knobs` as the authority rather than counting what it returns, which is the same repair the AC-4 rationale comment already carries five lines below the assertion. With no number in the sentence there is nothing left to recount, so the class cannot restart from a fresher figure.

Whether `lint-stale-cardinals.sh` should learn to read spelled-out cardinals stays out of scope, as it was on #1750: it is a checker change with its own noise tradeoff, and it is not required to fix this sentence.

## Verification

- `.gaia/tests/hooks/local-janitor-wiki-doc.bats` under bash 5: 5/5 pass
- `.gaia/tests/shell-lint.sh`: passed
- `.gaia/tests/whole-tree-invariants.sh`: passed
- Quality Gate: skipped, no staged source or gate-affecting config (`.bats` only)
- CHANGELOG: no entry, a maintainer-only test-file comment with no adopter-visible effect

Closes #1777

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Audit disposition

`code-audit-maintainer-shell` cleared this branch on round 1 with no Critical and no Important findings. Three Suggestions, all pre-existing, all on lines this diff does not touch, and none in the logic this change authored. Accepted as residuals:

- **`.gaia/tests/hooks/local-janitor-wiki-doc.bats:147`** — SC2314, a `!`-negated command that is bats-safe only because it is AC-5's terminal statement. No live failure; the risk is positional. Accepted as-is: `.claude/rules/bats-assertions.md` already governs anyone who appends an assertion after it, which is the only way it goes hollow.
- **`.gaia/tests/hooks/local-janitor-wiki-doc.bats:54`** — SC2020, a duplicate character in a `tr` target set. Correct on both BSD and GNU `tr`; legibility only. Accepted as-is.
- **`.gaia/scripts/lint-stale-cardinals.sh:348`** — the deterministic gate for the class this PR repairs carries no `knobs` entry in its NOUN vocabulary, so the removed sentence shipped green. Filed as #1837 rather than folded: a noun outside the closed vocabulary is on that script's own documented FAIL-OPEN list, so it is an invited extension rather than a gate defect, and `.gaia/scripts/**` is gate machinery, so folding it would rotate every member's content digest and buy a round the green gate does not owe.

Filing #1837 also corrects a wrong premise carried by #1777: that issue recorded the miss as green "because `three` is a word rather than a digit". The CARD table at `lint-stale-cardinals.sh:343` does carry spelled cardinals, and `its` is in the DET set at `:338`, so the absent noun is the sole cause.
