### PR TITLE
debt(comments): drop the suite-count cardinal and split the two claims in bats-path-helper's header

### DIFF
--- a/.gaia/scripts/tests/bats-path-helper.bats
+++ b/.gaia/scripts/tests/bats-path-helper.bats
@@ -1,10 +1,12 @@
 #!/usr/bin/env bats
 # The shared PATH primitives in .gaia/tests/helpers/path.sh.
 #
-# Two bats suites need the same thing: a PATH with a named tool guaranteed
-# absent, so a test can drive the "tool is not installed" arm on a developer
-# machine where the tool really is installed. Both hand-rolled the same loop,
-# and both wrote the membership test as `[ -x "$dir/$name" ]`.
+# A bats suite that drives a "tool is not installed" arm on a developer machine
+# where the tool really is installed needs a PATH with that tool guaranteed
+# absent. The need arrived independently in suites across the tree, each with
+# its own hand-rolled rebuild loop; a tree-wide grep for `helpers/path.sh`
+# answers which suites are clients today. Separately, and not at every one of
+# those loops, the membership test was written as `[ -x "$dir/$name" ]`.
 #
 # That predicate is wrong in one direction. `-x` is true for a searchable
 # DIRECTORY named for the tool, not only for an executable file, so a PATH


### PR DESCRIPTION
Closes #1830

## What

`.gaia/scripts/tests/bats-path-helper.bats`'s header opened *"Two bats suites need the same thing"* and paired two claims — *"Both hand-rolled the same loop"* and *"both wrote the membership test as `[ -x "$dir/$name" ]`"* — as a conjunction. Both halves were wrong.

**The cardinal.** The pull request that added this file converted three call sites, not two, and PR #1835 has since added further callers. Nothing recounts the number, so a maintainer repairing the duplication reads the header, believes two homes were folded into one, and never looks for the rest — the precise failure the shared helper exists to end, reintroduced in the prose explaining it.

**The conjunction.** No single call site satisfies both claims. At the fork point the `provision-worktree` arm rebuilt `PATH` by exclusion but already carried the correct `[ -f ] && [ -x ]` predicate (verified at `0f825b24:.gaia/tests/hooks/provision-worktree.bats:715`), while `scrub_gh_from_path` carried the bare `-x` and never rebuilt by exclusion at all, mirroring each matching directory into a shim instead.

## Fix

Drop the number rather than correcting it, per `.claude/rules/code-comments.md` ("Counts": prefer the set to its cardinality) and `.claude/rules/bats-assertions.md` ("No counts in test names or in the comments describing the set"). The header now points at a tree-wide grep for `helpers/path.sh` as the authority on the client set — the form the sibling `.gaia/tests/helpers/path.sh` header already uses. The two claims stand separately, and the predicate claim is explicitly non-universal ("not at every one of those loops").

Comment-only; no behavior change.

## Verification

- `.gaia/scripts/bats5.sh .gaia/scripts/tests/bats-path-helper.bats` — 13/13 pass
- `bash .gaia/tests/whole-tree-invariants.sh` — all pass (exit 0)
- Quality Gate: skip check ran and returned nothing (sole staged file is `.bats`, not source or gate-affecting config)
- Both falsifiable claims in the replacement text were run rather than asserted: the grep resolves the client set, and the fork-point predicate was read out of `git show`
- Not in `.gaia/manifest.json`, so no shipped surface and no CHANGELOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)