### PR TITLE
wiki: sync through d4e4d58

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "c25418411b0f4da9f971104b7c43a6a7f9e6546b",
-  "last_evaluated_at": "2026-09-08T06:33:05Z",
+  "last_evaluated_sha": "d4e4d58b8db1157c2e63c89df4fcd480d87e41c4",
+  "last_evaluated_at": "2026-09-08T12:08:34Z",
   "last_consolidated_sha": "78c69d0f81d5bc6460453391c466570f30da43c4",
   "last_consolidated_at": "2026-09-08T06:34:36Z"
 }

--- a/wiki/decisions/Wiki Management.md
+++ b/wiki/decisions/Wiki Management.md
@@ -4,7 +4,7 @@ status: active
 priority: 1
 date: 2026-05-07
 created: 2026-05-07
-updated: 2026-08-02
+updated: 2026-09-08
 tags: [decision, wiki, cli]
 ---
 
@@ -30,7 +30,7 @@ The wiki is critical infrastructure; it decays when drift between code and docum
 
 **`gaia wiki near-collisions`**: Groups pages per domain (decisions, concepts, modules, etc.) and finds near-duplicate titles using Levenshtein distance. Used by `/gaia-wiki consolidate` to surface redundancy.
 
-**`gaia wiki dead-paths`**: Lists backticked repo paths in `wiki/` body prose that don't exist on disk. Used by `/gaia-wiki lint` to catch zombie filename references after merges and renames.
+**`gaia wiki dead-paths`**: Lists backticked repo paths in `wiki/` body prose that don't exist on disk. Used by `/gaia-wiki lint` to catch zombie filename references after merges and renames. Exempts an explicit `HYPOTHETICAL_EXAMPLE_PATHS` set alongside the adopter-owned sentinels: a well-formed path a page names purely as a worked example of something that does not exist and is not meant to (e.g. a hypothetical future file, a made-up path illustrating a quoting rule) would otherwise report as dead on every run forever. Membership is by exact token (normalized to NFC), not a prefix rule, so a real dead citation nearby still flags.
 
 **`gaia wiki sync land`**: Branch-aware landing of staged wiki changes: commits in place on a feature branch; on `main`, stages a branch, opens a PR, queues auto-merge, and takes one bounded wait on it. When the merge lands inside that wait the command cleans up locally (returns to base, pulls, deletes the branch, prunes); on the common path the merge gate outlasts any wait that fits in a single invocation, so it returns with the local cleanup outstanding and `sync await` or the session-start janitor completes it. Used by `/gaia-wiki sync` as the deterministic write step.
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,16 @@ tags: [meta, log]
 
 ## [Unreleased]
 
+- 2026-09-08 d4e4d58 SKIP - errexit-source guard scan_roots widened to .github, page deliberately defers guard-surface detail to the guard's own header (precedent: log 4a55dc40)
+- 2026-09-08 2ed6816 SKIP - internal refactor consolidating whole-tree guard walks into a shared module, no CHANGELOG entry, no documented-contract change
+- 2026-09-08 51e8428 WORTHY - dead-path scan gains HYPOTHETICAL_EXAMPLE_PATHS exemption -> wiki/decisions/Wiki Management.md dead-paths bullet updated
+- 2026-09-08 0a0689c SKIP - tests-only
+- 2026-09-08 efe2628 SKIP - CI plumbing
+- 2026-09-08 c44d654 SKIP - internal robustness fix to resolve-audit-base.sh's fail-safe path, no documented-contract change
+- 2026-09-08 97eee29 SKIP - tests-only
+- 2026-09-08 a370b47 SKIP - health lens fix already updated wiki/decisions/Claude Integration Fitness.md in the commit itself
+- 2026-09-08 6e7278a SKIP - comment-only bullet reclassification in lint-hook-cwd-relative-loads.sh, zero behavior change
+- 2026-09-08 7eab894 SKIP - wiki's own prior maintenance chain commit, no new source content to sync
 - 2026-09-08 c2541841 WORTHY - hooks now root library loads and gate reads on BASH_SOURCE, not cwd -> wiki/concepts/Claude Hooks.md
 - 2026-09-08 2238689b SKIP - audit-scratch-dir worktree-keying bugfix, existing wiki pointers already abstract over this detail
 - 2026-09-08 991b0698 SKIP - internal NOUN vocab tweak in lint-stale-cardinals.sh, no dedicated wiki page (enumeration would violate wiki-style)


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to d4e4d58.