### PR TITLE
debt(scripts): give the reporting tests in the cwd-loads suite their own banner

### DIFF
--- a/.gaia/scripts/tests/lint-hook-cwd-relative-loads.bats
+++ b/.gaia/scripts/tests/lint-hook-cwd-relative-loads.bats
@@ -311,6 +311,8 @@ true  # Usage: [ -f .claude/hooks/lib/red-ledger.sh ] && . .claude/hooks/lib/red
   true
 }
 
+# --- where the quiet arms stop, and the class reports again -----------------
+
 @test "reports a mention inside a QUOTED span, which the # does not cut" {
   fixture_repo
   # The mention sits BEHIND the `#`, so only the quote tracker keeps it in the


### PR DESCRIPTION
Closes #1862

## What

Two `@test`s in `.gaia/scripts/tests/lint-hook-cwd-relative-loads.bats` sat under the section banner that reads *"quiet on every shape the header lists as deliberately not a hit"* while asserting `status -eq 1` and a positive report:

- `reports a mention inside a QUOTED span, which the # does not cut`
- `a comment carrying an apostrophe does not blind the next line`

A maintainer adding the next quiet case reads that banner as the contract for what belongs in the section, so a reporting test under it either mis-shapes the new test to match its neighbour or misplaces a correctly-shaped one. Both now sit under their own banner.

## Why this shape

The strategy comment on #1862 settled the fork against widening the `:241` banner to name both directions at once. The gate header introduces its blind spots *"split by which way each one fails, because that is the part that matters"*, and a banner naming both erases precisely that distinction, which makes it the one shape the file argues against. Moving the tests under the reporting banner at `:111` fails for a symmetric reason: that banner reads *"one test per position the header enumerates"*, and neither of these is a position.

Two departures from the issue as filed, both stated so a reviewer can weigh them:

1. **The issue names one test; there are two.** `a comment carrying an apostrophe does not blind the next line` is the second reporting test under the same banner. Fixing only the first would have left it under a new banner it also does not belong to, so it is in scope rather than adjacent.
2. **One banner over both, not one each.** `.claude/rules/code-comments.md` files *"a banner over a single item"* under "earns nothing" and keeps a banner over a group as navigation, so two one-test banners would trade this defect for that one. The shared banner is honest for both members: each is the same claim about where the quiet arms stop, the `#` not cutting inside a quoted span and a comment's quoting not carrying to the next line, so the class reports in each case. It does not widen the quiet banner, so the direction split the header cares about is preserved by the section boundary.

The `#1861` precondition the strategy comment named is satisfied: it merged, and the banner was written against the header's taxonomy read at HEAD.

## Noted, not fixed

The mirror-image case exists at `:152` and `:204`, two `status -eq 0` tests under the reporting banner. Both are named `... is still the repair, not a hit` and each sits immediately after the reporting test it contrasts with, which reads as a deliberate pairing that defines what firing means rather than as a misplacement. Left alone; not filed.

## Verification

- `.gaia/scripts/bats5.sh .gaia/scripts/tests/lint-hook-cwd-relative-loads.bats` — 23/23 pass, case count unchanged
- `.gaia/tests/shell-lint.sh` — clean
- `bash .gaia/tests/whole-tree-invariants.sh` — all invariants pass
- Quality Gate skips: the only changed file is a `.bats` file, no source or gate-affecting config staged
- No CHANGELOG entry: the suite is absent from `.gaia/manifest.json`, so it is maintainer-only and release-excluded, and the change carries no behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)