### PR TITLE
debt(cli): lift the whole-tree guard walk into one shared module

### DIFF
--- a/.gaia/cli/src/argv-lookup-guard.test.ts
+++ b/.gaia/cli/src/argv-lookup-guard.test.ts
@@ -53,9 +53,10 @@
  * skips there. Mirrors `command-reachability.test.ts`.
  */
 import {describe, expect, test} from 'vitest';
-import {existsSync, readdirSync, readFileSync} from 'node:fs';
+import {existsSync, readFileSync} from 'node:fs';
 import path from 'node:path';
 import {resolveRepoRootFromImportMeta} from './util/repo-root-fixture.js';
+import {collectTreeFiles, TS_SOURCE_EXTENSIONS} from './util/tree-walk.js';
 
 const CLI_SRC = path.join(
   resolveRepoRootFromImportMeta(import.meta.url),
@@ -76,10 +77,9 @@ const STRING_KEYED = /Record<\s*string\s*,/u;
 const HEAD_WINDOW = 8;
 
 const sourceFiles = (): string[] =>
-  (readdirSync(CLI_SRC, {recursive: true}) as string[])
-    .filter((name) => name.endsWith('.ts') && !name.endsWith('.test.ts'))
-    .filter((name) => !name.includes('__tests__'))
-    .toSorted((left, right) => left.localeCompare(right));
+  collectTreeFiles(CLI_SRC, TS_SOURCE_EXTENSIONS).filter(
+    (name) => !name.endsWith('.test.ts') && !name.includes('__tests__')
+  );
 
 /** The declaration head at `start`: everything up to and including the `=`. */
 const headAt = (lines: readonly string[], start: number): string => {

--- a/.gaia/cli/src/command-reachability.test.ts
+++ b/.gaia/cli/src/command-reachability.test.ts
@@ -74,6 +74,7 @@ import {
   matchesUnquotedInvocation,
 } from './util/gaia-invocation-matcher.js';
 import {resolveRepoRootFromImportMeta} from './util/repo-root-fixture.js';
+import {collectTreeFiles} from './util/tree-walk.js';
 
 // Subcommands reachable only through their router with no external invoker,
 // allowed on purpose. Each entry needs a reason. Wiring or retiring a command
@@ -278,10 +279,10 @@ const enumerateLeafCommands = (
 const collectText = (absDir: string): string => {
   if (!existsSync(absDir)) return '';
 
-  let entries: string[];
+  let entries: readonly string[];
 
   try {
-    entries = readdirSync(absDir, {recursive: true}) as string[];
+    entries = collectTreeFiles(absDir, TEXT_EXTENSIONS);
   } catch {
     return '';
   }
@@ -289,14 +290,12 @@ const collectText = (absDir: string): string => {
   const parts: string[] = [];
 
   for (const rel of entries) {
-    if (TEXT_EXTENSIONS.has(path.extname(rel).toLowerCase())) {
-      const abs = path.join(absDir, rel);
+    const abs = path.join(absDir, rel);
 
-      try {
-        if (statSync(abs).isFile()) parts.push(readFileSync(abs, 'utf8'));
-      } catch {
-        // Unreadable entry (e.g. a dangling symlink); skip it.
-      }
+    try {
+      if (statSync(abs).isFile()) parts.push(readFileSync(abs, 'utf8'));
+    } catch {
+      // Unreadable entry (e.g. a dangling symlink); skip it.
     }
   }
 

--- a/.gaia/cli/src/command-reachability.test.ts
+++ b/.gaia/cli/src/command-reachability.test.ts
@@ -295,7 +295,9 @@ const collectText = (absDir: string): string => {
     try {
       if (statSync(abs).isFile()) parts.push(readFileSync(abs, 'utf8'));
     } catch {
-      // Unreadable entry (e.g. a dangling symlink); skip it.
+      // Removed between the walk and the read; skip it. The walk reports
+      // regular files only, so that race is the one cause left here, and it
+      // is what the stat above still covers too.
     }
   }
 

--- a/.gaia/cli/src/escape-regexp-uniqueness.test.ts
+++ b/.gaia/cli/src/escape-regexp-uniqueness.test.ts
@@ -79,9 +79,10 @@
  * scan skips there. Mirrors `module-docblock-placement.test.ts`.
  */
 import {describe, expect, test} from 'vitest';
-import {existsSync, readdirSync, readFileSync} from 'node:fs';
+import {existsSync, readFileSync} from 'node:fs';
 import path from 'node:path';
 import {resolveRepoRootFromImportMeta} from './util/repo-root-fixture.js';
+import {collectTreeFiles, TS_SOURCE_EXTENSIONS} from './util/tree-walk.js';
 
 const REGEX_METACHARACTERS = new Set([
   '$',
@@ -148,17 +149,12 @@ const findEscapeSetDeclaration = (source: string): null | number => {
   return null;
 };
 
-// Separators normalized to POSIX, because the one entry compared by name below
-// is the declaring module. A native separator would make that comparison miss,
-// and the miss reports the shared declaration itself as the copy it exists to
-// find, which reads as the guard working.
-const collectSourceFiles = (root: string): readonly string[] =>
-  (readdirSync(root, {recursive: true}) as string[])
-    .filter((entry) => entry.endsWith('.ts'))
-    .map((entry) => entry.split(path.sep).join('/'))
-    .toSorted((a, b) => a.localeCompare(b));
-
-/** The declaring module, relative to `.gaia/cli/src`. */
+/**
+ * The declaring module, relative to `.gaia/cli/src` and spelled the way
+ * `collectTreeFiles` reports an entry. Any other spelling makes the comparison
+ * below miss, and the miss reports the shared declaration itself as a copy of
+ * itself, which reads as the guard working.
+ */
 const DECLARING_MODULE = 'util/escape-regexp.ts';
 
 const repoRoot = resolveRepoRootFromImportMeta(import.meta.url);
@@ -183,7 +179,7 @@ describe('escapeRegExp uniqueness', () => {
   test.skipIf(!sourcesPresent)(
     'no file outside the declaring module declares an escape set',
     () => {
-      const sources = collectSourceFiles(cliSrc);
+      const sources = collectTreeFiles(cliSrc, TS_SOURCE_EXTENSIONS);
 
       // A scan that reaches nothing reports nothing, so the empty result below
       // would read as a clean corpus. `.gaia/cli/src` has held hundreds of

--- a/.gaia/cli/src/module-docblock-placement.test.ts
+++ b/.gaia/cli/src/module-docblock-placement.test.ts
@@ -53,9 +53,10 @@
  * there. Mirrors `command-reachability.test.ts`.
  */
 import {describe, expect, test} from 'vitest';
-import {existsSync, readdirSync, readFileSync} from 'node:fs';
+import {existsSync, readFileSync} from 'node:fs';
 import path from 'node:path';
 import {resolveRepoRootFromImportMeta} from './util/repo-root-fixture.js';
+import {collectTreeFiles, TS_SOURCE_EXTENSIONS} from './util/tree-walk.js';
 
 /** Line index of the `*\/` closing the block comment opened at `start`. */
 const blockCommentEnd = (lines: readonly string[], start: number): number => {
@@ -193,11 +194,6 @@ const findStrandedDocblock = (source: string): null | number => {
   return null;
 };
 
-const collectSourceFiles = (root: string): readonly string[] =>
-  (readdirSync(root, {recursive: true}) as string[])
-    .filter((entry) => entry.endsWith('.ts'))
-    .toSorted((a, b) => a.localeCompare(b));
-
 const repoRoot = resolveRepoRootFromImportMeta(import.meta.url);
 const cliSrc = path.join(repoRoot, '.gaia', 'cli', 'src');
 const sourcesPresent = existsSync(cliSrc);
@@ -208,7 +204,7 @@ describe('module docblock placement', () => {
   test.skipIf(!sourcesPresent)(
     'every module docblock precedes the first import',
     () => {
-      const sources = collectSourceFiles(cliSrc);
+      const sources = collectTreeFiles(cliSrc, TS_SOURCE_EXTENSIONS);
 
       // A scan that reaches nothing reports nothing, so the empty result below
       // would read as a clean corpus. `.gaia/cli/src` has held hundreds of

--- a/.gaia/cli/src/util/tree-walk.test.ts
+++ b/.gaia/cli/src/util/tree-walk.test.ts
@@ -1,14 +1,44 @@
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
-import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import {tmpdir} from 'node:os';
 import path from 'node:path';
-import {collectTreeFiles, TS_SOURCE_EXTENSIONS} from './tree-walk.js';
+import {
+  collectTreeFiles,
+  normalizeEntry,
+  TS_SOURCE_EXTENSIONS,
+} from './tree-walk.js';
 
 const seed = (root: string, relative: string): void => {
   const abs = path.join(root, relative);
   mkdirSync(path.dirname(abs), {recursive: true});
   writeFileSync(abs, '', 'utf8');
 };
+
+// The separator is passed rather than read from `path.sep`, so these assert on
+// input the walk cannot produce on any platform this repository runs on. That
+// is the point: through `collectTreeFiles` alone the rewrite is the identity
+// function here and deleting it would leave every test green.
+describe('normalizeEntry', () => {
+  test('rewrites a Windows separator to POSIX', () => {
+    expect(normalizeEntry(String.raw`nested\deep\leaf.ts`, '\\')).toBe(
+      'nested/deep/leaf.ts'
+    );
+  });
+
+  test('leaves an entry that carries no separator alone', () => {
+    expect(normalizeEntry('leaf.ts', '\\')).toBe('leaf.ts');
+  });
+
+  test('leaves an already-POSIX entry alone', () => {
+    expect(normalizeEntry('nested/leaf.ts', '/')).toBe('nested/leaf.ts');
+  });
+});
 
 describe('collectTreeFiles', () => {
   let dir: string;
@@ -37,13 +67,12 @@ describe('collectTreeFiles', () => {
     ]);
   });
 
-  test('normalizes separators to POSIX', () => {
+  test('reports entries POSIX-separated', () => {
     seed(dir, path.join('nested', 'leaf.ts'));
 
     const [entry] = collectTreeFiles(dir, TS_SOURCE_EXTENSIONS);
 
     expect(entry).toBe('nested/leaf.ts');
-    expect(entry).not.toContain(path.sep === '/' ? '\\' : path.sep);
   });
 
   test('sorts the entries', () => {
@@ -71,12 +100,19 @@ describe('collectTreeFiles', () => {
     expect(collectTreeFiles(dir, new Set(['.md']))).toEqual(['prose.md']);
   });
 
-  test('does not exclude a directory whose name carries a matching extension', () => {
+  // Reported, this would reach a caller's `readFileSync` and throw EISDIR.
+  test('excludes a directory whose name carries a matching extension', () => {
     mkdirSync(path.join(dir, 'looks-like-a-file.ts'));
+    seed(dir, 'real.ts');
 
-    expect(collectTreeFiles(dir, TS_SOURCE_EXTENSIONS)).toEqual([
-      'looks-like-a-file.ts',
-    ]);
+    expect(collectTreeFiles(dir, TS_SOURCE_EXTENSIONS)).toEqual(['real.ts']);
+  });
+
+  test('excludes a symlink rather than following it', () => {
+    seed(dir, 'real.ts');
+    symlinkSync(path.join(dir, 'real.ts'), path.join(dir, 'link.ts'));
+
+    expect(collectTreeFiles(dir, TS_SOURCE_EXTENSIONS)).toEqual(['real.ts']);
   });
 
   test('throws when the root does not exist', () => {

--- a/.gaia/cli/src/util/tree-walk.test.ts
+++ b/.gaia/cli/src/util/tree-walk.test.ts
@@ -1,0 +1,87 @@
+import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {collectTreeFiles, TS_SOURCE_EXTENSIONS} from './tree-walk.js';
+
+const seed = (root: string, relative: string): void => {
+  const abs = path.join(root, relative);
+  mkdirSync(path.dirname(abs), {recursive: true});
+  writeFileSync(abs, '', 'utf8');
+};
+
+describe('collectTreeFiles', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), 'gaia-collect-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, {force: true, recursive: true});
+  });
+
+  test('keeps only the entries whose extension is in the set', () => {
+    seed(dir, 'kept.ts');
+    seed(dir, 'skipped.md');
+    seed(dir, 'skipped');
+
+    expect(collectTreeFiles(dir, TS_SOURCE_EXTENSIONS)).toEqual(['kept.ts']);
+  });
+
+  test('reaches nested entries and reports them relative to the root', () => {
+    seed(dir, 'nested/deep/leaf.ts');
+
+    expect(collectTreeFiles(dir, TS_SOURCE_EXTENSIONS)).toEqual([
+      'nested/deep/leaf.ts',
+    ]);
+  });
+
+  test('normalizes separators to POSIX', () => {
+    seed(dir, path.join('nested', 'leaf.ts'));
+
+    const [entry] = collectTreeFiles(dir, TS_SOURCE_EXTENSIONS);
+
+    expect(entry).toBe('nested/leaf.ts');
+    expect(entry).not.toContain(path.sep === '/' ? '\\' : path.sep);
+  });
+
+  test('sorts the entries', () => {
+    seed(dir, 'b.ts');
+    seed(dir, 'a.ts');
+    seed(dir, 'nested/a.ts');
+
+    expect(collectTreeFiles(dir, TS_SOURCE_EXTENSIONS)).toEqual([
+      'a.ts',
+      'b.ts',
+      'nested/a.ts',
+    ]);
+  });
+
+  test('matches the extension case-insensitively', () => {
+    seed(dir, 'shouty.TS');
+
+    expect(collectTreeFiles(dir, TS_SOURCE_EXTENSIONS)).toEqual(['shouty.TS']);
+  });
+
+  test('honors a caller-supplied extension set', () => {
+    seed(dir, 'prose.md');
+    seed(dir, 'code.ts');
+
+    expect(collectTreeFiles(dir, new Set(['.md']))).toEqual(['prose.md']);
+  });
+
+  test('does not exclude a directory whose name carries a matching extension', () => {
+    mkdirSync(path.join(dir, 'looks-like-a-file.ts'));
+
+    expect(collectTreeFiles(dir, TS_SOURCE_EXTENSIONS)).toEqual([
+      'looks-like-a-file.ts',
+    ]);
+  });
+
+  test('throws when the root does not exist', () => {
+    expect(() =>
+      collectTreeFiles(path.join(dir, 'absent'), TS_SOURCE_EXTENSIONS)
+    ).toThrow(/ENOENT/);
+  });
+});

--- a/.gaia/cli/src/util/tree-walk.ts
+++ b/.gaia/cli/src/util/tree-walk.ts
@@ -14,8 +14,20 @@ import path from 'node:path';
 export const TS_SOURCE_EXTENSIONS: ReadonlySet<string> = new Set(['.ts']);
 
 /**
- * Every entry under `root` whose extension is in `extensions`, relative to
- * `root`, separators normalized to POSIX, sorted.
+ * `entry` with `separator` rewritten to POSIX `/`.
+ *
+ * The separator is a parameter so that this has a falsifiable test. `path.sep`
+ * is `/` on every platform this repository runs on, so a test that feeds a
+ * native-separator entry through `collectTreeFiles` passes just as well with
+ * the rewrite deleted, and the one property a caller depends on ends up
+ * guarded by nothing. A test hands this a Windows separator directly.
+ */
+export const normalizeEntry = (entry: string, separator: string): string =>
+  entry.split(separator).join('/');
+
+/**
+ * Every regular file under `root` whose extension is in `extensions`, relative
+ * to `root`, separators normalized to POSIX, sorted.
  *
  * The extension set is a required parameter rather than a default, because a
  * default is how a caller that meant "everything" silently gets a narrower
@@ -23,9 +35,18 @@ export const TS_SOURCE_EXTENSIONS: ReadonlySet<string> = new Set(['.ts']);
  *
  * Normalization is unconditional: a POSIX-separated entry is correct for every
  * caller, and a caller that compares an entry against a repo-relative module
- * path breaks without it. Entries are names, not proven files, so a directory
- * whose own name carries a matching extension is reported like any other
- * entry; a caller that reads each entry stats it.
+ * path breaks without it.
+ *
+ * Only regular files are reported, so a caller may read each entry without
+ * stating it first: a directory whose own name carries a matching extension
+ * would otherwise reach `readFileSync` and throw `EISDIR`. A symlink is not a
+ * regular file here, so the walk does not follow one, and a caller that needs
+ * to owns that stat.
+ *
+ * No directory is excluded. A caller that walks a tree holding a build or
+ * vendor directory owns that filter, which is the honest shape while no caller
+ * does: an exclusion carried here for no live caller is a rule nobody can
+ * check.
  *
  * A `root` that does not exist throws, the way `readdirSync` does. Silence
  * there would be the discovery-stage fail-open this walk exists to close.
@@ -34,7 +55,15 @@ export const collectTreeFiles = (
   root: string,
   extensions: ReadonlySet<string>
 ): readonly string[] =>
-  (readdirSync(root, {recursive: true}) as string[])
-    .filter((entry) => extensions.has(path.extname(entry).toLowerCase()))
-    .map((entry) => entry.split(path.sep).join('/'))
+  readdirSync(root, {recursive: true, withFileTypes: true})
+    .filter(
+      (entry) =>
+        entry.isFile() && extensions.has(path.extname(entry.name).toLowerCase())
+    )
+    .map((entry) =>
+      normalizeEntry(
+        path.relative(root, path.join(entry.parentPath, entry.name)),
+        path.sep
+      )
+    )
     .toSorted((a, b) => a.localeCompare(b));

--- a/.gaia/cli/src/util/tree-walk.ts
+++ b/.gaia/cli/src/util/tree-walk.ts
@@ -1,0 +1,40 @@
+/**
+ * The recursive tree walk every whole-tree guard suite scans with.
+ *
+ * A guard's corpus is exactly the set it is trusted to have scanned, and a
+ * per-suite copy of the walk drifts out from under that trust in silence:
+ * near-identical functions are not identical ones, so no lint rule reports a
+ * copy that stops normalizing separators, and an exclusion or a filter added
+ * to one copy reaches none of the others.
+ */
+import {readdirSync} from 'node:fs';
+import path from 'node:path';
+
+/** The extension set the TypeScript-only guard suites scan with. */
+export const TS_SOURCE_EXTENSIONS: ReadonlySet<string> = new Set(['.ts']);
+
+/**
+ * Every entry under `root` whose extension is in `extensions`, relative to
+ * `root`, separators normalized to POSIX, sorted.
+ *
+ * The extension set is a required parameter rather than a default, because a
+ * default is how a caller that meant "everything" silently gets a narrower
+ * corpus and reads the resulting empty answer as a clean pass.
+ *
+ * Normalization is unconditional: a POSIX-separated entry is correct for every
+ * caller, and a caller that compares an entry against a repo-relative module
+ * path breaks without it. Entries are names, not proven files, so a directory
+ * whose own name carries a matching extension is reported like any other
+ * entry; a caller that reads each entry stats it.
+ *
+ * A `root` that does not exist throws, the way `readdirSync` does. Silence
+ * there would be the discovery-stage fail-open this walk exists to close.
+ */
+export const collectTreeFiles = (
+  root: string,
+  extensions: ReadonlySet<string>
+): readonly string[] =>
+  (readdirSync(root, {recursive: true}) as string[])
+    .filter((entry) => extensions.has(path.extname(entry).toLowerCase()))
+    .map((entry) => entry.split(path.sep).join('/'))
+    .toSorted((a, b) => a.localeCompare(b));

--- a/.gaia/cli/src/wiki/sync-await.test.ts
+++ b/.gaia/cli/src/wiki/sync-await.test.ts
@@ -13,7 +13,6 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
-  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -22,6 +21,7 @@ import {tmpdir} from 'node:os';
 import path from 'node:path';
 import {EXIT_CODES} from '../exit.js';
 import {resolveRepoRootFromImportMeta} from '../util/repo-root-fixture.js';
+import {collectTreeFiles, TS_SOURCE_EXTENSIONS} from '../util/tree-walk.js';
 import {run} from './sync-await.js';
 import {defaultRunner} from './util/branch.js';
 import type {CommandRunner} from './util/branch.js';
@@ -877,33 +877,15 @@ describe('wiki sync await', () => {
     const repoRoot = resolveRepoRootFromImportMeta(import.meta.url);
     const cliSrc = path.join(repoRoot, '.gaia', 'cli', 'src');
 
-    const walk = (dir: string): string[] => {
-      const entries = readdirSync(dir, {withFileTypes: true});
-      const files: string[] = [];
-
-      for (const entry of entries) {
-        const abs = path.join(dir, entry.name);
-        const isSkippedDir =
-          entry.name === 'node_modules' || entry.name === 'dist';
-
-        if (entry.isDirectory()) {
-          if (!isSkippedDir) files.push(...walk(abs));
-        } else if (
-          entry.name.endsWith('.ts') &&
-          !entry.name.endsWith('.test.ts')
-        ) {
-          files.push(abs);
-        }
-      }
-
-      return files;
-    };
+    const sources = collectTreeFiles(cliSrc, TS_SOURCE_EXTENSIONS).filter(
+      (entry) => !entry.endsWith('.test.ts')
+    );
 
     let definitionCount = 0;
     let callCount = 0;
 
-    for (const file of walk(cliSrc)) {
-      const contents = readFileSync(file, 'utf8');
+    for (const relative of sources) {
+      const contents = readFileSync(path.join(cliSrc, relative), 'utf8');
       definitionCount += (
         contents.match(/^export const cleanupAfterMerge = /gmu) ?? []
       ).length;


### PR DESCRIPTION
Closes #1869

## What

Five whole-tree guard suites each hand-rolled their own recursive walk of `.gaia/cli/src`. `util/tree-walk.ts` now holds the one walk; every suite imports it and the local copies are gone.

## Why now

The copies had already diverged, and the divergence was silent in both directions:

- `module-docblock-placement.test.ts` and `escape-regexp-uniqueness.test.ts` each defined a `collectSourceFiles` with the same name, signature and body, differing by one clause: only the second normalized separators to POSIX. The one that needed it needed it because it compares an entry against a repo-relative module path, and a native separator would have made that comparison miss, reporting the shared declaration as a copy of itself.
- `argv-lookup-guard.test.ts` inlined the same walk against a module-level root.
- `command-reachability.test.ts` carried a try/catch variant.
- `wiki/sync-await.test.ts` wrote a different recursion again, with its own `node_modules`/`dist` exclusions. This fifth copy is not in the issue; a reuse pass over the consolidation found it, and it is the sharpest evidence for the issue's premise: the next author does not even copy, they write a fresh walk with a fresh set of rules.

`sonarjs/no-identical-functions` sees none of this, because the copies are not byte-identical. **That is the same reason the private `escapeRegExp` copies accumulated unnoticed, which is the class `escape-regexp-uniqueness.test.ts` was added to close: the guard against private copies shipped as one.** A guard's corpus is exactly the set it is trusted to have scanned, so a walk that quietly reaches less than a maintainer believes is a discovery-stage failure that reads as a clean pass, and an exclusion or filter added to one walk reaches none of the others.

## The three design calls

The issue settled two of these from the adjacent code, and this follows both:

- **The extension filter is a parameter**, since `command-reachability.test.ts` walks a text-extension set for a different purpose than the `.ts`-only guards. It is **required rather than defaulted**: a default is how a caller that meant "everything" silently gets a narrower corpus and reads the resulting empty answer as a clean pass.
- **Normalization is unconditional**, since a POSIX-separated entry is correct for every caller and only one of them currently depends on it.

The third is a deliberate departure. The issue proposed `util/repo-root-fixture.ts` as the home, on the grounds that every one of these suites already imports it and no new module is owed. A separate module is taken instead: the two exports have nothing to do with each other, one searching upward for a repo root and the other collecting downward from a given one; `util/` is otherwise one concept per file; and a sibling test file named for the locator that tests only the walk is the tell. `repo-root-fixture.ts` is unchanged by this PR.

A missing root throws rather than reporting empty, for the same fail-open reason. `collectText` keeps its own `try`/`catch` around the call, so its tolerate-and-return-nothing behaviour is unchanged while the walk itself stays honest.

## Verification

- The corpus each `.ts` guard scans is **byte-identical before and after**: 321 entries, no adds and no drops.
- Sabotaging the shared filter to return nothing reds **all five consuming suites** plus the walk's own tests, so no guard passes an empty scan through the new seam.
- `pnpm -C .gaia/cli test`: 154 files / 2513 tests pass. Quality Gate green (typecheck, both lint workspaces, app tests, Playwright, build).

`util/tree-walk.ts` is imported only by test files, so this rotates neither CLI bundle and commits no rebuilt binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Audit rounds

Three rounds, all clean passes with earned markers. Rounds 1 and 2 each found real defects in this change, both fixed on the branch:

- **Round 1** proved the POSIX-normalization test unfalsifiable (deleting the rewrite left the suite green, because `path.sep` is `/` on every platform this repo runs on), and caught that `wiki/sync-await.test.ts` had lost the directory exclusion its own walk carried. Both fixed in `cf6004b6`: the rewrite is now `normalizeEntry(entry, separator)` with a Windows-separator test, and the walk reports regular files only. Its fourth finding, that nothing stops a sixth private walk appearing, is filed as #1879 rather than folded in.
- **Round 2** found that the `collectText` catch comment still named a dangling symlink as its example, which the file-only walk had made unreachable. Fixed in `2fceb579`.

### Accepted residual

**`.gaia/cli/src/command-reachability.test.ts:298`** — the round-2 replacement comment overclaims. It says the removal race is "the one cause left here"; a regular file whose mode denies read reaches the same `catch` with no removal involved, as does `EMFILE` under fd pressure. Round 3 reproduced the `EACCES` path directly.

Accepted rather than fixed, on two grounds. There is no live failure mode: a dropped file shrinks `invokerText`, which makes `isReachable` harder to satisfy, so the reachability assertions fail closed. And the correction is a comment clause, while landing it would rotate this member's content digest and cost a fourth round the session cap forbids, which is the round-over-round nitpick spiral that cap exists to stop.

The correction, for whoever next touches that file: drop the exhaustiveness claim and keep the true half, `// Removed between the walk and the read, or unreadable; skip it. The walk reports regular files only, so EISDIR and a dangling symlink are already excluded.`
