### PR TITLE
wiki: sync through 2b72247

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "d4e4d58b8db1157c2e63c89df4fcd480d87e41c4",
-  "last_evaluated_at": "2026-09-08T12:08:34Z",
+  "last_evaluated_sha": "2b72247b7a1f09656efd0862eff4a5edff1eea8c",
+  "last_evaluated_at": "2026-09-09T06:19:29Z",
   "last_consolidated_sha": "78c69d0f81d5bc6460453391c466570f30da43c4",
   "last_consolidated_at": "2026-09-08T06:34:36Z"
 }

--- a/wiki/decisions/Wiki Management.md
+++ b/wiki/decisions/Wiki Management.md
@@ -4,7 +4,7 @@ status: active
 priority: 1
 date: 2026-05-07
 created: 2026-05-07
-updated: 2026-09-08
+updated: 2026-09-09
 tags: [decision, wiki, cli]
 ---
 
@@ -43,6 +43,12 @@ The wiki is critical infrastructure; it decays when drift between code and docum
 - `finish` (after lint): pushes the branch, opens one PR for all stage commits, enables auto-merge, and takes one bounded wait on the merge. When it lands inside that wait, `finish` cleans up locally; on the common path the merge gate outlasts the wait, so it returns to base with the local cleanup outstanding for `sync await` or the session-start janitor. Drops the branch if it is empty. Leaves an aborted dirty tree in place for review. No-op for in-place runs on a feature branch.
 
 Standalone `/gaia-wiki sync`, `/gaia-wiki consolidate`, and `/gaia-wiki lint` are unaffected; the chain commands are invoked only by the no-arg `/gaia-wiki` full-chain wrapper.
+
+<!-- gaia:maintainer-only:start -->
+## Shipped-surface boundary check
+
+`wiki/` ships, so a page `/gaia-wiki sync` authors is a newly-shipping file the moment it's created. Before landing, sync stages its own authored pages and runs the release-staging build against them, the same check CI's advisory shipped-surface leak check runs, moved ahead of the pull request rather than discovered after it's open. It repairs what a page's own prose caused (a pointer at a release-excluded path, a wikilink to a release-excluded page), bounded at three attempts, and records what it can't repair or what a newly-created page still owes the distribution manifest in the sync summary instead of staying silent about it.
+<!-- gaia:maintainer-only:end -->
 
 ## State file
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,19 @@ tags: [meta, log]
 
 ## [Unreleased]
 
+- 2026-09-09 2b72247b WORTHY - sync playbook gains Step 5c shipped-surface boundary check -> wiki/decisions/Wiki Management.md new Shipped-surface boundary check section
+- 2026-09-09 4cf1a9cc WORTHY - shared jq-availability arm closes fail-open across blocking PreToolUse hooks -> wiki/concepts/Claude Hooks.md 'Shared jq-availability decision' section already added inline
+- 2026-09-09 9a456ba3 SKIP - internal refactor routing four hand-rolled CLI tree walks through collectTreeFiles, no documented-contract change
+- 2026-09-09 d93b964d SKIP - tests-only
+- 2026-09-09 d6aa6d83 SKIP - internal CLI test-fixture consolidation for uniqueness guards, no documented-contract change
+- 2026-09-09 7abb756c SKIP - tests-only
+- 2026-09-09 cc4a5c8a SKIP - brought dead-paths scanner in line with pre-existing wiki-style.md hot.md exemption claim, no new wiki fact
+- 2026-09-09 10f68dfc SKIP - tests-only
+- 2026-09-09 aa81e38d SKIP - tests-only
+- 2026-09-09 2df85cb7 SKIP - tests-only
+- 2026-09-09 87d9ac8c SKIP - tests-only
+- 2026-09-09 30cca068 WORTHY - dead-paths scan gains GITIGNORED_LOCAL_FILES exemption -> wiki/decisions/Wiki Management.md dead-paths bullet already updated inline
+- 2026-09-09 f1ab27f4 SKIP - prior wiki sync's own commit (advances state/log), no new content to catalogue
 - 2026-09-08 d4e4d58 SKIP - errexit-source guard scan_roots widened to .github, page deliberately defers guard-surface detail to the guard's own header (precedent: log 4a55dc40)
 - 2026-09-08 2ed6816 SKIP - internal refactor consolidating whole-tree guard walks into a shared module, no CHANGELOG entry, no documented-contract change
 - 2026-09-08 51e8428 WORTHY - dead-path scan gains HYPOTHETICAL_EXAMPLE_PATHS exemption -> wiki/decisions/Wiki Management.md dead-paths bullet updated


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to 2b72247.