### PR TITLE
debt(guards): add knobs to lint-stale-cardinals' NOUN vocabulary

### DIFF
--- a/.gaia/scripts/lint-stale-cardinals.sh
+++ b/.gaia/scripts/lint-stale-cardinals.sh
@@ -345,7 +345,7 @@ readonly PRED_AWK='
 
       # Nouns naming an artifact this repository CONTAINS, which is what makes
       # a recount possible and therefore what makes the finding actionable.
-      split("agents callers commands consumers entries exemptions files fixtures guards helpers hooks jobs labels lines markers members pages rules scripts shards siblings sites skills subcommands suites tests workflows", t, " ")
+      split("agents callers commands consumers entries exemptions files fixtures guards helpers hooks jobs knobs labels lines markers members pages rules scripts shards siblings sites skills subcommands suites tests workflows", t, " ")
       for (i in t) NOUN[t[i]] = 1
 
       # How many words may sit between the cardinal and its noun. One admits

--- a/.gaia/scripts/tests/lint-stale-cardinals.bats
+++ b/.gaia/scripts/tests/lint-stale-cardinals.bats
@@ -14,17 +14,19 @@
 # switched off; and assert the real scanned tree is clean so a regression fails
 # CI.
 #
-# Two tests are load-bearing beyond coverage, and both carry a historical form
-# verbatim rather than a tidied stand-in. A gate written for a class must red
-# against that class's real shape or it asserts nothing about the class it was
-# written for. `reds against the naming-convention header form` and `reds
-# against the derived-count separator form` are the two instances that motivated
-# this gate, copied from the comments they were found in: one spells its
-# cardinal as a word and sits directly against its noun, the other spells it as
-# digits and sits behind a modifier. They fail differently, and a detector that
-# reaches one does not necessarily reach the other -- the digit form was in fact
-# missed by the first draft of the noun vocabulary, which is why it is pinned
-# here rather than trusted.
+# Some tests are load-bearing beyond coverage, and each of those carries a
+# historical form verbatim rather than a tidied stand-in. A gate written for a
+# class must red against that class's real shape or it asserts nothing about
+# the class it was written for. `reds against the naming-convention header
+# form` and `reds against the derived-count separator form` are the instances
+# that motivated this gate, copied from the comments they were found in: one
+# spells its cardinal as a word and sits directly against its noun, the other
+# spells it as digits and sits behind a modifier. They fail differently, and a
+# detector that reaches one does not necessarily reach the other -- the digit
+# form was in fact missed by the first draft of the noun vocabulary, which is
+# why it is pinned here rather than trusted. `reds against the retention-knob
+# header form` joins them on the same terms, and its own comment says which
+# vocabulary entry it stands behind.
 #
 # Assertion style: bash-3.2-safe per .claude/rules/bats-assertions.md.
 #
@@ -187,11 +189,11 @@ true'
   [ "$status" -eq 1 ]
 }
 
-# A third historical form, and the one that motivated the vocabulary entry it
-# pins: `knobs` was outside the closed list, so this comment stood on main
-# until a human found it (#1777, repaired by #1832) and the gate stayed green
-# against the very instance it was pointed at. Carried verbatim from the
-# comment it was found in, for the reason the two forms above are.
+# A historical form too, and the one that motivated the `knobs` vocabulary
+# entry it pins: that noun was outside the closed list, so this comment stood
+# on main until a human found it (#1777, repaired by #1832) and the gate stayed
+# green against the very instance it was pointed at. Carried verbatim from the
+# comment it was found in, for the reason the forms above it are.
 @test "reds against the retention-knob header form" {
   fixture_repo
   fixture_script '# the outlier sweep'"'"'s own documentation must name its three retention knobs

--- a/.gaia/scripts/tests/lint-stale-cardinals.bats
+++ b/.gaia/scripts/tests/lint-stale-cardinals.bats
@@ -187,6 +187,20 @@ true'
   [ "$status" -eq 1 ]
 }
 
+# A third historical form, and the one that motivated the vocabulary entry it
+# pins: `knobs` was outside the closed list, so this comment stood on main
+# until a human found it (#1777, repaired by #1832) and the gate stayed green
+# against the very instance it was pointed at. Carried verbatim from the
+# comment it was found in, for the reason the two forms above are.
+@test "reds against the retention-knob header form" {
+  fixture_repo
+  fixture_script '# the outlier sweep'"'"'s own documentation must name its three retention knobs
+true'
+  run_linter
+  [ "$status" -eq 1 ]
+  grep -qF -- "check.sh:1:" <<<"$output"
+}
+
 @test "reds regardless of letter case" {
   fixture_repo
   fixture_script '# Earned write lands for ALL THREE MEMBERS.


### PR DESCRIPTION
`.gaia/scripts/lint-stale-cardinals.sh:348`

The stale-cardinal gate could not see the very instance #1777 was filed for and #1832 repaired by hand: `its three retention knobs`, in the header of `.gaia/tests/hooks/local-janitor-wiki-doc.bats`.

Every other term in the predicate matched. `its` is a DET entry at `:338`, `three` is a CARD entry at `:343` (the table carries spelled cardinals, so #1777's recorded reason for the miss, "because `three` is a word rather than a digit", was wrong), and the one-word gap `retention` is within `GAP_MAX` at `:355`. `knobs` was simply outside the closed NOUN vocabulary at `:348`. That is a shape the script's own FAIL-OPEN list names, and the header explicitly invites closing it: "Extending it is a one-line change, and an extension that reds the tree is the gate working."

`knobs` meets the vocabulary's stated inclusion criterion, the adjacent comment's "Nouns naming an artifact this repository CONTAINS": a retention knob is a named setting a reader can go and count.

## Scope

The noun arm only. Two stale cardinals in `.gaia/scripts/main-only-lib.sh` (#1802) look like the same gap and are not: both fail the determiner test at `:338`, not the noun test, and adding their noun to the vocabulary leaves the gate clean. The DET arm and the line-boundary arm are separate fail-open arms of the same script and are deliberately untouched here.

## Verification

- The new suite case `reds against the retention-knob header form` carries the historical comment verbatim, beside the two forms the gate was written for. It fails against the vocabulary as it stood (`[ "$status" -eq 1 ]` at line 200) and passes with the entry added, so the guard is proven able to fail.
- Full sibling suite: 49/49 pass, including `the real tracked tree passes the gate`, so the extension reds nothing on main.
- `bash .gaia/tests/shell-lint.sh`: passed.
- `bash .gaia/tests/whole-tree-invariants.sh`: all invariants pass.
- Quality Gate: skipped, no staged file matches its source or gate-affecting-config classes (`.sh` and `.bats` only).

No CHANGELOG entry. The guard is maintainer-only and release-excluded (absent from `.gaia/manifest.json`), so no adopter clone runs it, and a one-noun vocabulary addition is below Keep a Changelog altitude.

Closes #1837

🤖 Generated with [Claude Code](https://claude.com/claude-code)
