### PR TITLE
debt(tests): route the last eight inline allowlist builders through path_allowlist

### DIFF
--- a/.gaia/scripts/tests/check-cli-workspace-floors.bats
+++ b/.gaia/scripts/tests/check-cli-workspace-floors.bats
@@ -22,6 +22,8 @@
 setup() {
   THIS_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
   REPO_ROOT="$( cd "$THIS_DIR/../../.." && pwd )"
+  # shellcheck source=.gaia/tests/helpers/path.sh
+  . "$REPO_ROOT/.gaia/tests/helpers/path.sh"
   CHECK="$REPO_ROOT/.gaia/scripts/check-cli-workspace-floors.sh"
   TMP="$(mktemp -d)"
   WS="$TMP/ws"
@@ -895,9 +897,7 @@ STUB
   # genuinely unfalsifiable terms in place rather than leaving them bare.
   write_workspace "  fast-uri: 3.1.6"
   write_lock "  fast-uri: 3.1.4"
-  mkdir -p "$TMP/nodeonly"
-  ln -s "$(command -v node)" "$TMP/nodeonly/node"
-  PATH="$TMP/nodeonly" run /bin/bash "$CHECK" --no-audit "$WS"
+  PATH="$(path_allowlist node)" run /bin/bash "$CHECK" --no-audit "$WS"
   [ "$status" -eq 2 ]
   grep -qF -- 'awk is required to compare the two maps' <<<"$output"
 }
@@ -1449,12 +1449,8 @@ STUB
   # was asked.
   write_workspace "  fast-uri: 3.1.6"
   write_lock "  fast-uri: 3.1.6"
-  mkdir -p "$TMP/emptybin"
-  for tool in awk node grep sed sort cat mktemp rm dirname chmod; do
-    command -v "$tool" >/dev/null 2>&1 || continue
-    ln -sf "$(command -v "$tool")" "$TMP/emptybin/$tool"
-  done
-  PATH="$TMP/emptybin" run /bin/bash "$CHECK" --advisory-strict "$WS"
+  PATH="$(path_allowlist awk node grep sed sort cat mktemp rm dirname chmod)" \
+    run /bin/bash "$CHECK" --advisory-strict "$WS"
   [ "$status" -eq 2 ]
   grep -qF -- 'advisory arm skipped' <<<"$output"
 }
@@ -1465,12 +1461,8 @@ STUB
   # posture the rest of this repository's local audits take.
   write_workspace "  fast-uri: 3.1.6"
   write_lock "  fast-uri: 3.1.6"
-  mkdir -p "$TMP/emptybin"
-  for tool in awk node grep sed sort cat mktemp rm dirname chmod; do
-    command -v "$tool" >/dev/null 2>&1 || continue
-    ln -sf "$(command -v "$tool")" "$TMP/emptybin/$tool"
-  done
-  PATH="$TMP/emptybin" run /bin/bash "$CHECK" "$WS"
+  PATH="$(path_allowlist awk node grep sed sort cat mktemp rm dirname chmod)" \
+    run /bin/bash "$CHECK" "$WS"
   [ "$status" -eq 0 ]
   grep -qF -- 'advisory arm skipped' <<<"$output"
 }
@@ -1481,12 +1473,8 @@ STUB
   # relabelled as an environment problem.
   write_workspace "  fast-uri: 3.1.6"
   write_lock "  fast-uri: 3.1.4"
-  mkdir -p "$TMP/emptybin"
-  for tool in awk node grep sed sort cat mktemp rm dirname chmod; do
-    command -v "$tool" >/dev/null 2>&1 || continue
-    ln -sf "$(command -v "$tool")" "$TMP/emptybin/$tool"
-  done
-  PATH="$TMP/emptybin" run /bin/bash "$CHECK" --advisory-strict "$WS"
+  PATH="$(path_allowlist awk node grep sed sort cat mktemp rm dirname chmod)" \
+    run /bin/bash "$CHECK" --advisory-strict "$WS"
   [ "$status" -eq 1 ]
   grep -qF -- 'FLOOR NOT APPLIED' <<<"$output"
 }

--- a/.gaia/scripts/tests/post-findings-block.bats
+++ b/.gaia/scripts/tests/post-findings-block.bats
@@ -19,6 +19,8 @@
 
 setup() {
   THIS_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
+  # shellcheck source=.gaia/tests/helpers/path.sh
+  . "$( cd "$THIS_DIR/../../.." && pwd )/.gaia/tests/helpers/path.sh"
   SCRIPT="$THIS_DIR/../post-findings-block.sh"
   [ -x "$SCRIPT" ] || skip "post-findings-block.sh not executable"
   command -v jq >/dev/null 2>&1 || skip "jq required"
@@ -184,15 +186,13 @@ STUB
 # last for sourcing audit-key-lib.sh, .gaia/scripts/audit-key-lib.sh).
 minimal_path() {
   local omit="$1"
-  local d="$SANDBOX/minimal-bin-${omit}"
-  mkdir -p "$d"
+  local cmd
+  local names=()
   for cmd in bash jq git mktemp sort cat head sed rm mkdir printf gh dirname; do
     [ "$cmd" = "$omit" ] && continue
-    local real
-    real="$(command -v "$cmd" 2>/dev/null || true)"
-    [ -n "$real" ] && ln -sf "$real" "$d/$cmd"
+    names+=("$cmd")
   done
-  printf '%s' "$d"
+  path_allowlist "${names[@]}"
 }
 
 run_script() {

--- a/.gaia/scripts/tests/serena-lang-drift.bats
+++ b/.gaia/scripts/tests/serena-lang-drift.bats
@@ -43,6 +43,8 @@ refute_contains() {
 
 setup() {
   THIS_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  # shellcheck source=.gaia/tests/helpers/path.sh
+  . "$( cd "$THIS_DIR/../../.." && pwd )/.gaia/tests/helpers/path.sh"
   LIB="$THIS_DIR/../lib/serena-lang.sh"
   CHECK_SRC="$THIS_DIR/../check-updates.sh"
   [ -f "$LIB" ] || skip "serena-lang.sh missing"
@@ -302,11 +304,7 @@ JSON
   local cache="$s/.gaia/local/cache/shared/update-check.json"
   # A symlink farm of the tools the refresher needs, deliberately WITHOUT jq,
   # so `command -v jq` fails and the printf write branch runs.
-  local farm="$TMPROOT/nojq012"; mkdir -p "$farm"
-  local t p
-  for t in git date mkdir mktemp mv rm find wc tr sed grep awk ls stat sort head tail cut dirname cat env bash; do
-    p="$(command -v "$t" 2>/dev/null)" && ln -sf "$p" "$farm/$t"
-  done
+  local farm; farm="$(path_allowlist git date mkdir mktemp mv rm find wc tr sed grep awk ls stat sort head tail cut dirname cat env bash)"
   # Sanity: jq is not reachable through the farm.
   run env PATH="$farm" bash -c 'command -v jq'
   [ "$status" -ne 0 ]

--- a/.gaia/tests/forensics/07-gh-not-installed.bats
+++ b/.gaia/tests/forensics/07-gh-not-installed.bats
@@ -44,25 +44,18 @@ no_gh_surrogate() {
 }
 
 setup() {
+  . "$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)/.gaia/tests/helpers/path.sh"
   WORKDIR="$(mktemp -d)"
-  # Build a PATH that has no gh binary. CLEAN_BIN is the ONLY entry;
+  # Build a PATH that has no gh binary. The built directory is the ONLY entry;
   # /usr/bin and /bin are deliberately excluded because GitHub Actions
   # ubuntu-latest ships gh at /usr/bin/gh, which would defeat the test.
-  CLEAN_BIN="$(mktemp -d)"
-  # Populate with the binaries the surrogate needs. printf/command are bash
-  # builtins; mkdir is the only external command exercised in the surrogate.
-  for cmd in bash mkdir; do
-    local real
-    real="$(command -v "$cmd" 2>/dev/null || true)"
-    if [[ -n "$real" ]]; then
-      ln -sf "$real" "$CLEAN_BIN/$cmd" 2>/dev/null || true
-    fi
-  done
-  NO_GH_PATH="$CLEAN_BIN"
+  # printf/command are bash builtins; mkdir is the only external command
+  # exercised in the surrogate.
+  NO_GH_PATH="$(path_allowlist bash mkdir)"
 }
 
 teardown() {
-  rm -rf "$WORKDIR" "$CLEAN_BIN"
+  rm -rf "$WORKDIR"
 }
 
 # ---------------------------------------------------------------------------

--- a/.gaia/tests/hooks/drift-check.bats
+++ b/.gaia/tests/hooks/drift-check.bats
@@ -2,6 +2,7 @@
 
 setup() {
   . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
+  . "$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)/.gaia/tests/helpers/path.sh"
   HELPERS="$BATS_TEST_DIRNAME/helpers"
   HOOK="$BATS_TEST_DIRNAME/../../../.claude/hooks/wiki-drift-check.sh"
   # Hook is invoked relative to its own repo. Resolve to absolute.
@@ -199,16 +200,12 @@ EOF
   # unavailable" the PATH below carries no jq at all -- only symlinks to the
   # handful of external binaries the drain block itself needs (head, rm) plus
   # bash to run the hook.
-  nojq_bin=$(mktemp -d -t gaia-drift-nojq-XXXXXX)
-  ln -sf "$(command -v bash)" "$nojq_bin/bash"
-  ln -sf "$(command -v head)" "$nojq_bin/head"
-  ln -sf "$(command -v rm)" "$nojq_bin/rm"
+  nojq_bin="$(path_allowlist bash head rm)"
 
   run bash -c 'PATH="$1" bash "$2" < /dev/null' _ "$nojq_bin" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   grep -qF -- '[wiki base] fast-forward of main to origin/main refused' <<<"$output" || return 1
   [ ! -f .gaia/local/cache/shared/wiki-base-catchup.report ] || return 1
-  rm -rf "$nojq_bin"
 }
 
 @test "no report file is a silent no-op" {

--- a/.gaia/tests/hooks/token-tally-review.bats
+++ b/.gaia/tests/hooks/token-tally-review.bats
@@ -23,6 +23,7 @@ setup() {
   . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HELPERS="$BATS_TEST_DIRNAME/helpers"
   REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  . "$REPO_ROOT/.gaia/tests/helpers/path.sh"
   HOOK_ABS="$REPO_ROOT/.claude/hooks/token-tally-review.sh"
   LIB_SRC="$REPO_ROOT/.claude/hooks/lib/gaia-active-plan.sh"
   LIB_MAIN_ROOT_SRC="$REPO_ROOT/.gaia/scripts/main-root-lib.sh"
@@ -39,7 +40,6 @@ setup() {
 teardown() {
   [ -n "${REPO:-}" ] && rm -rf "$REPO"
   [ -n "${PROOT:-}" ] && rm -rf "$PROOT"
-  [ -n "${FARM:-}" ] && rm -rf "$FARM"
   return 0
 }
 
@@ -171,11 +171,7 @@ run_hook_stop() {
   PROOT="$REPO/projects-unused"
   # Symlink farm of the tools the hook + git need, deliberately WITHOUT jq, so
   # `command -v jq` fails and the hook's earliest guard fires.
-  FARM="$(mktemp -d -t token-tally-review-nojq-XXXXXX)"
-  local t p
-  for t in bash git cat mkdir mktemp mv rm cp chmod grep sed printf basename dirname env sh; do
-    p="$(command -v "$t" 2>/dev/null)" && ln -sf "$p" "$FARM/$t"
-  done
+  FARM="$(path_allowlist bash git cat mkdir mktemp mv rm cp chmod grep sed printf basename dirname env sh)"
   run env PATH="$FARM" GAIA_TALLY_PROJECTS_ROOT="$PROOT" bash -c "echo 'x' | '$HOOK_ABS'"
   [ "$status" -eq 0 ]
   [ ! -f "$CALLS_FILE" ]

--- a/.gaia/tests/lib/spec-reconcile.bats
+++ b/.gaia/tests/lib/spec-reconcile.bats
@@ -14,6 +14,7 @@ setup() {
   HELPERS="$BATS_TEST_DIRNAME/helpers"
   # snapshot_file + assert_files_identical: byte identity without `$(cat …)`.
   . "$BATS_TEST_DIRNAME/../helpers/files.sh"
+  . "$BATS_TEST_DIRNAME/../helpers/path.sh"
   RECONCILE=".specify/extensions/gaia/lib/spec-reconcile.sh"
 }
 
@@ -23,9 +24,6 @@ teardown() {
   fi
   if [ -n "${STUB_DIR:-}" ]; then
     rm -rf "$STUB_DIR"
-  fi
-  if [ -n "${NO_GH_PATH:-}" ]; then
-    rm -rf "$NO_GH_PATH"
   fi
 }
 
@@ -74,12 +72,7 @@ EOF
 # with-ledger-lock.sh deps) actually invokes, symlinked in from the real
 # PATH, but with no `gh` anywhere on it.
 _no_gh_path() {
-  NO_GH_PATH="$(mktemp -d)"
-  local cmd real
-  for cmd in bash jq git sed mktemp mv rm mkdir rmdir stat date sleep; do
-    real="$(command -v "$cmd" 2>/dev/null || true)"
-    [ -n "$real" ] && ln -sf "$real" "$NO_GH_PATH/$cmd"
-  done
+  NO_GH_PATH="$(path_allowlist bash jq git sed mktemp mv rm mkdir rmdir stat date sleep)"
 }
 
 # --- 6: matching merged PR flips SPEC-006 to merged with merged_at from the PR ---


### PR DESCRIPTION
Closes #1895

## What

`#1890` converted the four suites its body enumerated, and PR #1892 delivered exactly that set. It did not retire the class. The same construct stood inline at **eight further sites across seven suites**, none of which sourced `.gaia/tests/helpers/path.sh`: build a directory, symlink each named binary into it from `command -v`, run with that directory as the whole `PATH`.

This routes all eight through `path_allowlist`, so the mechanism has one home.

| Site | Shape before |
|---|---|
| `.gaia/tests/hooks/drift-check.bats` | `mktemp -d` plus three `ln -sf "$(command -v …)"` |
| `.gaia/tests/hooks/token-tally-review.bats` | the `command -v` loop spelling |
| `.gaia/scripts/tests/check-cli-workspace-floors.bats` | a lone bare `ln -s "$(command -v node)"`, plus three loop copies over `$TMP/emptybin` |
| `.gaia/scripts/tests/serena-lang-drift.bats` | the `command -v` loop spelling |
| `.gaia/scripts/tests/post-findings-block.bats` | the `[ -n "$real" ] && ln -sf` spelling |
| `.gaia/tests/lib/spec-reconcile.bats` | the same `[ -n "$real" ] && ln -sf` spelling |
| `.gaia/tests/forensics/07-gh-not-installed.bats` | `ln -sf "$real" … \|\| true` |

Each caller's enumeration stays exactly as it was: the list is the caller's, and the point is that the mechanism has one home, not that the lists reconcile. `.gaia/tests/helpers/path.sh` itself is untouched.

## The latent defect the copies carried

Two of the residual lists name `printf` (`token-tally-review.bats` and `post-findings-block.bats`). `command -v printf` answers a builtin with a **bare word**, not a path, so the hand-rolled form wrote a dangling self-referential symlink at `$dir/printf`. `path_allowlist` walks `$PATH` for the real file instead. Nothing was failing today, because a script running under the stripped `PATH` resolves `printf` to the bash builtin before any lookup, but the issue body's aside that "none of the residual enumerations names a builtin-shadowed command" was wrong at those two sites. The repair the primitive already carries now reaches them.

## The three sites the issue flagged for judgement

All three are mechanical, confirmed against the tree:

- `BATS_TEST_TMPDIR` is set and populated by the time `setup()` runs (bats 1.13.0), so `path_allowlist`'s refusal arm never fires at `07-gh-not-installed.bats`.
- The `check-cli-workspace-floors.bats` sites build inside `@test` bodies, where `BATS_TEST_TMPDIR` is unconditionally set. Those tests assert on the behaviour of the command under a stripped `PATH`, never on the built directory's name; no reference to `$TMP/emptybin` or `$TMP/nodeonly` survives outside the `PATH=` assignment itself.
- Three teardowns that swept a hand-built directory (`$FARM`, `$CLEAN_BIN`, `$NO_GH_PATH`) are dropped, because bats now owns that lifetime. No comment is left claiming a suite owns a directory it does not.

## Deliberately not converted

`check-cli-workspace-floors.bats:922` builds `$TMP/emptybin` and leaves it **empty** on purpose (a `PATH` that resolves nothing). It carries no `ln` and therefore no copy of the mechanism, so there is nothing there to drift; it is outside this issue's enumeration and is left alone.

## Verification

- All seven touched suites pass under bash 5 via `.gaia/scripts/bats5.sh`, and `check-cli-workspace-floors.bats` passes all 102.
- `post-findings-block.bats` (the one conversion that introduces an array) additionally passes under stock macOS bats/bash 3.2.
- `.gaia/scripts/tests/bats-path-helper.bats`, the primitive's own suite, is green.
- `.gaia/tests/shell-lint.sh` and `.gaia/tests/whole-tree-invariants.sh` both pass.
- `git grep -n 'ln -s' -- '.gaia/**/*.bats'` now returns only shared-state and worktree symlinks; no remaining site links a `command -v` result into a PATH directory.

No CHANGELOG entry: every changed file sits under `.gaia/tests/` or `.gaia/scripts/tests/`, both release-excluded wholesale, so nothing here reaches an adopter bundle. Same disposition as PR #1892.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
