### PR TITLE
debt(tests): route four bats suites' allowlist builders through path_allowlist

### DIFF
--- a/.gaia/scripts/tests/audit-noop-detect.bats
+++ b/.gaia/scripts/tests/audit-noop-detect.bats
@@ -17,6 +17,8 @@ assert_contains() {
 
 setup() {
   THIS_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
+  # shellcheck source=.gaia/tests/helpers/path.sh
+  . "$( cd "$THIS_DIR/../../.." && pwd )/.gaia/tests/helpers/path.sh"
   SCRIPT="$THIS_DIR/../audit-noop-detect.sh"
   [ -x "$SCRIPT" ] || skip "audit-noop-detect.sh not executable"
   FIX="$THIS_DIR/fixtures/audit-noop"
@@ -587,14 +589,9 @@ _noop_write_findings() {
 
   # Shim PATH rather than an empty one: the script's `#!/usr/bin/env bash`
   # shebang and its basename/cat/grep calls all resolve through PATH, so
-  # emptying it fails the run at exec time (127) and tests nothing. Symlink in
+  # emptying it fails the run at exec time (127) and tests nothing. Name
   # exactly what the script needs and deliberately leave jq out.
-  shim="$BATS_TEST_TMPDIR/nojq-bin"
-  mkdir -p "$shim"
-  for _c in bash basename cat grep dirname; do
-    _p="$(command -v "$_c" 2>/dev/null)" || continue
-    ln -sf "$_p" "$shim/$_c"
-  done
+  shim="$(path_allowlist bash basename cat grep dirname)"
   if PATH="$shim" command -v jq >/dev/null 2>&1; then
     skip "jq still resolvable through the shim PATH"
   fi

--- a/.gaia/tests/hooks/capture-gh-artifact.bats
+++ b/.gaia/tests/hooks/capture-gh-artifact.bats
@@ -10,6 +10,7 @@ setup() {
   . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HELPERS="$BATS_TEST_DIRNAME/helpers"
   REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  . "$REPO_ROOT/.gaia/tests/helpers/path.sh"
   HOOK_ABS="$REPO_ROOT/.claude/hooks/capture-gh-artifact.sh"
   LIB_SRC="$REPO_ROOT/.gaia/scripts/gh-artifact-lib.sh"
   AKL_SRC="$REPO_ROOT/.gaia/scripts/audit-key-lib.sh"
@@ -258,11 +259,7 @@ any_breadcrumb_exists() {
   cd "$REPO"
   git checkout -b feat/nojq --quiet
 
-  nojq_bin="$BATS_TEST_TMPDIR/nojq-bin"
-  mkdir -p "$nojq_bin"
-  ln -sf "$(command -v bash)" "$nojq_bin/bash"
-  ln -sf "$(command -v cat)" "$nojq_bin/cat"
-  ln -sf "$(command -v git)" "$nojq_bin/git"
+  nojq_bin="$(path_allowlist bash cat git)"
 
   input=$("$HELPERS/mock-hook-input.sh" post-tool-use S1 Bash "gh pr create --title x" \
     "https://github.com/gaia-react/gaia/pull/712")

--- a/.gaia/tests/hooks/issue-claim-release.bats
+++ b/.gaia/tests/hooks/issue-claim-release.bats
@@ -25,6 +25,7 @@
 
 setup() {
   . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
+  . "$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)/.gaia/tests/helpers/path.sh"
   HELPERS="$BATS_TEST_DIRNAME/helpers"
   HOOK_ABS=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)/issue-claim-release.sh
   command -v jq >/dev/null 2>&1 || skip "jq required"
@@ -634,14 +635,7 @@ assert_nothing_released() { [ ! -s "$FAKE_GH_STATE/issue_edits" ]; }
 
 @test "8a: gh absent from PATH releases nothing and exits 0" {
   export FAKE_GH_PR_BODY="Closes #12"
-  nogh_bin="$BATS_TEST_TMPDIR/nogh-bin"
-  mkdir -p "$nogh_bin"
-  ln -sf "$(command -v bash)" "$nogh_bin/bash"
-  ln -sf "$(command -v jq)" "$nogh_bin/jq"
-  ln -sf "$(command -v git)" "$nogh_bin/git"
-  ln -sf "$(command -v grep)" "$nogh_bin/grep"
-  ln -sf "$(command -v sort)" "$nogh_bin/sort"
-  ln -sf "$(command -v cat)" "$nogh_bin/cat"
+  nogh_bin="$(path_allowlist bash jq git grep sort cat)"
 
   input=$("$HELPERS/mock-hook-input.sh" post-tool-use S1 Bash 'gh pr merge 42')
   PATH="$nogh_bin" invoke_hook_in "$REPO" "$input" "$HOOK_ABS"
@@ -651,10 +645,7 @@ assert_nothing_released() { [ ! -s "$FAKE_GH_STATE/issue_edits" ]; }
 
 @test "8b: jq absent from PATH releases nothing and exits 0" {
   export FAKE_GH_PR_BODY="Closes #12"
-  nojq_bin="$BATS_TEST_TMPDIR/nojq-bin"
-  mkdir -p "$nojq_bin"
-  ln -sf "$(command -v bash)" "$nojq_bin/bash"
-  ln -sf "$(command -v cat)" "$nojq_bin/cat"
+  nojq_bin="$(path_allowlist bash cat)"
 
   input=$("$HELPERS/mock-hook-input.sh" post-tool-use S1 Bash 'gh pr merge 42')
   PATH="$nojq_bin" invoke_hook_in "$REPO" "$input" "$HOOK_ABS"

--- a/.gaia/tests/hooks/local-janitor-outlier-sweep.bats
+++ b/.gaia/tests/hooks/local-janitor-outlier-sweep.bats
@@ -48,6 +48,7 @@
 # `return 1`, never `!`-negation; final-line absence uses `[ ! -e ... ]`.
 
 setup() {
+  . "$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)/.gaia/tests/helpers/path.sh"
   HOOK_ABS=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)/local-janitor.sh
   GAIA_DIR_REAL=$(cd "$BATS_TEST_DIRNAME/../.." && pwd)
 }
@@ -287,11 +288,7 @@ copy_shipped_registry() {
   local_dir="$REPO/.gaia/local"
   echo x > "$local_dir/totally-unknown-thing.md"
 
-  nojq_bin="$BATS_TEST_TMPDIR/nojq-bin"
-  mkdir -p "$nojq_bin"
-  ln -sf "$(command -v bash)" "$nojq_bin/bash"
-  ln -sf "$(command -v git)" "$nojq_bin/git"
-  ln -sf "$(command -v dirname)" "$nojq_bin/dirname"
+  nojq_bin="$(path_allowlist bash git dirname)"
 
   cd "$REPO"
   PATH="$nojq_bin" GAIA_JANITOR_SWEEP_ONLY=outliers run bash "$HOOK_ABS"


### PR DESCRIPTION
Closes #1890

## What

Four bats suites carried five inline copies of the additive PATH-allowlist rebuild, none of them sourcing `.gaia/tests/helpers/path.sh`:

- `.gaia/tests/hooks/issue-claim-release.bats` — **two** sites (8a `nogh_bin`, 8b `nojq_bin`)
- `.gaia/tests/hooks/capture-gh-artifact.bats`
- `.gaia/tests/hooks/local-janitor-outlier-sweep.bats`
- `.gaia/scripts/tests/audit-noop-detect.bats` — the `for` + `command -v … || continue` spelling

Each suite now sources the helper in its `setup()` and calls `path_allowlist NAME...`. Every enumeration is carried over unchanged: the list is the caller's, and the point is that the mechanism has one home, not that the lists reconcile.

`.gaia/tests/helpers/path.sh` is untouched.

## Scope: this delivers #1890's enumeration, it does not retire the class

The commit subject on this branch says "the last five allowlist builders". **That word is wrong**, and this section is the correction. The construct still stands inline at eight further sites the issue never enumerated: `drift-check.bats:202-205`, `token-tally-review.bats:177`, `check-cli-workspace-floors.bats:899` and `:1455` and `:1471` and `:1487`, `serena-lang-drift.bats:308`, `post-findings-block.bats:193`, `spec-reconcile.bats:81`, and `07-gh-not-installed.bats:58`.

Filed as **#1895**. Two of those sites build outside `BATS_TEST_TMPDIR`, so each needs a judgement on whether `path_allowlist`'s per-test lifetime fits before conversion — which is why they are a follow-up rather than a widening of this PR.

Why the miscount survived authoring: the obvious grep for this class (`ln -sf "$(command -v`) misses the loop spellings and the bare `ln -s` form, so a literal search reports clean over most of the set. `git grep -n 'ln -s' -- '.gaia/**/*.bats'` and reading each hit is what finds it. `code-audit-maintainer-shell` caught this.

## Why

Nothing failed today; the drift is the defect the helper's own docblock names as the condition it exists to remove. The repair the primitive already carries and the copies did not: `command -v` answers a builtin with a bare word, so a hand-rolled `ln -sf "$(command -v printf)" "$dir/printf"` creates a self-referential dangling symlink, while `path_allowlist` walks `$PATH` for the real file. No converted enumeration names a builtin-shadowed command, so this buys the repair rather than fixing a live break.

The fifth spelling's `|| continue` is not a behavioural difference: `path_allowlist` already skips a name the current `$PATH` does not provide, for the reason its docblock gives. And it prints one bare directory with no PATH remainder, so `PATH="$shim"` and the follow-on `PATH="$shim" command -v jq` guard both work unchanged.

## Two corrections to the issue body, applied

Both came from the issue's dispatch-notes comment and govern over the body:

1. **Five build sites, not four.** `issue-claim-release.bats` has two; the body cites only `:654` (test 8b) and misses `:639`-`:644` (test 8a). Both are converted.
2. **The fifth spelling carries no decision.** `audit-noop-detect.bats:592`'s `|| continue` is already the primitive's documented semantics, so all five converge with no judgment call.

## Verification

All four suites run green under bash 5 via `.gaia/scripts/bats5.sh`, unchanged counts:

| Suite | Tests | Failures |
|---|---|---|
| `issue-claim-release.bats` | 81 | 0 |
| `capture-gh-artifact.bats` | 24 | 0 |
| `local-janitor-outlier-sweep.bats` | 27 | 0 |
| `audit-noop-detect.bats` | 96 | 0 |

`.gaia/tests/shell-lint.sh` and `.gaia/tests/whole-tree-invariants.sh` both pass.

**Adversarial fixture** (guards-must-fail): dropping `bash` from 8a's enumeration reds the test, which pins `path_allowlist`'s output as the effective PATH rather than a vacuously-satisfied one. Reverted.

A note on what the conversion does **not** prove: mutating 8b's list to re-add `jq` leaves it green, because that test's PATH excludes `gh` as well, so it releases nothing regardless of jq. That is pre-existing test design in the original hand-rolled form, carried over byte-for-byte, and out of scope here.

## Audit

`code-audit-maintainer-shell` cleared with one out-of-scope finding, filed as #1895 and corrected in the Scope section above.

No CHANGELOG entry: all four files are release-excluded, so nothing adopter-visible changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)