### PR TITLE
debt(cli): give escapeRegExp one home and pin its escape set

### DIFF
--- a/.gaia/cli/gaia
+++ b/.gaia/cli/gaia
@@ -17175,11 +17175,14 @@ var windowClasses = (prs) => {
 import { readdirSync, readFileSync as readFileSync7 } from "node:fs";
 import path8 from "node:path";
 
+// src/util/escape-regexp.ts
+var METACHARACTERS = /[.*+?^${}()|[\]\\]/g;
+var escapeRegExp = (value) => value.replaceAll(METACHARACTERS, String.raw`\$&`);
+
 // src/harden/marker.ts
 var MARKER_PREFIX = "gaia-harden: promoted from recurring finding_class";
 
 // src/harden/covered-classes.ts
-var escapeRegExp = (value) => value.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 var tryReadFile = (filePath) => {
   try {
     return readFileSync7(filePath, "utf8");

--- a/.gaia/cli/gaia-maintainer
+++ b/.gaia/cli/gaia-maintainer
@@ -22636,6 +22636,10 @@ import { execFileSync as execFileSync2 } from "node:child_process";
 import { existsSync as existsSync16, readFileSync as readFileSync19 } from "node:fs";
 import path22 from "node:path";
 
+// src/util/escape-regexp.ts
+var METACHARACTERS = /[.*+?^${}()|[\]\\]/g;
+var escapeRegExp = (value) => value.replaceAll(METACHARACTERS, String.raw`\$&`);
+
 // src/release/manifest-answers.ts
 var CATEGORY_HEADER = /^# --- (\d+)\. (.+?) ---\s*$/;
 var REJECTED_PATH_CHARACTERS = [
@@ -22974,7 +22978,6 @@ var WIKI_OWNED_PREFIXES = [
   "wiki/sources/"
 ];
 var WIKI_OWNED_EXACT = /* @__PURE__ */ new Set(["wiki/overview.md", "wiki/README.md"]);
-var escapeRegExp = (pattern) => pattern.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 var parseExcludeLines = (text) => text.split("\n").flatMap((line) => {
   const trimmed = line.trim();
   if (trimmed.length === 0 || trimmed.startsWith("#")) return [];
@@ -25476,7 +25479,6 @@ var runDerivedWorkflowCheck = ({
     }))
   );
 };
-var TITLE_ESCAPE = /[.*+?^${}()|[\]\\]/g;
 var WIKILINK_SPAN = /\[\[[^[\]]*\]\]/g;
 var INLINE_CODE_SPAN = /`[^`]*`/g;
 var addTitlesForExcludeLine = (line, cwd, addTitle) => {
@@ -25501,8 +25503,7 @@ var buildExcludedTitleSet = (cwd) => {
   }
   return titles;
 };
-var escapeTitle = (title) => title.replaceAll(TITLE_ESCAPE, String.raw`\$&`);
-var titleToRegex = (title) => new RegExp(String.raw`(?<![\w-])${escapeTitle(title)}(?![\w-])`);
+var titleToRegex = (title) => new RegExp(String.raw`(?<![\w-])${escapeRegExp(title)}(?![\w-])`);
 var isFenceDelimiter = (line) => {
   const trimmed = line.trim();
   return trimmed.startsWith("```") || trimmed.startsWith("~~~");

--- a/.gaia/cli/src/automation/__tests__/gaia-ci-template-refs.test.ts
+++ b/.gaia/cli/src/automation/__tests__/gaia-ci-template-refs.test.ts
@@ -68,6 +68,7 @@ import {describe, expect, test} from 'vitest';
 import {existsSync, readdirSync, readFileSync} from 'node:fs';
 import path from 'node:path';
 import type {ToolId} from '../../schemas/automation-config.js';
+import {escapeRegExp} from '../../util/escape-regexp.js';
 import {matchesShippedInvocation} from '../../util/gaia-invocation-matcher.js';
 import {resolveRepoRootFromImportMeta} from '../../util/repo-root-fixture.js';
 import {workflowSchedulerTemplatePath, workflowTemplatePath} from '../paths.js';
@@ -103,9 +104,6 @@ const templatePathFor = (key: TemplateKey): string =>
   key === 'scheduler' ?
     workflowSchedulerTemplatePath()
   : workflowTemplatePath(key);
-
-const escapeRegExp = (value: string): string =>
-  value.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 
 // A router recognizes a dispatch token when the token is a
 // `SUBCOMMAND_HANDLERS` map key (`'token': runX`) or an inline

--- a/.gaia/cli/src/harden/covered-classes.ts
+++ b/.gaia/cli/src/harden/covered-classes.ts
@@ -12,10 +12,8 @@
  */
 import {readdirSync, readFileSync} from 'node:fs';
 import path from 'node:path';
+import {escapeRegExp} from '../util/escape-regexp.js';
 import {MARKER_PREFIX} from './marker.js';
-
-const escapeRegExp = (value: string): string =>
-  value.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 
 // Returns null for an unreadable file rather than throwing, so one bad rule
 // file doesn't abort the whole scan.

--- a/.gaia/cli/src/release/manifest.ts
+++ b/.gaia/cli/src/release/manifest.ts
@@ -20,6 +20,7 @@ import {z} from 'zod';
 import {execFileSync} from 'node:child_process';
 import {existsSync, readFileSync} from 'node:fs';
 import path from 'node:path';
+import {escapeRegExp} from '../util/escape-regexp.js';
 import {gitZArgs, splitZStream} from '../util/git-z.js';
 import {resolveRepoRoot} from '../util/repo-root.js';
 import {hasRejectedExcludeMetacharacter} from './manifest-answers.js';
@@ -76,16 +77,6 @@ const WIKI_OWNED_PREFIXES = [
 const WIKI_OWNED_EXACT = new Set(['wiki/overview.md', 'wiki/README.md']);
 
 export type ManifestClass = 'owned' | 'shared' | 'wiki-owned';
-
-// Escapes every regex metacharacter, including `*`. `.gaia/release-exclude`
-// entries are literal paths, matched the same way by the shell staging
-// pipeline (`release.yml`) and the distribution bats suite; a compiler that
-// rewrote `*` into a glob, or left `[](){}^$|` unescaped, would silently
-// disagree with both of them (or crash on a bracketed path). See
-// `validateExcludeText` below, which is the loud-rejection half of the same
-// fix: this escaping is defense-in-depth for any direct caller.
-const escapeRegExp = (pattern: string): string =>
-  pattern.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 
 /**
  * Trimmed, non-blank, non-comment lines from a `.gaia/release-exclude` body.
@@ -145,6 +136,14 @@ export const validateExcludeText = (text: string): void => {
  * Emitted from the string form, NOT `RegExp.prototype.source`: `.source` escapes
  * `/` to `\/` and renders the empty pattern as `(?:)`, which would diverge from
  * the shell `awk | sed | awk` text on every slash-bearing line.
+ *
+ * `escapeRegExp` escapes every metacharacter, `*` included, because
+ * `.gaia/release-exclude` entries are literal paths matched the same way by the
+ * shell staging pipeline (`release.yml`) and the distribution bats suite; a
+ * compiler that rewrote `*` into a glob, or left `[](){}^$|` unescaped, would
+ * silently disagree with both of them (or crash on a bracketed path). See
+ * `validateExcludeText` below, which is the loud-rejection half of the same
+ * fix: this escaping is defense-in-depth for any direct caller.
  */
 export const compileExcludeRegexStrings = (text: string): string[] =>
   parseExcludeLines(text).map((line) => `^${escapeRegExp(line)}(/|$)`);

--- a/.gaia/cli/src/release/scrub.ts
+++ b/.gaia/cli/src/release/scrub.ts
@@ -45,6 +45,7 @@ import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
 import {takeValue} from '../util/argv.js';
 import {atomicWriteFileSync} from '../util/atomic-write.js';
+import {escapeRegExp} from '../util/escape-regexp.js';
 import {extractWikilinks} from '../wiki/util/wikilinks.js';
 import {parseExcludeLines} from './manifest.js';
 import {stripMarkerBlocks} from './marker-strip.js';
@@ -1083,10 +1084,6 @@ const runDerivedWorkflowCheck = ({
 
 // Derived excluded-titles check
 
-// Literal regex-escape set for a title body. Matches `escapeRegExp` in
-// `manifest.js`: `-` is deliberately absent, harmless as a literal outside a
-// character class, and the token boundaries below handle hyphen adjacency.
-const TITLE_ESCAPE = /[.*+?^${}()|[\]\\]/g;
 // Exclude BOTH brackets from the inner class: a wikilink target never contains
 // one, and excluding `[` keeps overlapping `[[` prefixes from forcing a rescan
 // (linear, not polynomial).
@@ -1144,15 +1141,14 @@ const buildExcludedTitleSet = (cwd: string): Set<string> => {
   return titles;
 };
 
-const escapeTitle = (title: string): string =>
-  title.replaceAll(TITLE_ESCAPE, String.raw`\$&`);
-
 // Case-sensitive (no `i` flag), whole-token: alphanumerics AND hyphens are
 // token-internal, so `Bundle-time Scrub` never fires inside `Bundle-time
 // Scrubbing` and `CLI-Binary-Split` never fires inside `CLI-Binary-Split-Extra`
-// or `Pre-CLI-Binary-Split`.
+// or `Pre-CLI-Binary-Split`. The boundaries are also why the shared escaper's
+// omission of `-` is safe here: hyphen adjacency is decided by them, not by
+// the escape set.
 const titleToRegex = (title: string): RegExp =>
-  new RegExp(String.raw`(?<![\w-])${escapeTitle(title)}(?![\w-])`);
+  new RegExp(String.raw`(?<![\w-])${escapeRegExp(title)}(?![\w-])`);
 
 // A fence delimiter opens or closes a fenced code block: a line whose trimmed
 // text begins with three backticks or three tildes.

--- a/.gaia/cli/src/util/escape-regexp.test.ts
+++ b/.gaia/cli/src/util/escape-regexp.test.ts
@@ -2,7 +2,10 @@
  * Strategy: `escapeRegExp` is pure, so every case calls it directly. What this
  * suite owns is the **escape set itself**, which is the reason the helper has
  * one home: its call sites build guards whose matching behaviour is decided by
- * which characters get escaped, and no call site asserts that set.
+ * which characters get escaped. Only `exclude-parser-parity.test.ts` pins the
+ * whole set today, and it does so through one call site, against the shell
+ * reference pipeline rather than against this module; the remaining callers
+ * keep passing their own suites with a wrong set.
  *
  * The set is pinned two ways on purpose. The character-by-character table is
  * the readable statement of intent; the round-trip cases are the ones that
@@ -90,8 +93,11 @@ describe('escapeRegExp', () => {
     // An unescaped `[` opens a character class the input never closes, so the
     // `new RegExp` call itself throws. A caller compiling a user-supplied path
     // gets a crash rather than a wrong match.
-    expect(
-      () => new RegExp(escapeRegExp('wiki/[draft].md'), 'u')
-    ).not.toThrow();
+    //
+    // The bracket is deliberately unclosed. A balanced `[draft]` compiles as a
+    // character class whether or not the brackets were escaped, so this case
+    // would stay green with `[` and `]` dropped from the set, asserting
+    // nothing while naming the construct it cannot detect.
+    expect(() => new RegExp(escapeRegExp('wiki/[draft.md'), 'u')).not.toThrow();
   });
 });

--- a/.gaia/cli/src/util/escape-regexp.test.ts
+++ b/.gaia/cli/src/util/escape-regexp.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Strategy: `escapeRegExp` is pure, so every case calls it directly. What this
+ * suite owns is the **escape set itself**, which is the reason the helper has
+ * one home: its call sites build guards whose matching behaviour is decided by
+ * which characters get escaped, and no call site asserts that set.
+ *
+ * The set is pinned two ways on purpose. The character-by-character table is
+ * the readable statement of intent; the round-trip cases are the ones that
+ * would actually catch a wrong escape, because a metacharacter that survives
+ * unescaped still produces a *valid* regex, just one that matches the wrong
+ * strings.
+ */
+import {describe, expect, test} from 'vitest';
+import {escapeRegExp} from './escape-regexp.js';
+
+// Written as an escaped literal rather than `String.raw`: a template whose
+// body ends in a backslash escapes its own closing backtick and will not parse.
+const BACKSLASH = '\\';
+
+// Every metacharacter the helper escapes.
+const ESCAPED = [
+  '.',
+  '*',
+  '+',
+  '?',
+  '^',
+  '$',
+  '{',
+  '}',
+  '(',
+  ')',
+  '|',
+  '[',
+  ']',
+  BACKSLASH,
+];
+
+// `-` is deliberately absent from the set: it is a metacharacter only inside a
+// character class, and no caller interpolates into one. Callers that need
+// hyphen adjacency handled bound it with their own token boundaries instead.
+const NOT_ESCAPED = [
+  '-',
+  'a',
+  'Z',
+  '0',
+  '_',
+  '/',
+  ' ',
+  ':',
+  '#',
+  '@',
+  '=',
+  ',',
+];
+
+describe('escapeRegExp', () => {
+  test.each(ESCAPED)('escapes %s', (character) => {
+    expect(escapeRegExp(character)).toBe(`${BACKSLASH}${character}`);
+  });
+
+  test.each(NOT_ESCAPED)('leaves %s alone', (character) => {
+    expect(escapeRegExp(character)).toBe(character);
+  });
+
+  test('escapes every occurrence, not just the first', () => {
+    expect(escapeRegExp('a.b.c')).toBe(String.raw`a\.b\.c`);
+  });
+
+  test('returns the empty string unchanged', () => {
+    expect(escapeRegExp('')).toBe('');
+  });
+
+  test('the escaped form matches its own input literally', () => {
+    const literal = `wiki/A (draft) [v1] {2}.md|*+?^$${BACKSLASH}x`;
+
+    expect(new RegExp(`^${escapeRegExp(literal)}$`, 'u').test(literal)).toBe(
+      true
+    );
+  });
+
+  test('the escaped form does not match a string the metacharacters would', () => {
+    // Unescaped, `a.c` matches `abc` and `a+` matches `aaa`. Escaped, neither
+    // does: this is the failure a missing metacharacter produces, and it is
+    // silent, because the wrong pattern is still a valid regex.
+    expect(new RegExp(`^${escapeRegExp('a.c')}$`, 'u').test('abc')).toBe(false);
+    expect(new RegExp(`^${escapeRegExp('a+')}$`, 'u').test('aaa')).toBe(false);
+  });
+
+  test('an escaped path with a bracket compiles instead of throwing', () => {
+    // An unescaped `[` opens a character class the input never closes, so the
+    // `new RegExp` call itself throws. A caller compiling a user-supplied path
+    // gets a crash rather than a wrong match.
+    expect(
+      () => new RegExp(escapeRegExp('wiki/[draft].md'), 'u')
+    ).not.toThrow();
+  });
+});

--- a/.gaia/cli/src/util/escape-regexp.ts
+++ b/.gaia/cli/src/util/escape-regexp.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared regex-literal escaper.
+ *
+ * One copy, because the escape set is a correctness boundary rather than a
+ * formatting nicety. Every caller feeds the result into `new RegExp(...)`
+ * built from a token it did not choose, so a character class that is right in
+ * one copy and stale in another silently changes which strings a guard
+ * matches. That failure is invisible at the call site: the wrong pattern is
+ * still a *valid* regex, it just matches (or refuses) a token its sibling
+ * handles the other way.
+ *
+ * `escape-regexp.test.ts` beside this file is the assertion that set is what
+ * it claims to be. No call site asserts it: most of them are guards whose
+ * matching behaviour depends on it, and a guard that matches the wrong set
+ * still passes its own suite.
+ */
+
+/**
+ * `value` with every regex metacharacter escaped, safe to interpolate into a
+ * pattern as a literal.
+ *
+ * `*` is escaped along with the rest: a caller compiling a literal path would
+ * otherwise have it silently rewritten into a glob. `[](){}^$|` are escaped
+ * both to keep them literal and because leaving `[` unescaped opens a
+ * character class the input never closes, which makes `new RegExp` throw
+ * rather than mismatch.
+ *
+ * `-` is deliberately absent. It is a metacharacter only inside a character
+ * class, and no caller interpolates into one; a caller that needs hyphen
+ * adjacency handled bounds it with its own token boundaries instead.
+ */
+// Hoisted rather than written inline: a literal in the function body
+// constructs a fresh RegExp on every call. Sharing one `g`-flagged object
+// across callers is safe because `replaceAll` resets `lastIndex` before it
+// matches, so no call can observe another's scan position.
+const METACHARACTERS = /[.*+?^${}()|[\]\\]/g;
+
+export const escapeRegExp = (value: string): string =>
+  value.replaceAll(METACHARACTERS, String.raw`\$&`);

--- a/.gaia/cli/src/util/escape-regexp.ts
+++ b/.gaia/cli/src/util/escape-regexp.ts
@@ -9,11 +9,13 @@
  * *valid* regex, it just matches (or refuses) a token its sibling handles the
  * other way.
  *
- * The release exclude-regex path is the caller that does not compile: it emits
- * the escaped text on stdout for the shell staging pipeline to read as POSIX
- * ERE. So the set has to stay portable across both consumers, and a
- * JavaScript-only escape added here (`/` as `\/`, a `\u{...}` form) would break
- * a parity contract no `new RegExp` caller can see.
+ * The release exclude path is the strictest caller, because one set of escaped
+ * strings feeds two consumers that read them under different grammars:
+ * `renderExcludeRegex` writes them to stdout for the shell staging pipeline to
+ * read as POSIX ERE, and `parseExcludePatterns` compiles the same strings with
+ * `new RegExp`. So the set has to satisfy both, and a JavaScript-only escape
+ * added here (`/` as `\/`, a `\u{...}` form) breaks a parity contract the
+ * compiling consumer cannot see.
  *
  * `exclude-parser-parity.test.ts` is the only call-site suite that pins the
  * whole set today, and only through that one path, against the shell reference

--- a/.gaia/cli/src/util/escape-regexp.ts
+++ b/.gaia/cli/src/util/escape-regexp.ts
@@ -2,18 +2,31 @@
  * Shared regex-literal escaper.
  *
  * One copy, because the escape set is a correctness boundary rather than a
- * formatting nicety. Every caller feeds the result into `new RegExp(...)`
- * built from a token it did not choose, so a character class that is right in
- * one copy and stale in another silently changes which strings a guard
- * matches. That failure is invisible at the call site: the wrong pattern is
- * still a *valid* regex, it just matches (or refuses) a token its sibling
- * handles the other way.
+ * formatting nicety. Most callers feed the result into `new RegExp(...)` built
+ * from a token they did not choose, so a character class that is right in one
+ * copy and stale in another silently changes which strings a guard matches.
+ * That failure is invisible at the call site: the wrong pattern is still a
+ * *valid* regex, it just matches (or refuses) a token its sibling handles the
+ * other way.
  *
- * `escape-regexp.test.ts` beside this file is the assertion that set is what
- * it claims to be. No call site asserts it: most of them are guards whose
- * matching behaviour depends on it, and a guard that matches the wrong set
- * still passes its own suite.
+ * The release exclude-regex path is the caller that does not compile: it emits
+ * the escaped text on stdout for the shell staging pipeline to read as POSIX
+ * ERE. So the set has to stay portable across both consumers, and a
+ * JavaScript-only escape added here (`/` as `\/`, a `\u{...}` form) would break
+ * a parity contract no `new RegExp` caller can see.
+ *
+ * `exclude-parser-parity.test.ts` is the only call-site suite that pins the
+ * whole set today, and only through that one path, against the shell reference
+ * rather than against this module. The remaining callers are guards that keep
+ * passing their own suites with a wrong set, which is what
+ * `escape-regexp.test.ts` beside this file exists to assert directly.
  */
+
+// Hoisted rather than written inline: a literal in the function body
+// constructs a fresh RegExp on every call. Sharing one `g`-flagged object
+// across callers is safe because `replaceAll` resets `lastIndex` before it
+// matches, so no call can observe another's scan position.
+const METACHARACTERS = /[.*+?^${}()|[\]\\]/g;
 
 /**
  * `value` with every regex metacharacter escaped, safe to interpolate into a
@@ -29,11 +42,5 @@
  * class, and no caller interpolates into one; a caller that needs hyphen
  * adjacency handled bounds it with its own token boundaries instead.
  */
-// Hoisted rather than written inline: a literal in the function body
-// constructs a fresh RegExp on every call. Sharing one `g`-flagged object
-// across callers is safe because `replaceAll` resets `lastIndex` before it
-// matches, so no call can observe another's scan position.
-const METACHARACTERS = /[.*+?^${}()|[\]\\]/g;
-
 export const escapeRegExp = (value: string): string =>
   value.replaceAll(METACHARACTERS, String.raw`\$&`);

--- a/.gaia/cli/src/util/gaia-invocation-matcher.ts
+++ b/.gaia/cli/src/util/gaia-invocation-matcher.ts
@@ -30,8 +30,7 @@
  * adopter clone carries neither this module nor its consumers.
  */
 
-const escapeRegExp = (value: string): string =>
-  value.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+import {escapeRegExp} from './escape-regexp.js';
 
 // An invocation-shaped string for `commandPath` in `text`: the binary name,
 // optionally closed by a quote, then the space-separated path, bounded so


### PR DESCRIPTION
## What

`escapeRegExp` had four byte-identical private declarations across the CLI tree, plus a fifth copy of the same character class living as `scrub.ts`'s `TITLE_ESCAPE` (whose own comment said it "matches `escapeRegExp` in `manifest.js`"). Each fed a caller-supplied token into `new RegExp(...)`, so the escape set is a correctness boundary rather than a formatting nicety: a metacharacter added to one copy and not the others silently changes which strings a guard matches, and the wrong pattern is still a *valid* regex, so nothing throws and no suite reds.

This gives the helper one definition at `.gaia/cli/src/util/escape-regexp.ts` and points every site at it.

## Decisions the issue left open

Both were called out on the issue and both are answered here:

- **The shared contract covers `manifest.ts`'s "defense-in-depth for any direct caller" use.** That rationale is about *why the exclude compiler escapes at all*, not about a different escape set, so it moves to `compileExcludeRegexStrings`, its only caller, rather than into the shared module. The shared module carries the set's own rationale instead.
- **The shared module earns its own test.** Most call sites are guards whose matching behaviour the set decides, and none of them asserted it. `escape-regexp.test.ts` pins the set two ways: a character-by-character table for readable intent, and round-trip cases that would actually catch a wrong escape (`escapeRegExp('a.c')` must not match `abc`; a bracketed path must compile rather than throw).

`scrub.ts`'s `TITLE_ESCAPE` was not named in the issue's four, but it is the same character class in the same subsystem, and leaving it would have been a half-fix of the exact drift this consolidates away. Its hyphen-boundary comment now says why the shared escaper's omission of `-` is safe at that site.

## Bundles

This edits `.gaia/cli/src/**`, so `.gaia/cli/gaia` and `.gaia/cli/gaia-maintainer` are rebuilt and committed. No local gate checks that (`verify-cli-bundle-fresh.sh` is excluded from `whole-tree-invariants.sh` and runs only in CI), so it was run deliberately and verified green.

## Verification

Quality Gate green end to end: root and CLI typecheck, root and CLI lint, 2496 CLI tests, 159 root tests, 8 Playwright specs, dev-server smoke (HTTP 200), production build. `whole-tree-invariants.sh` passes. `verify-cli-bundle-fresh.sh` passes.

## Filed as separate debt

`/simplify`'s altitude pass flagged that the consolidation leaves no machine gate against a fifth private copy arriving later (`sonarjs/no-identical-functions` cannot see a one-line arrow function, and no existing runner scans TypeScript for it). That carries its own mechanism and pattern-scope decision on top of a new runner registration, so it is filed as #1834 rather than folded in.

Closes #1756

🤖 Generated with [Claude Code](https://claude.com/claude-code)
