### PR TITLE
debt(tests): retire the two inert SC2317 directives and the retired account

### DIFF
--- a/.gaia/scripts/tests/verify-audit-roster.bats
+++ b/.gaia/scripts/tests/verify-audit-roster.bats
@@ -3,10 +3,16 @@
 # writers use single-quoted printf format strings where a $ is literal output
 # text (the heredoc line they emit into a fixture), not a shell expansion.
 # shellcheck disable=SC2016
-# SC2317 and SC2329 likewise: shellcheck does not model bats' `@test` dispatch,
-# so it reads a block following an early `return 0` as unreachable and the
-# helpers as uncalled. Every test runs; shell-lint gates `.bats` at
-# severity=warning, above these two, so this only quiets an ad-hoc run.
+# SC2317 and SC2329 likewise, and both trace to one cause that is not bats'
+# `@test` dispatch: a `@test` body parses as a top-level brace group rather than
+# a function, so each bare `return 0` terminating a test below reads as a
+# script-level return. Every `@test` after one then reads as unreachable
+# (SC2317), and a helper defined past one reads as never invoked because its
+# call sites do (SC2329). Every test runs. shell-lint gates `.bats` at
+# severity=warning, above both codes, so this only quiets an ad-hoc run. The
+# spelling that avoids both outright is the explicit `true`
+# .claude/rules/bats-assertions.md prescribes, and
+# .gaia/tests/shell-lint.sh's header carries the full account.
 # shellcheck disable=SC2317,SC2329
 # Tests for .gaia/scripts/verify-audit-roster.sh, the roster's deterministic
 # check.

--- a/.gaia/scripts/tests/verify-audit-roster.bats
+++ b/.gaia/scripts/tests/verify-audit-roster.bats
@@ -12,7 +12,8 @@
 # severity=warning, above both codes, so this only quiets an ad-hoc run. The
 # spelling that avoids both outright is the explicit `true`
 # .claude/rules/bats-assertions.md prescribes, and
-# .gaia/tests/shell-lint.sh's header carries the full account.
+# .gaia/tests/shell-lint.sh's header carries the full account of the SC2317
+# half.
 # shellcheck disable=SC2317,SC2329
 # Tests for .gaia/scripts/verify-audit-roster.sh, the roster's deterministic
 # check.

--- a/.gaia/tests/hooks/block-env-read.bats
+++ b/.gaia/tests/hooks/block-env-read.bats
@@ -16,17 +16,6 @@
 # circuit breaker, which forces a manual approval prompt on every recursive
 # search or copy in the tree.
 
-# shellcheck disable=SC2317
-# SC2317 (command appears unreachable) is not intrinsic to bats, and a suite
-# carrying no bare `return` inside a `@test` body reports none of it. A `@test`
-# body parses as a top-level brace group rather than a function, so the bare
-# `return 0` terminating one of the tests below reads as a script-level return
-# and every `@test` after it looks unreachable. File-wide because that cascade
-# is. shell-lint gates `.bats` at severity=warning, above SC2317's info tier, so
-# the directive only quiets an ad-hoc `shellcheck -S style` run. The terminator
-# that avoids it outright is the explicit `true`
-# .claude/rules/bats-assertions.md prescribes.
-
 setup() {
   . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HOOKS_SRC=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)
@@ -313,7 +302,7 @@ run_write_hook_edit() {
   assert_denied_by_json
   grep -qF -- "hunter2" <<<"$output" && return 1
   grep -qF -- "env SECRET=hunter2 cat .env.local" <<<"$output" && return 1
-  return 0
+  true
 }
 
 # --- UAT-007: Edit/Write dimension, driven against the existing write hook ---

--- a/.gaia/tests/hooks/block-eslint-config-edit.bats
+++ b/.gaia/tests/hooks/block-eslint-config-edit.bats
@@ -29,23 +29,12 @@
 # legitimate shape and the silencing shape are the same shape, so the uniform ask
 # is the contract rather than a coarse approximation of one.
 #
-# shellcheck disable=SC2317
-# SC2317 (command appears unreachable) is not intrinsic to bats, and a suite
-# carrying no bare `return` inside a `@test` body reports none of it. A `@test`
-# body parses as a top-level brace group rather than a function, so a bare
-# `return 0` terminating one of the tests below reads as a script-level return
-# and every `@test` after it looks unreachable. File-wide because that cascade
-# is. shell-lint gates `.bats` at severity=warning, above SC2317's info tier, so
-# the directive only quiets an ad-hoc `shellcheck -S style` run. The terminator
-# that avoids it outright is the explicit `true`
-# .claude/rules/bats-assertions.md prescribes. (Keep the word "shellcheck"
-# off the start of a comment line here; it is parsed as a directive there.)
-#
 # shellcheck disable=SC2016
 # SC2016 (expressions don't expand in single quotes) fires on the `$` inside
 # fixture identifiers and on `${...}` inside fixture config bodies. Not
 # expanding is the point: a fixture has to reach the hook as the literal text a
-# real edit would carry.
+# real edit would carry. (Keep the word "shellcheck" off the start of a comment
+# line here; it is parsed as a directive there.)
 
 setup() {
   . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
@@ -254,7 +243,7 @@ export default"
     "    rules: {'no-console': 'off', 'no-empty-pattern': 'off'},"
   [ "$status" -eq 0 ]
   grep -qF -- '"permissionDecision": "deny"' <<<"$output" && return 1
-  return 0
+  true
 }
 
 # The decision is machine-read, so a reason string that broke out of the JSON


### PR DESCRIPTION
Drains the three residuals PR #1884 accepted rather than folded, in the order the issue prescribes: item 3 first, item 2 second, item 1 dissolving with item 3.

## What changed

**`.gaia/tests/hooks/block-env-read.bats`, `.gaia/tests/hooks/block-eslint-config-edit.bats`** — the bare `return 0` terminating a `@test` body swapped for the explicit `true` `.claude/rules/bats-assertions.md` prescribes, and the now-inert file-wide `# shellcheck disable=SC2317` plus the prose justifying it removed. That prose is what carried the narrowed "only quiets an ad-hoc `shellcheck -S style` run" clause item 1 named, so item 1 needs no separate edit.

One thing deliberately preserved: `block-eslint-config-edit.bats`'s SC2317 block also carried "Keep the word `shellcheck` off the start of a comment line here", which is not about SC2317 and still applies to the SC2016 directive below it. It moves to that block rather than going with the deleted one.

**`.gaia/scripts/tests/verify-audit-roster.bats`** — prose only, as the issue says: its `SC2317,SC2329` directive is live (44 SC2317, 5 SC2329 behind it), so only the header changed.

## A correction the re-derivation turned up

The old header named "shellcheck does not model bats' `@test` dispatch" as the cause for both codes. That is the retired account for SC2317, which the issue already says. It is also wrong for **SC2329** on this file, which the issue does not: stripping the file's bare terminators drops SC2329 to zero along with SC2317. So the helpers there read as never invoked because their *call sites* sit past a script-level return, not because bats is what dispatches them. The new header states the single shared cause and points at `.gaia/tests/shell-lint.sh`'s header for the full account.

## Where this deviates from the issue, and why

The issue counts **three** bare `return 0` terminators; there are three bare `return 0`, but only **two** are `@test`-body terminators. `block-eslint-config-edit.bats:59` is inside `teardown()`, a real function, and it drives zero SC2317: with the directive stripped, swapping `:257` alone takes the file to 0, and swapping `:59` alone leaves all 10. It is left as `return 0`, which is correct and clearer than `true` in a real function. The issue's own dispatch comment repeats the three-terminator count, so this is recorded here rather than silently diverged from.

## Verification

shellcheck 0.11.0, `--exclude=SC1091,SC1090` matching `shell-lint.sh`:

| File | SC2317 before (directive stripped) | after |
|---|---|---|
| `block-env-read.bats` | 34 | 0 |
| `block-eslint-config-edit.bats` | 10 | 0 |

Both hook suites are now clean at `-S style`, the strictest tier, with only `block-eslint-config-edit.bats`'s SC2016 directive still doing work. The roster suite is unchanged behind its live directive.

- `bats5.sh` on both hook suites: 96 ok, 0 not ok
- `bats5.sh` on `verify-audit-roster.bats`: 84 ok, 0 not ok, exit 0
- `bash .gaia/tests/shell-lint.sh`: passed
- `bash .gaia/tests/whole-tree-invariants.sh`: all invariants pass, exit 0

No new guard, so nothing here needs a can-it-fail fixture; the per-site counts above are the falsifiability evidence that each removed directive was genuinely inert and each retained one genuinely is not.

CHANGELOG: no `## [Unreleased]` entry. All three files are absent from `.gaia/manifest.json`, so no adopter receives any of them, there is no behavior change, and PR #1884 landed the same class of change with no entry.

Closes #1889

🤖 Generated with [Claude Code](https://claude.com/claude-code)
