### PR TITLE
debt(cli): guard the escapeRegExp consolidation against a fifth private copy

### DIFF
--- a/.gaia/cli/src/escape-regexp-uniqueness.test.ts
+++ b/.gaia/cli/src/escape-regexp-uniqueness.test.ts
@@ -17,8 +17,8 @@
  * # What counts as an offense
  *
  * A JavaScript regex literal that OPENS with a character class carrying `*` and
- * at least six distinct regex metacharacters, anywhere under `.gaia/cli/src`
- * outside the declaring module. Each of the three conditions is a measured
+ * at least six distinct regex metacharacters, in any `.ts` file under
+ * `.gaia/cli/src` outside the declaring module. Each condition is a measured
  * boundary rather than a taste, and each one is what spares a live construct in
  * this tree:
  *
@@ -43,7 +43,7 @@
  *
  * # Scope boundary (v1), and it is a floor rather than a clean bill of health
  *
- * Four shapes are deliberately unreached, and a copy taking any of them slips:
+ * These shapes are deliberately unreached, and a copy taking any of them slips:
  * a class that is not the literal's first token (`/^[…]/`), a set assembled
  * through `new RegExp(...)` from string pieces, a pattern imported from another
  * module, and a set spelled across several lines. Reaching them means deciding
@@ -52,6 +52,12 @@
  * TypeScript AST rather than from lines at all. What this floor does cover is
  * the shape every copy the consolidation removed actually took, and the one the
  * next author would reach for.
+ *
+ * The corpus is `.ts` only, so the `.tmpl` scaffold templates sharing this root
+ * are never opened. They render into an adopter's app rather than into the CLI,
+ * and none carries an escape set today, so this is a boundary rather than a
+ * known miss: a template that grew one would be a copy in the adopter's tree,
+ * which is not what the shared module's callers are.
  *
  * Nothing is exempted by path except the declaring module itself, which is the
  * one place the declaration belongs. There is deliberately no allowlist beside

--- a/.gaia/cli/src/escape-regexp-uniqueness.test.ts
+++ b/.gaia/cli/src/escape-regexp-uniqueness.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Maintainer guard: the regex-metacharacter escape set is declared once.
+ *
+ * `util/escape-regexp.ts` holds the CLI's one `escapeRegExp`, and every caller
+ * imports it. Nothing noticed when the copies it replaced arrived, and nothing
+ * would notice a fifth: the next author who needs to escape a token into a
+ * `new RegExp(...)` writes the one-line arrow function they already know rather
+ * than finding the module. `sonarjs/no-identical-functions` stayed silent
+ * through every copy, because a single-line arrow sits below that rule's
+ * minimum-lines threshold, and the shell-side scanners reach no TypeScript.
+ *
+ * The failure a second copy produces is invisible at the call site: a
+ * metacharacter added to one set and not the other still compiles to a *valid*
+ * regex, so nothing throws and no suite reds. It just changes which strings a
+ * guard matches, and most of the callers are guards.
+ *
+ * # What counts as an offense
+ *
+ * A JavaScript regex literal that OPENS with a character class carrying `*` and
+ * at least six distinct regex metacharacters, anywhere under `.gaia/cli/src`
+ * outside the declaring module. Each of the three conditions is a measured
+ * boundary rather than a taste, and each one is what spares a live construct in
+ * this tree:
+ *
+ * - **`*` must be in the class.** It is what separates a regex-literal escaper
+ *   from a glob escaper. `release/scrub.ts`'s `REGEX_SPECIAL` deliberately
+ *   omits `*` because `globToRegex` expands the wildcard after escaping, and
+ *   the shared module's own docblock states the converse: `*` is escaped there
+ *   precisely so a caller compiling a literal path does not have it silently
+ *   rewritten into a glob. A set without `*` is not a substitute for
+ *   `escapeRegExp` and never becomes the fifth copy.
+ * - **Six distinct metacharacters.** An escape set has to cover essentially all
+ *   of them to be correct (the shared one carries fourteen), while a
+ *   metacharacter *detector* names the handful it cares about. Measured, the
+ *   two live detectors carry four (`wiki/dead-paths.ts`'s
+ *   `PLACEHOLDER_PATTERN`) and five (`release/runtime-deps.ts`'s
+ *   `PATH_TRUNCATING_METACHAR`); six is the first floor clear of both.
+ * - **The literal must open with the class.** A bracket expression carried
+ *   inside a string is not a JavaScript regex literal, and reading one as such
+ *   would report `release/exclude-parser-parity.test.ts`, whose hardcoded
+ *   `sed` reference pipeline is a byte-for-byte oracle that must not be
+ *   touched.
+ *
+ * # Scope boundary (v1), and it is a floor rather than a clean bill of health
+ *
+ * Four shapes are deliberately unreached, and a copy taking any of them slips:
+ * a class that is not the literal's first token (`/^[…]/`), a set assembled
+ * through `new RegExp(...)` from string pieces, a pattern imported from another
+ * module, and a set spelled across several lines. Reaching them means deciding
+ * where a regex literal starts and ends in arbitrary source, which is a
+ * tokenizer, and a tokenizer is the argument for reading this from the
+ * TypeScript AST rather than from lines at all. What this floor does cover is
+ * the shape every copy the consolidation removed actually took, and the one the
+ * next author would reach for.
+ *
+ * Nothing is exempted by path except the declaring module itself, which is the
+ * one place the declaration belongs. There is deliberately no allowlist beside
+ * it: `#1831` is open because three hand-rolled allowlists have already
+ * diverged, and a fourth would be volunteered here for a case the conditions
+ * above already answer on the merits.
+ *
+ * Repair, when this goes red: delete the private copy and
+ * `import {escapeRegExp} from '…/util/escape-regexp.js'`. If the new set is
+ * genuinely different rather than a copy, say so where it is declared and give
+ * it a set this guard does not read as the shared one.
+ *
+ * Because this file sits inside the surface it scans, its fixtures are
+ * assembled at runtime rather than written as literals: a fixture spelled out
+ * as a regex literal would be reported as the very declaration it plants.
+ *
+ * Maintainer-only by construction: `.gaia/cli/src` is release-excluded, so an
+ * adopter clone carries neither these sources nor this test, and the corpus
+ * scan skips there. Mirrors `module-docblock-placement.test.ts`.
+ */
+import {describe, expect, test} from 'vitest';
+import {existsSync, readdirSync, readFileSync} from 'node:fs';
+import path from 'node:path';
+import {resolveRepoRootFromImportMeta} from './util/repo-root-fixture.js';
+
+const REGEX_METACHARACTERS = new Set([
+  '$',
+  '(',
+  ')',
+  '*',
+  '+',
+  '.',
+  '?',
+  '[',
+  '\\',
+  ']',
+  '^',
+  '{',
+  '|',
+  '}',
+]);
+
+/**
+ * The smallest metacharacter count this guard reads as an escape SET rather
+ * than as a detector naming the few metacharacters it cares about.
+ */
+const ESCAPE_SET_FLOOR = 6;
+
+// Counted from the metacharacter side rather than by walking the class body:
+// every metacharacter is a single UTF-16 unit, so this needs no view on how the
+// body decomposes.
+const distinctMetacharacters = (classBody: string): number =>
+  [...REGEX_METACHARACTERS].filter((character) => classBody.includes(character))
+    .length;
+
+/**
+ * A regex literal opening with a character class, up to that class's first
+ * closing bracket.
+ *
+ * The bracket it stops at is the first one, escaped or not, so the shared set's
+ * own `\]` truncates the captured body. That is deliberate: the body is counted
+ * rather than parsed, and a truncated escape set still carries far more than
+ * the floor. Recovering the true end means tracking escapes, which is the
+ * tokenizer this guard declines to be.
+ */
+const CLASS_OPENED_REGEX_LITERAL = /\/\[[^\]\n]*\]/g;
+
+/**
+ * Reports the 1-based line of the first escape-set declaration, or `null` when
+ * the source declares none.
+ */
+const findEscapeSetDeclaration = (source: string): null | number => {
+  const lines = source.split('\n');
+
+  for (const [index, line] of lines.entries()) {
+    for (const match of line.matchAll(CLASS_OPENED_REGEX_LITERAL)) {
+      const classBody = match[0].slice(2, -1);
+
+      if (
+        classBody.includes('*') &&
+        distinctMetacharacters(classBody) >= ESCAPE_SET_FLOOR
+      ) {
+        return index + 1;
+      }
+    }
+  }
+
+  return null;
+};
+
+// Separators normalized to POSIX, because the one entry compared by name below
+// is the declaring module. A native separator would make that comparison miss,
+// and the miss reports the shared declaration itself as the copy it exists to
+// find, which reads as the guard working.
+const collectSourceFiles = (root: string): readonly string[] =>
+  (readdirSync(root, {recursive: true}) as string[])
+    .filter((entry) => entry.endsWith('.ts'))
+    .map((entry) => entry.split(path.sep).join('/'))
+    .toSorted((a, b) => a.localeCompare(b));
+
+/** The declaring module, relative to `.gaia/cli/src`. */
+const DECLARING_MODULE = 'util/escape-regexp.ts';
+
+const repoRoot = resolveRepoRootFromImportMeta(import.meta.url);
+const cliSrc = path.join(repoRoot, '.gaia', 'cli', 'src');
+const sourcesPresent = existsSync(cliSrc);
+
+// Assembled rather than written out, for the reason the docblock gives: a
+// literal fixture would be an offense in this very file.
+const asRegexLiteral = (classBody: string, flags: string): string =>
+  ['/', '[', classBody, ']', '/', flags].join('');
+
+/** The set the shared module declares: every metacharacter, `*` included. */
+const SHARED_SET = '.*+?^${}()|[\\]\\\\';
+/** `release/scrub.ts`'s glob escaper: the same idiom, deliberately without `*`. */
+const GLOB_ESCAPER_SET = '.+^$()[\\]{}|\\\\';
+/** `release/runtime-deps.ts`'s detector: five metacharacters, `*` among them. */
+const PATH_METACHARACTER_DETECTOR_SET = '$*?[{';
+
+describe('escapeRegExp uniqueness', () => {
+  // Maintainer-only guard: `sourcesPresent` is false on an adopter clone,
+  // where `.gaia/cli/src` is release-excluded.
+  test.skipIf(!sourcesPresent)(
+    'no file outside the declaring module declares an escape set',
+    () => {
+      const sources = collectSourceFiles(cliSrc);
+
+      // A scan that reaches nothing reports nothing, so the empty result below
+      // would read as a clean corpus. `.gaia/cli/src` has held hundreds of
+      // `.ts` files for the life of the CLI; a count this low means the walk
+      // or the extension filter broke, not that the tree shrank.
+      expect(sources.length).toBeGreaterThan(50);
+
+      const copies = sources
+        .filter((relative) => relative !== DECLARING_MODULE)
+        .flatMap((relative) => {
+          const line = findEscapeSetDeclaration(
+            readFileSync(path.join(cliSrc, relative), 'utf8')
+          );
+
+          return line === null ? [] : [`.gaia/cli/src/${relative}:${line}`];
+        });
+
+      expect(copies).toEqual([]);
+    }
+  );
+
+  // The corpus above is expected to be empty, so on its own it would green just
+  // as loudly with a detector that matches nothing. This is the one assertion
+  // driven against the live declaration the guard is written for.
+  test.skipIf(!sourcesPresent)('the declaring module itself matches', () => {
+    const source = readFileSync(path.join(cliSrc, DECLARING_MODULE), 'utf8');
+
+    expect(findEscapeSetDeclaration(source)).not.toBeNull();
+  });
+
+  // No `skipIf`: these run against assembled strings, so they hold on any clone
+  // and they are what establish that the detector can report at all.
+  test('reports a private copy of the shared set', () => {
+    const source = [
+      'const escape = (value: string): string =>',
+      `  value.replaceAll(${asRegexLiteral(SHARED_SET, 'g')}, String.raw\`\\$&\`);`,
+    ].join('\n');
+
+    expect(findEscapeSetDeclaration(source)).toBe(2);
+  });
+
+  // The drift worth catching is a copy whose set is not byte-identical, which
+  // is exactly what a literal match of the shared class would miss.
+  test('reports a copy whose set has drifted', () => {
+    const source = [
+      'const escape = (value: string): string =>',
+      String.raw`  value.replaceAll(${asRegexLiteral('.*+?^$(', 'gu')}, '\\$&');`,
+    ].join('\n');
+
+    expect(findEscapeSetDeclaration(source)).toBe(2);
+  });
+
+  test('reports the first offending line when a file carries several', () => {
+    const source = [
+      'const first = 1;',
+      `const early = ${asRegexLiteral(SHARED_SET, 'g')};`,
+      `const late = ${asRegexLiteral(SHARED_SET, 'gu')};`,
+    ].join('\n');
+
+    expect(findEscapeSetDeclaration(source)).toBe(2);
+  });
+
+  // The boundary between a regex-literal escaper and a glob escaper. Reporting
+  // this would red on `release/scrub.ts`, whose set omits `*` deliberately.
+  test('accepts a glob escaper, whose set omits the wildcard', () => {
+    const source = `const REGEX_SPECIAL = ${asRegexLiteral(GLOB_ESCAPER_SET, 'g')};`;
+
+    expect(findEscapeSetDeclaration(source)).toBeNull();
+  });
+
+  // Below the floor: a detector naming the metacharacters it cares about is not
+  // an escape set, and `release/runtime-deps.ts` declares this one live.
+  test('accepts a metacharacter detector below the floor', () => {
+    const source = `const PATH_TRUNCATING_METACHAR = ${asRegexLiteral(
+      PATH_METACHARACTER_DETECTOR_SET,
+      ''
+    )};`;
+
+    expect(findEscapeSetDeclaration(source)).toBeNull();
+  });
+
+  // A bracket expression inside a string is not a JavaScript regex literal.
+  // `release/exclude-parser-parity.test.ts` carries this exact text as a
+  // byte-for-byte oracle of the retired shell pipeline.
+  test('accepts a shell bracket expression carried in a string', () => {
+    const source = String.raw`const STAGE2 = "sed 's|[][\\.*^$()+?{}|]|\\&|g'";`;
+
+    expect(findEscapeSetDeclaration(source)).toBeNull();
+  });
+
+  test('accepts a file that declares no character class at all', () => {
+    const source = [
+      'import path from "node:path";',
+      'export const x = 1;',
+    ].join('\n');
+
+    expect(findEscapeSetDeclaration(source)).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #1834

## What

`util/escape-regexp.ts` holds the CLI's one `escapeRegExp` and every call site imports it, but nothing in the tree notices when a new private copy arrives. `sonarjs/no-identical-functions` sits above a one-line arrow function, and the shell-side scanners reach no TypeScript, so the escape set can start drifting again from a fresh copy. The drift is silent: a wrong set is still a *valid* regex, so nothing throws and no suite reds, and most of the callers are guards whose matching behaviour is exactly what changes.

`.gaia/cli/src/escape-regexp-uniqueness.test.ts` is a whole-tree Vitest guard asserting the escape set is declared once.

## The mechanism fork, and why it settles to neither named arm

The issue proposed a grep-based `.gaia/scripts/lint-*.sh` or a custom ESLint rule. It takes a third: a whole-tree Vitest scanner in the package that owns the code, joining `argv-lookup-guard`, `command-reachability`, `format-ignore-scope`, `lint-pin-parity`, `module-docblock-placement` and `node-pin-parity`, all raw-text scanners over `.gaia/cli/src/**` that CI already runs via `pnpm -C .gaia/cli test`. `module-docblock-placement.test.ts` is the nearest and this is modelled on it, `skipIf` arm and maintainer-only header included. The ESLint arm would be the first custom rule anywhere in this repository; the shell arm would judge TypeScript from outside its package.

## What the pattern matches, measured rather than picked

An offense is a regex literal that **opens** with a character class carrying `*` and at least six distinct regex metacharacters. Each of the three conditions spares a live construct, and each was measured against the tree:

- **`*` in the class** separates a regex-literal escaper from a glob escaper. `release/scrub.ts`'s `REGEX_SPECIAL` omits `*` deliberately, because `globToRegex` expands the wildcard after escaping. A set without `*` is not a substitute for `escapeRegExp`.
- **Six distinct metacharacters** separates an escape *set* (the shared one carries fourteen) from a metacharacter *detector*. The two live detectors carry four (`wiki/dead-paths.ts`) and five (`release/runtime-deps.ts`); six is the first floor clear of both.
- **The literal must open with the class**, so a bracket expression carried inside a string is not read as one. Without it the guard reports `release/exclude-parser-parity.test.ts`, whose hardcoded `sed` reference pipeline is a byte-for-byte oracle.

There is **no allowlist**: nothing is exempt by path except the declaring module itself. The header states the four shapes the floor deliberately does not reach (a class that is not the literal's first token, a set assembled through `new RegExp`, an imported pattern, a set spelled across lines), each of which needs a tokenizer.

## Verification

Per `.claude/rules/guards-must-fail.md`, the guard was driven into its failing state twice, not merely observed passing:

- A private copy planted in `util/gaia-invocation-matcher.ts` → red, reporting `.gaia/cli/src/util/gaia-invocation-matcher.ts:117`.
- A private copy planted in the new guard file itself → red, which is also what proves discovery reaches a file that is still untracked.

Both were reverted. Seven assembled-string fixtures pin the detector's positive and negative boundaries on any clone, and one assertion drives it against the live shared declaration so a detector that matched nothing could not green.

Quality Gate: typecheck, lint, unit tests and build green in both workspaces (CLI 2505 tests, root 159), Playwright green, `whole-tree-invariants.sh` clean. `pnpm -C .gaia/cli bundle` re-run and both binaries confirmed byte-identical, so no bundle commit is owed.

No CHANGELOG entry: `.gaia/cli/src` is release-excluded, so nothing here reaches an adopter or changes anything they can observe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Audit round 1: clean, two advisory Suggestions

`code-audit-maintainer-node` returned a clean pass (no Critical, no Important) and wrote its marker. Both Suggestions were verified against the tree before disposing of them:

- **Applied.** The offense definition said "anywhere under `.gaia/cli/src`" while the walk keeps only `.ts`, and the scope-boundary section did not name that filter. Confirmed: 35 `.tmpl` files share the root and are never opened. The sentence now says `.ts` and the boundary section states why the templates sit outside it. Prose-only, so it is the fold the digest economics license on an already-marked branch.
- **Accepted and noted, filed as #1869.** The recursive `.gaia/cli/src` walk is hand-copied across four guard suites (`module-docblock-placement`, `argv-lookup-guard`, `command-reachability`, and this one) with no shared source, and the copies already disagree on separator normalization. The audit proposed lifting it into `repo-root-fixture.ts`. Measured, the class is four suites wide and three of the copies predate this change, so repairing the two that happen to share a name is a partial fix that leaves the divergence standing, and rewiring three unrelated guard suites is outside an issue scoped to `escapeRegExp`.


## Audit round 2: clean, one accepted residual

`code-audit-maintainer-node` re-earned its marker against the docblock-only delta. No Critical, no Important. It independently confirmed the round-1 repair: the `.ts` wording now matches `collectSourceFiles`, there are no `.tsx` files the filter silently drops, and all 35 `.tmpl` files under this root grep clean for a regex-literal character class.

**Accepted residual, not fixed.** The new paragraph calls the `.tmpl` files "scaffold templates" and says they render into an adopter's app; 14 of the 35 are CI-workflow templates that render into an adopter's `.github/workflows/` instead. The load-bearing half of that sentence, that the templates render into an adopter's tree rather than into the CLI, so a copy growing there would not be a copy of this module's, holds for both families, and the imprecision sits in the incidental clause. This is a finding on the previous round's own prose repair proposing to widen a prose list, which is the shape `wiki/concepts/PR Merge Workflow.md`'s "When rounds stop" section dispositions as accept-and-note rather than as another round.
