### PR TITLE
debt(audit): give resolve-audit-base's library loop a directive that covers it

### DIFF
--- a/.github/audit/resolve-audit-base.sh
+++ b/.github/audit/resolve-audit-base.sh
@@ -454,6 +454,7 @@ delta_for() {
 lib_dir="${repo_root}/.claude/hooks/lib"
 for lib_file in audit-scope.sh audit-machinery.sh audit-rules-changed.sh audit-clearance.sh; do
   if [ -f "${lib_dir}/${lib_file}" ]; then
+    # shellcheck source=/dev/null
     . "${lib_dir}/${lib_file}" 2>/dev/null || true
   fi
 done


### PR DESCRIPTION
## What

`.github/audit/resolve-audit-base.sh:457` sources `"${lib_dir}/${lib_file}"`, a path built from two variables, with no shellcheck directive. A bare `shellcheck .github/audit/resolve-audit-base.sh` reported `SC1090 (warning): ShellCheck can't follow non-constant source.` there.

Added the `# shellcheck source=/dev/null` form every sibling dynamic-source site in `.claude/hooks` and `.gaia/scripts` already uses (`pr-merge-audit-check.sh`, `block-worktree-path-mismatch.sh`, `block-fourth-audit-round.sh`, `worthiness-presence-check.sh`, and others).

## Why it matters

There is no live failure mode: `.gaia/tests/shell-lint.sh` sets `TOOLING_EXCLUDE=SC1091,SC1090`, so the deterministic gate was silent either way. What it cost is that the bare `shellcheck <file>` invocation, which is exactly the path the `code-audit-maintainer-shell` oracle takes, read noisy at this one site while every comparable site read clean, leaving a future auditor to triage a stale oracle hit. This was the last `SC1090` in the tree after #1746 / PR #1798 closed the sibling instance in `.claude/hooks/local-janitor.sh`.

## Verification

- **Before:** `shellcheck -S style -f gcc .github/audit/resolve-audit-base.sh` → `SC1090` at line 457.
- **After:** same command → clean.
- **Tree-wide re-derivation:** `git ls-files -- '*.sh' | xargs shellcheck -S style -f gcc` over all 246 tracked scripts → **0** `SC1090` (was exactly 1, at the cited line, which re-derives the issue's sole-survivor premise). The issue's "242 tracked" figure is now 246; the count the fix depends on, the number of surviving instances, re-derives exactly.
- `bash .gaia/tests/shell-lint.sh` → passed, every lens clean.
- `bash .gaia/tests/whole-tree-invariants.sh` → all invariants pass.
- Bats under bash 5 (`.gaia/scripts/bats5.sh`): `check-audit-base-derivation.bats` + `audit-base-agreement.bats` → 79/79 pass; `resolve-audit-members.bats` + `audit-machinery-lib.bats` → 45/45 pass.
- Quality Gate: skipped by its own rule; the sole staged file is `.sh`, matching no source or gate-affecting-config pattern.

## CHANGELOG

No `## [Unreleased]` entry. The change is a comment directive with no behavioral or adopter-visible effect, the same disposition PR #1798 took for the sibling instance.

Closes #1801

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Audit disposition

`code-audit-maintainer-shell` cleared this diff (earned marker, zero Critical, zero Important) and surfaced one out-of-scope Suggestion: `.github/audit/tests/resolve-audit-base.bats:1063`, where the four `degraded: <lib> cannot be sourced` tests all route through a helper whose fixture *deletes* the lib, so they exercise only the absent-file arm and never the present-but-unparseable one, which under `set -euo pipefail` abandons the shell at the load instead of degrading to full scope.

**Filed as #1846, not waived.** Neither waive term fires: the cited path is not gate machinery (`audit_path_is_machinery` returns false for `.github/audit/tests/**`, unlike `.github/audit/resolve-audit-base.sh` itself), and this pull request does not change it. Both disqualifiers clear as well, this change authors nothing about that gap and leaves no pointer in shipped content, so with no eligible path term the finding routes to the normal filing path.
