### PR TITLE
debt(scripts): file the trailing-comment bullet under deliberately-not-a-hit

### DIFF
--- a/.gaia/scripts/lint-hook-cwd-relative-loads.sh
+++ b/.gaia/scripts/lint-hook-cwd-relative-loads.sh
@@ -89,6 +89,13 @@
 #     (`cd "$root" && bash .gaia/scripts/x.sh`). The `cd` is the rooting, and
 #     it is the shape a caller uses when the target tree is deliberately not
 #     this hook's own.
+#   - A trailing comment that mentions one of the four positions after real
+#     code on the same line. `code_prefix()` cuts the line at the first
+#     unquoted `#` preceded by whitespace and the match arms read only what is
+#     left, so the mention is quiet. That is the same call the whole-line
+#     comment arm makes, and it is the right one for a documentation mention;
+#     it is listed here rather than left unsaid because a reader who expects
+#     the scan to read the raw line would expect the opposite.
 #
 # KNOWN BLIND SPOTS, split by which way each one fails, because that is the
 # part that matters.
@@ -115,13 +122,6 @@
 #   - A load inside a heredoc body that a `bash -c` later executes. Heredoc
 #     bodies are skipped outright, because the tree carries the class in them
 #     only as documentation an operator reads.
-#   - A trailing comment that mentions one of the four positions after real
-#     code on the same line. `code_prefix()` cuts the line at the first
-#     unquoted `#` preceded by whitespace and the match arms read only what is
-#     left, so the mention is quiet. That is the same call the whole-line
-#     comment arm makes, and it is the right one for a documentation mention;
-#     it is listed here rather than left unsaid because a reader who expects
-#     the scan to read the raw line would expect the opposite.
 #
 # FAIL-CLOSED, so each costs a correct edit and never a missed defect:
 #   - A mention inside a QUOTED span on a line of real code. A `#` inside the


### PR DESCRIPTION
`.gaia/scripts/lint-hook-cwd-relative-loads.sh`'s `FAIL-OPEN` heading characterises every member of its list as *"a construct the line-oriented scan cannot read"*. The trailing-comment bullet is not one of those: `code_prefix()` reads the line and deliberately cuts it at the first unquoted `#` preceded by whitespace, and the bullet's own body says exactly that and calls the cut the right one for a documentation mention.

Filed under `FAIL-OPEN`, the bullet sends a maintainer hunting for a reader that follows the raw line, which should not exist and which the gate deliberately does not have.

## What changed

The bullet moves to `WHAT IS DELIBERATELY NOT A HIT`, whose stated criterion is *"why each exclusion is the right call rather than a gap this gate wishes it could close"* — the bullet's own closing clause almost verbatim. It lands beside the per-tree STATE path, git pathspec, and `cd`-first interpreter exclusions, so a reader arrives at every case the gate deliberately does not reach in one place.

The issue offered a second arm — narrow the `FAIL-OPEN` parenthetical instead — and it is refused. The parenthetical is accurate for all three remaining members; weakening a true characterisation to accommodate one non-member leaves the next reader a weaker heading and the same misfiling.

The bullet's reader-expectation clause is kept verbatim: it is the reason the case is stated at all, and it reads correctly under either heading.

## Verification

- Comment-only, zero behavior change. No shipped surface: the file is release-excluded (`.gaia/release-exclude:186`) and absent from the manifest, so no CHANGELOG entry is owed.
- `.gaia/scripts/tests/lint-hook-cwd-relative-loads.bats` — 23/23 pass, sibling suite untouched by this diff.
- `bash .gaia/tests/whole-tree-invariants.sh` — all pass.
- Quality Gate skip check ran and returned empty (no staged source or gate-affecting config), so the gate correctly skips.
- Every citation in the issue re-verified against HEAD before implementing: `:96` heading, `:118` bullet, `:74` destination heading, `:221` `code_prefix()`.

Closes #1861

🤖 Generated with [Claude Code](https://claude.com/claude-code)