### PR TITLE
debt(comments): point both 3-minute setup-node caps at the composite, not a copy

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -640,12 +640,16 @@ jobs:
       - if: steps.filter.outputs.code == 'true' || github.event_name == 'workflow_dispatch'
         name: Setup Node
         # Same bound-a-stall reasoning as the sibling job's install step above,
-        # sized to what this one actually does. `install: none` runs no pnpm
-        # install of its own, so all it can stall on is the Node tarball
-        # download and the pnpm store restore; across recent CI runs it took
-        # 13-18 seconds warm, and three minutes is about ten times that. Lower
-        # than the sibling's five because the work is lower, not because the job
-        # cap is: both jobs cap at 15, and the scenarios below need the rest.
+        # sized to what this one actually does. What the cap has to hold is the
+        # composite's own provisioning, which
+        # `.github/actions/gaia-setup-node/action.yml` enumerates and already
+        # sizes its retry pause against this cap. Read that set there rather
+        # than restating it here, where a copy of it goes stale the next time
+        # the composite changes. Across recent CI runs it took 13-18 seconds
+        # warm, and three minutes is about ten times that. Lower than the
+        # sibling's five because `install: none` skips the workspace install,
+        # not because the job cap is lower: both jobs cap at 15, and the
+        # scenarios below need the rest.
         timeout-minutes: 3
         uses: ./.github/actions/gaia-setup-node
         with:

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -37,11 +37,15 @@ jobs:
 
       - name: Setup Node
         # Same bound-a-stall reasoning as every other gaia-setup-node call site.
-        # `install: none` runs no pnpm install of its own, so the only thing that
-        # can hang here is the Node tarball download or the pnpm store restore;
-        # across recent CI runs this step took 5-10 seconds, and three minutes is
-        # many times its observed cost while leaving twelve of the job's 15 for
-        # the distribution layers below.
+        # Lower than the usual five because `install: none` skips the workspace
+        # install; what the cap still has to hold is the composite's own
+        # provisioning, which `.github/actions/gaia-setup-node/action.yml`
+        # enumerates and already sizes its retry pause against this cap. Read
+        # that set there rather than restating it here, where a copy of it goes
+        # stale the next time the composite changes. Across recent CI runs this
+        # step took 5-10 seconds, and three minutes is many times its observed
+        # cost while leaving twelve of the job's 15 for the distribution layers
+        # below.
         timeout-minutes: 3
         uses: ./.github/actions/gaia-setup-node
         with:


### PR DESCRIPTION
## What

The two `gaia-setup-node` call sites capped at `timeout-minutes: 3`, `.github/workflows/distribution.yml` and `.github/workflows/cli-tests.yml`, each restated the set of things the cap has to hold, and both restatements omitted the composite's own pnpm bootstrap fetch (`pnpm/action-setup` runs `npm ci` then `pnpm self-update` before `actions/setup-node` starts). `install: none` does not exclude that fetch: it is the action's own provisioning, not a workspace install.

The omission became consequential once that fetch gained a retry with a fixed 15-second pause, because the worst case the same 3 minutes has to hold is now attempt-1 time-to-failure, plus the pause, plus a full second bootstrap, plus the tarball download and the store restore.

## The form

Both sites now point at `.github/actions/gaia-setup-node/action.yml`, which enumerates its own provisioning and already sizes that pause against this cap, instead of keeping a hand-maintained copy of the stalling set at each site. This takes the second of the two arms the issue offered: the first arm re-authors the same defect, a hand-kept restatement at two sites, which the issue itself names as how the two rationales diverge.

The shipped-surface constraint does not bar the pointer here, and the direction is why. Both edited files are absent from `.gaia/manifest.json`; the pointer target is `owned` and ships. Two release-excluded files pointing at a shipped one leaks nothing, because the pointing files never reach an adopter.

The site-local reasoning that is genuinely local stays where it is: the observed warm cost at each site, and why the cap is lower than the usual five.

## Verification

- `bash .gaia/tests/whole-tree-invariants.sh` — pass (includes `audit-ci-shards.bats`, whose W12 block reads every `gaia-setup-node` cap).
- `.gaia/scripts/tests/workflow-filter-coverage.bats` — 18/18.
- Quality Gate skipped by its own skip logic: the staged set is workflow YAML only, no source or gate-affecting config.
- Claims in the new comments re-derived against the tree: the two 3-minute sites are exactly the two `install: none` sites and every other call site declares 5; both `cli-tests.yml` jobs cap at 15; the composite's pause comment already sizes itself against this cap.

The cap does not need raising, and this does not raise it. Three minutes still covers the doubled worst case comfortably; what changes is that a maintainer trimming either cap now reads the budget from the file that owns it.

Closes #1848

🤖 Generated with [Claude Code](https://claude.com/claude-code)