### PR TITLE
debt(tests): drive the assert4 environment aggregation, both halves

### DIFF
--- a/.gaia/scripts/tests/check-scope-digest-adoption.bats
+++ b/.gaia/scripts/tests/check-scope-digest-adoption.bats
@@ -557,7 +557,7 @@ EOF
 # mirroring shape, rather than a stub directory holding just the binaries the
 # check needs. That helper's header states the criterion: which shape fits is
 # decided by whether the subject's binary needs are enumerable. This check is a
-# large shell program reaching for git, sed, awk and grep among others, so its
+# large shell program reaching for awk, grep and find among others, so its
 # needs are not enumerable, and an allowlist that missed one would fail as a
 # missing-tool error inside the fixture rather than on the arm under test.
 

--- a/.gaia/scripts/tests/check-scope-digest-adoption.bats
+++ b/.gaia/scripts/tests/check-scope-digest-adoption.bats
@@ -23,6 +23,8 @@ setup() {
   SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
   CHECK="$SCRIPT_DIR/check-scope-digest-adoption.sh"
   REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+  # shellcheck source=.gaia/tests/helpers/path.sh
+  . "$REPO_ROOT/.gaia/tests/helpers/path.sh"
   # shellcheck source=.gaia/scripts/check-scope-digest-adoption.sh
   source "$CHECK"
   FIXTURE_REPOS=()
@@ -538,6 +540,52 @@ EOF
   run gaia_check_scope_digest_adoption "$repo"
   [ "$status" -eq 1 ]
   grep -qF '.github/workflows/fake-audit.yml: unmatched backtick truncated the scan' <<<"$output" || return 1
+}
+
+# The environment arm, and the aggregation that decides what a run reports
+# when it fires. `_gaia_sda_assert4` returns 2 when `jq` is absent, and
+# `gaia_check_scope_digest_adoption` RECORDS that rather than returning on the
+# spot, because assertion 4 runs after the earlier assertions have already
+# found whatever they found: returning 2 from there would discard a real
+# finding and send the operator to install jq while the tree still needs
+# repairing. Both halves of that contract are driven below, and neither was
+# reachable from any other test here -- the malformed-settings case exercises
+# the arm below the jq one, and exits 1 identically with or without the
+# aggregation, so it stands behind nothing.
+#
+# The shim is `path_shim_without` from `.gaia/tests/helpers/path.sh`, the
+# mirroring shape, rather than a stub directory holding just the binaries the
+# check needs. That helper's header states the criterion: which shape fits is
+# decided by whether the subject's binary needs are enumerable. This check is a
+# large shell program reaching for git, sed, awk and grep among others, so its
+# needs are not enumerable, and an allowlist that missed one would fail as a
+# missing-tool error inside the fixture rather than on the arm under test.
+
+@test "environment: jq absent on an otherwise-clean tree exits 2 rather than passing" {
+  local repo
+  # Built before the shim: the fixture builder is git, and it has no business
+  # running against a rebuilt PATH.
+  repo="$(make_fixture_repo jq-absent-healthy)"
+  PATH="$(path_shim_without jq)"
+  run gaia_check_scope_digest_adoption "$repo"
+  [ "$status" -eq 2 ]
+  grep -qF 'jq not found; assertion 4 cannot read .claude/settings.json' <<<"$output" || return 1
+}
+
+@test "environment: jq absent alongside an assertion-1 defect exits 1 and still names the defect" {
+  local repo
+  repo="$(make_fixture_repo jq-absent-defective)"
+  perl -0pi -e 's/ --scope-digest "\$D_SCOPE"//g' \
+    "$repo/.claude/agents/code-audit-maintainer-prose.md"
+  git -C "$repo" add -A
+  git -C "$repo" commit -q -m mutate
+  PATH="$(path_shim_without jq)"
+  run gaia_check_scope_digest_adoption "$repo"
+  # 1, not 2. The environment note is real and still printed, but a status of 2
+  # would report the missing tool as the run's verdict and bury the finding.
+  [ "$status" -eq 1 ]
+  grep -qF '.claude/agents/code-audit-maintainer-prose.md: earned call site missing --scope-digest' <<<"$output" || return 1
+  grep -qF 'jq not found; assertion 4 cannot read .claude/settings.json' <<<"$output" || return 1
 }
 
 @test "usage: a fixture with no scan surface exits 2 rather than passing vacuously" {


### PR DESCRIPTION
Closes #1818

## What

`gaia_check_scope_digest_adoption` records a missing `jq` as `assert4_env` rather than returning 2 on the spot, so an environment note cannot hide a defect assertions 1-3 already found. The flag was written in exactly one place and read in exactly one place, and nothing in `.gaia/scripts/tests/check-scope-digest-adoption.bats` drove either, so neither half of the contract was pinned.

Two bats cases close that:

- `jq` absent on an otherwise-clean fixture still exits **2**.
- `jq` absent alongside an assertion-1 defect exits **1** and still names the defect.

No production code changes. The check script is byte-identical to `main`.

## Guards-must-fail

Each case was driven red against its own mutation before being relied on, and the first is the exact mutation the issue names:

| Mutation | Result |
| --- | --- |
| Collapse the final read (`[ "$assert4_env" -eq 0 ] \|\| return 2`) to a bare `return 0` | case 1 reds, case 2 stays green |
| Return 2 on the spot instead of setting `assert4_env=1` | case 2 reds, case 1 stays green |

Restored, both green: the suite runs 24/24 under bash 5.

## Seam

The issue's body left the seam as an open choice; a comment on it settled the fork, and this follows the comment. The shim is `path_shim_without` from the shared `.gaia/tests/helpers/path.sh` (extracted in #1835), the **mirroring** shape, not a hand-built allowlist directory and not a probe seam in shipped code.

That helper's own header states the criterion: which shape fits is decided by whether the subject's binary needs are enumerable. `check-scope-digest-adoption.sh` is a large shell program reaching for several tools beyond `jq`, so its needs are not enumerable, and an allowlist that missed one would fail as a missing-tool error inside the fixture rather than on the arm under test. Reaching for the shared helper also avoids adding a fourth hand-rolled allowlist rebuild alongside the three #1831 is open about.

## Verification

- `.gaia/scripts/tests/check-scope-digest-adoption.bats` — 24/24 under bash 5
- `.gaia/scripts/tests/bats-path-helper.bats` — 13/13 (new client of the helper)
- `bash .gaia/tests/shell-lint.sh` — passed
- `bash .gaia/tests/whole-tree-invariants.sh` — all pass
- Quality Gate skipped: no staged source or gate-affecting config file (`.bats` only)
- No CHANGELOG entry: `.gaia/scripts/tests/` is release-excluded, so nothing here reaches an adopter

🤖 Generated with [Claude Code](https://claude.com/claude-code)
