### PR TITLE
debt(tests): resolve env-indirected run: paths before the membership test

### DIFF
--- a/.gaia/scripts/tests/workflow-filter-coverage.bats
+++ b/.gaia/scripts/tests/workflow-filter-coverage.bats
@@ -31,10 +31,11 @@
 #   the globs of the filter output that gates it,
 #
 # where "names literally" means a git-tracked file appearing as a whitespace-
-# delimited token in the step's `run:` body, plus the `action.yml` of a local
-# composite action the step `uses:`. Each gated step's own workflow file counts as
-# an input of itself, which is the self-coverage half: a gate must re-run on a
-# change to its own definition.
+# delimited token in the step's `run:` body, after any `$VAR` whose value is a
+# literal string in an `env:` block in scope has been substituted for that value,
+# plus the `action.yml` of a local composite action the step `uses:`. Each gated
+# step's own workflow file counts as an input of itself, which is the
+# self-coverage half: a gate must re-run on a change to its own definition.
 #
 # The following are deliberately out of scope, because each needs a mechanism
 # this floor does not have and a decision this suite should not make on its own
@@ -43,8 +44,12 @@
 #   1. Transitive inputs. A step invoking `run-all.sh` gets that script checked,
 #      not the files the scenarios inside it inspect. Reaching those needs either
 #      a declared-inputs convention on every gated step or a runtime witness.
-#   2. Paths built at runtime. A path assembled from a variable or a glob
-#      expansion is invisible to a token scan, and always will be.
+#   2. Paths built at runtime. A `$VAR/` prefix is resolved when the workflow
+#      states the value outright, in an `env:` block whose value is a literal
+#      string; that much is right there in the file. Everything else stays
+#      invisible to a token scan and always will be: a value that is a `${{ }}`
+#      expression, a name assigned in the shell, a glob expansion, a path
+#      assembled from a variable that is not a whole leading segment.
 #   3. Composite-action bodies. A local action's own `run:` steps are not
 #      descended into; only its `action.yml` is checked.
 #   4. A filter propagated across jobs. The gate scan reads
@@ -179,6 +184,12 @@ GATE = re.compile(r'steps\.([A-Za-z0-9_-]+)\.outputs\.([A-Za-z0-9_-]+)')
 # A shell token that could be a repo-relative path. Deliberately permissive: the
 # tracked-file membership test below is what decides, not this.
 TOKEN = re.compile(r'[A-Za-z0-9_./+-]+')
+# `$NAME` or `${NAME}` in a `run:` body. `$` is outside TOKEN's character class,
+# so an unexpanded reference never survives the scan intact: `$D/x.sh` tokenizes
+# as the untracked `D/x.sh` and `${D}/x.sh` splits at the brace into `D` and
+# `/x.sh`. Either way the path the step really reads is dropped and the step
+# grades as reading nothing but its own workflow file.
+ENV_REF = re.compile(r'\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))')
 
 
 def die(msg):
@@ -302,17 +313,57 @@ def filters_in(steps):
     return found
 
 
-def literal_inputs(step, workflow_rel):
+def literal_env(*scopes):
+    """Merge `env:` mappings, inner scopes last, keeping only literal strings.
+
+    A value holding a `${{ }}` expression resolves at runtime from context this
+    parse cannot see, and a non-string scalar is never a path; both are dropped.
+    An inner scope that redeclares a name drops the outer value with it rather
+    than falling back to it: the outer value is not what the step runs under, so
+    expanding it would name a path the step provably never reads.
+    """
+    merged = {}
+    for scope in scopes:
+        if not isinstance(scope, dict):
+            continue
+        for name, value in scope.items():
+            name = str(name)
+            if isinstance(value, str) and '${{' not in value:
+                merged[name] = value
+            else:
+                merged.pop(name, None)
+    return merged
+
+
+def expand_env(body, env):
+    """Substitute the `env:` values in scope into a `run:` body.
+
+    Single-pass and non-recursive: a value that itself holds a `$NAME` is left
+    with that reference intact, which drops out of the token scan the same way an
+    unresolved name does. A name with no literal value in scope is left verbatim,
+    so this only ever adds paths the workflow states outright.
+    """
+    def resolve(match):
+        return env.get(match.group(1) or match.group(2), match.group(0))
+
+    return ENV_REF.sub(resolve, body)
+
+
+def literal_inputs(step, workflow_rel, outer_env):
     """Repo-relative paths this step names literally.
 
     A `run:` body's comment lines are stripped first: a comment naming a path is
     documentation about the step, not an input to it, and counting it would make
     the guard red on prose.
+
+    `<outer_env>` is the workflow's and job's merged literal `env:`; the step's
+    own overrides it.
     """
     body = str(step.get('run', ''))
     body = '\n'.join(
         line for line in body.splitlines() if not line.lstrip().startswith('#')
     )
+    body = expand_env(body, literal_env(outer_env, step.get('env')))
     inputs = set()
     for token in TOKEN.findall(body):
         if token.startswith('./'):
@@ -369,6 +420,7 @@ for path in sys.argv[3:]:
         steps = job.get('steps') or []
         if not isinstance(steps, list):
             continue
+        job_env = literal_env(doc.get('env'), job.get('env'))
         filters = filters_in(steps)
         for step in steps:
             if not isinstance(step, dict):
@@ -395,7 +447,7 @@ for path in sys.argv[3:]:
             if mode == 'gated':
                 rows.append('\t'.join([workflow_rel, job_id, name]))
                 continue
-            inputs = literal_inputs(step, workflow_rel)
+            inputs = literal_inputs(step, workflow_rel, job_env)
             for step_id, output in gates:
                 globs = filters[step_id].get(output)
                 # dorny/paths-filter accepts a filter value as a bare scalar, not
@@ -851,6 +903,96 @@ YAML
   # unreachable (SC2317). This is also the spelling .claude/rules/bats-assertions.md
   # prescribes for closing a test whose last assertion is the `<bad-case> && return 1`
   # form.
+  true
+}
+
+@test "negative: a gated step's env-indirected path resolves to the file it names" {
+  require_yaml_parser
+  local dir="$BATS_TEST_TMPDIR/sb"
+  mkdir -p "$dir/.github/workflows"
+  # Both spellings, because the token scan mangles them differently: `$VAR/x`
+  # tokenizes as `VAR/x` (a slash-bearing token that is simply untracked), while
+  # `${VAR}/x` splits into `VAR` and `/x`. Neither reaches the membership test as
+  # a path, so an unexpanded body grades the step as reading nothing but its own
+  # workflow file, which is the same silent green a broken token scan gives.
+  cat > "$dir/.github/workflows/fixture.yml" <<'YAML'
+name: Fixture
+on:
+  pull_request:
+jobs:
+  fixture:
+    runs-on: ubuntu-latest
+    env:
+      SCRIPTS_DIR: scripts
+    steps:
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            code:
+              - '.github/workflows/fixture.yml'
+      - if: steps.filter.outputs.code == 'true'
+        name: Gated step
+        run: |
+          bash "$SCRIPTS_DIR/guard.sh"
+          bash "${SCRIPTS_DIR}/other.sh"
+YAML
+  printf '%s\n' \
+    ".github/workflows/fixture.yml" "scripts/guard.sh" "scripts/other.sh" > "$dir/tracked"
+
+  run filter_coverage pairs "$dir/tracked" "$dir/.github/workflows/fixture.yml"
+  [ "$status" -eq 0 ] || { echo "extractor failed: $output" >&2; return 1; }
+
+  local script
+  for script in scripts/guard.sh scripts/other.sh; do
+    printf '%s\n' "$output" | grep -q "^unreached.*$script" || {
+      echo "the guard did not report $script; a path indirected through env: is invisible to it" >&2
+      return 1
+    }
+  done
+}
+
+@test "negative: an env name a step redeclares does not expand to the outer value" {
+  require_yaml_parser
+  local dir="$BATS_TEST_TMPDIR/sb"
+  mkdir -p "$dir/.github/workflows"
+  # The step's own value is a `${{ }}` expression, resolved at runtime from
+  # context this parse cannot see. Falling back to the job's literal would name a
+  # tracked file the step provably never reads: an over-reach, and the one
+  # direction this guard must not have, since it reports a red against a path
+  # nobody can make the filter cover.
+  cat > "$dir/.github/workflows/fixture.yml" <<'YAML'
+name: Fixture
+on:
+  pull_request:
+jobs:
+  fixture:
+    runs-on: ubuntu-latest
+    env:
+      SCRIPTS_DIR: scripts
+    steps:
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            code:
+              - '.github/workflows/fixture.yml'
+      - if: steps.filter.outputs.code == 'true'
+        name: Gated step
+        env:
+          SCRIPTS_DIR: ${{ runner.temp }}/staged
+        run: bash "$SCRIPTS_DIR/guard.sh"
+YAML
+  printf '%s\n' ".github/workflows/fixture.yml" "scripts/guard.sh" > "$dir/tracked"
+
+  run filter_coverage pairs "$dir/tracked" "$dir/.github/workflows/fixture.yml"
+  [ "$status" -eq 0 ] || { echo "extractor failed: $output" >&2; return 1; }
+
+  printf '%s\n' "$output" | grep -q "scripts/guard.sh" && {
+    echo "the step's redeclared env name fell back to the job's value; the guard named a path the step never reads" >&2
+    return 1
+  }
+  # Explicit `true` for the reason the comment-fixture test above gives.
   true
 }
 

--- a/.gaia/scripts/tests/workflow-filter-coverage.bats
+++ b/.gaia/scripts/tests/workflow-filter-coverage.bats
@@ -45,11 +45,13 @@
 #      not the files the scenarios inside it inspect. Reaching those needs either
 #      a declared-inputs convention on every gated step or a runtime witness.
 #   2. Paths built at runtime. A `$NAME` or `${NAME}` reference is resolved
-#      wherever it sits in the body, not only as a leading segment, whenever the
-#      workflow states the value outright in an `env:` block whose value is a
-#      literal string; that much is right there in the file. Everything else
-#      stays invisible to a token scan and always will be: a value that is a
-#      `${{ }}` expression, a name assigned in the shell, and a glob expansion.
+#      wherever it sits in the body, not only as a leading segment, whenever an
+#      `env:` block in scope states the value outright as a literal string; that
+#      much is right there in the file. Every other shape stays invisible to a
+#      token scan and always will be, and the rule generating that set is that
+#      one pass over the file does not answer it: a `${{ }}` value, a name
+#      assigned in the shell, a glob expansion, a value holding another `$NAME`
+#      (the substitution runs once and does not recurse).
 #   3. Composite-action bodies. A local action's own `run:` steps are not
 #      descended into; only its `action.yml` is checked.
 #   4. A filter propagated across jobs. The gate scan reads

--- a/.gaia/scripts/tests/workflow-filter-coverage.bats
+++ b/.gaia/scripts/tests/workflow-filter-coverage.bats
@@ -44,12 +44,12 @@
 #   1. Transitive inputs. A step invoking `run-all.sh` gets that script checked,
 #      not the files the scenarios inside it inspect. Reaching those needs either
 #      a declared-inputs convention on every gated step or a runtime witness.
-#   2. Paths built at runtime. A `$VAR/` prefix is resolved when the workflow
-#      states the value outright, in an `env:` block whose value is a literal
-#      string; that much is right there in the file. Everything else stays
-#      invisible to a token scan and always will be: a value that is a `${{ }}`
-#      expression, a name assigned in the shell, a glob expansion, a path
-#      assembled from a variable that is not a whole leading segment.
+#   2. Paths built at runtime. A `$NAME` or `${NAME}` reference is resolved
+#      wherever it sits in the body, not only as a leading segment, whenever the
+#      workflow states the value outright in an `env:` block whose value is a
+#      literal string; that much is right there in the file. Everything else
+#      stays invisible to a token scan and always will be: a value that is a
+#      `${{ }}` expression, a name assigned in the shell, and a glob expansion.
 #   3. Composite-action bodies. A local action's own `run:` steps are not
 #      descended into; only its `action.yml` is checked.
 #   4. A filter propagated across jobs. The gate scan reads
@@ -915,6 +915,11 @@ YAML
   # `${VAR}/x` splits into `VAR` and `/x`. Neither reaches the membership test as
   # a path, so an unexpanded body grades the step as reading nothing but its own
   # workflow file, which is the same silent green a broken token scan gives.
+  #
+  # The third and fourth put the reference somewhere other than the leading
+  # segment, which is where the header's out-of-scope note used to draw a
+  # boundary the substitution does not actually have. Pinned here so the prose is
+  # a claim that re-checks itself rather than one that decays.
   cat > "$dir/.github/workflows/fixture.yml" <<'YAML'
 name: Fixture
 on:
@@ -924,6 +929,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SCRIPTS_DIR: scripts
+      LEAF: third
+      MIDDLE: nested
     steps:
       - uses: dorny/paths-filter@v4
         id: filter
@@ -936,15 +943,18 @@ jobs:
         run: |
           bash "$SCRIPTS_DIR/guard.sh"
           bash "${SCRIPTS_DIR}/other.sh"
+          bash "scripts/$LEAF.sh"
+          bash "scripts/${MIDDLE}/fourth.sh"
 YAML
   printf '%s\n' \
-    ".github/workflows/fixture.yml" "scripts/guard.sh" "scripts/other.sh" > "$dir/tracked"
+    ".github/workflows/fixture.yml" "scripts/guard.sh" "scripts/other.sh" \
+    "scripts/third.sh" "scripts/nested/fourth.sh" > "$dir/tracked"
 
   run filter_coverage pairs "$dir/tracked" "$dir/.github/workflows/fixture.yml"
   [ "$status" -eq 0 ] || { echo "extractor failed: $output" >&2; return 1; }
 
   local script
-  for script in scripts/guard.sh scripts/other.sh; do
+  for script in scripts/guard.sh scripts/other.sh scripts/third.sh scripts/nested/fourth.sh; do
     printf '%s\n' "$output" | grep -q "^unreached.*$script" || {
       echo "the guard did not report $script; a path indirected through env: is invisible to it" >&2
       return 1


### PR DESCRIPTION
## What

`literal_inputs()` in `.gaia/scripts/tests/workflow-filter-coverage.bats` keeps a `run:` token only when it holds a `/` and is a member of `git ls-files`. A path written through a shell variable never reaches that test as a path: `$D/x.sh` tokenizes as the untracked `D/x.sh`, and `${D}/x.sh` splits at the brace into `D` and `/x.sh`. Both drop, and the gated step grades as reading nothing but its own workflow file.

A step whose scripts are indirected that way is then unarmed against a filter that does not reach them, and the guard that exists to catch exactly that reports green.

## How

Substitute `$NAME` / `${NAME}` for the value the workflow states outright, in a workflow-, job-, or step-level `env:` block, before the membership test runs. The membership test's real job is untouched, which the issue was explicit about: it exists to keep git refs, URL fragments, absolute system paths, and bare directory prefixes out of the input set, and it still does.

Only a name whose value is a **literal string** resolves. A `${{ }}` expression, a name assigned in the shell, and a glob expansion all stay invisible, which is this guard's deliberate under-reaching bias. A scope that redeclares a name drops the outer value with it rather than falling back to it, so the extractor never names a path the step provably never reads: that is the one over-reach direction the change could have introduced, and the second new test pins it.

The header's out-of-scope note (item 2, paths built at runtime) and the "names literally" definition are both narrowed to match what the extractor now does.

## Verification

- `.gaia/scripts/tests/workflow-filter-coverage.bats` 18/18 green under bash 5, including cases 3-7 over the live tree.
- Both new tests were driven into their failing state before being relied on: the expansion test reds against the pre-change extractor, and the shadowing test reds against a build with the inner-scope drop removed.
- `bash .gaia/tests/shell-lint.sh` clean; `bash .gaia/tests/whole-tree-invariants.sh` passes.

## Blast radius

No verdict on the live tree changes. No gated step indirects a path through `env:` today, which is what makes this arming rather than a repair. `forensics-triage.yml` is full of the shape (a job-level `FORENSICS_DIR` in front of a dozen-odd tracked scripts) and escapes only because that job runs no paths-filter step at all.

The suite is release-excluded and absent from `.gaia/manifest.json`, so nothing adopter-facing changes and no CHANGELOG entry is owed.


## Audit rounds

Three rounds, each clean with a marker written. Rounds 1 and 2 each returned one Suggestion on the header's out-of-scope item 2, both applied:

- **Round 1**: item 2 claimed a reference which is not a whole leading segment stays invisible, but the substitution has no positional anchor. Repaired in `63dd4458`, which also put both off-leading-segment shapes into the expansion fixture so the claim re-checks itself.
- **Round 2**: the round-1 rewrite ended item 2's list with an `and`, closing a set that omits an `env:` value holding another `$NAME`. Repaired in `c3b015f5` by stating the rule that generates the set rather than naming the fourth case.
- **Round 3**: no finding on this change. Its two Suggestions are on a file this PR does not touch, recorded below.

The disposition for round 3 was pre-committed in a comment on this PR before the round ran.

## Out-of-scope machinery findings (recorded, not filed)

Both sit on `.gaia/tests/hooks/local-janitor-wiki-doc.bats`, which reached this branch through the catch-up merge of `origin/main` and is absent from this PR's own diff against its fork point. Each is latent at that fork point, reads the same whether or not this change lands, and sits on a gate-machinery path, so both are waived rather than filed. No pointer to either is written into shipped content.

- `.gaia/tests/hooks/local-janitor-wiki-doc.bats:147` — SC2314: an absence assertion written as a bare `!`-negated `grep`. It gates today only because it is the test's final command; a line appended after it would make `set -e` exempt the negation and the assertion would stop failing, silently. Dedup key: `holistic/unclassified` at `.gaia/tests/hooks/local-janitor-wiki-doc.bats:147`.
- `.gaia/tests/hooks/local-janitor-wiki-doc.bats:54` — SC2020: `tr` with two-character sets reads as a likely word-replacement mistake. The character-set semantics are the intent here and the adjacent comment says so, so there is no live failure mode; recorded because the oracle is authoritative on whether a hit is real. Dedup key: `holistic/unclassified` at `.gaia/tests/hooks/local-janitor-wiki-doc.bats:54`.

Closes #1784

🤖 Generated with [Claude Code](https://claude.com/claude-code)
