### PR TITLE
debt(tests): state build-staging's third exit arm as a complement

### DIFF
--- a/.gaia/tests/distribution/lib/build-staging.sh
+++ b/.gaia/tests/distribution/lib/build-staging.sh
@@ -10,15 +10,13 @@
 #
 # Exit codes:
 #   0; staged tree clean (scrub passed, runtime-deps passed)
-#   1; a refusal. Either this script's own, each of which prints a
-#     diagnostic naming its cause, or one propagated from a release verb
-#     that also spends 1. Read the diagnostic rather than the status: exit
-#     1 alone does not say which refusal it was.
-#   anything else; a failing command's own status, propagated by the
-#     `set -e` below rather than normalized, so it means whatever that
-#     command's own contract says it means. Stated as a complement
-#     deliberately: an enumeration would leave a caller holding an unlisted
-#     status with no branch for it.
+#   anything else; a failure. Some are this script's own refusals, which
+#     each print a diagnostic naming the cause; the rest are propagated by
+#     the `set -e` below and carry whatever status the failing command
+#     spends, in some cases silently, a filter that selects no lines among
+#     them. The only boundary a caller can rely on is zero versus non-zero,
+#     so branch on that and read stderr: no particular value is this
+#     script's to promise, and any list of them here would go short.
 set -euo pipefail
 
 if [ "$#" -ne 1 ]; then

--- a/.gaia/tests/distribution/lib/build-staging.sh
+++ b/.gaia/tests/distribution/lib/build-staging.sh
@@ -11,7 +11,11 @@
 # Exit codes:
 #   0; staged tree clean (scrub passed, runtime-deps passed)
 #   1; bad usage, missing binary, scrub leak, runtime-deps leak
-#   2; unexpected (rsync/git failure, IO error)
+#   anything else; the failing command's own status, propagated by the
+#     `set -e` below rather than normalized. rsync and the version-control
+#     commands surface their own numbers, so this arm is stated as a
+#     complement: an enumeration would leave a caller holding an unlisted
+#     status with no branch for it.
 set -euo pipefail
 
 if [ "$#" -ne 1 ]; then

--- a/.gaia/tests/distribution/lib/build-staging.sh
+++ b/.gaia/tests/distribution/lib/build-staging.sh
@@ -10,11 +10,14 @@
 #
 # Exit codes:
 #   0; staged tree clean (scrub passed, runtime-deps passed)
-#   1; bad usage, missing binary, scrub leak, runtime-deps leak
-#   anything else; the failing command's own status, propagated by the
-#     `set -e` below rather than normalized. rsync and the version-control
-#     commands surface their own numbers, so this arm is stated as a
-#     complement: an enumeration would leave a caller holding an unlisted
+#   1; a refusal. Either this script's own, each of which prints a
+#     diagnostic naming its cause, or one propagated from a release verb
+#     that also spends 1. Read the diagnostic rather than the status: exit
+#     1 alone does not say which refusal it was.
+#   anything else; a failing command's own status, propagated by the
+#     `set -e` below rather than normalized, so it means whatever that
+#     command's own contract says it means. Stated as a complement
+#     deliberately: an enumeration would leave a caller holding an unlisted
 #     status with no branch for it.
 set -euo pipefail
 


### PR DESCRIPTION
Closes #1904

## What

`.gaia/tests/distribution/lib/build-staging.sh`'s exit-code header described a contract the script does not have. The block is now reduced to the one boundary the script actually guarantees.

**The documented `exit 2` is unreachable from this process.** Every explicit exit in the file is `exit 1`; `set -euo pipefail` propagates a failing command's own status rather than normalizing one, and the only `trap` is a scratch-dir cleanup that leaves the status alone.

**The `exit 1` line was a four-item list covering four of six refusals.** A failed tracked-path discovery and a failed `release exclude-regex` compile were named by none of its items.

**Both defects have the same root, and it is the class the issue names.** The phantom `2` is `scrub.ts`'s own code (`2: unexpected (config parse error, filesystem IO failure)`), copied into a header describing a different process. That copy is also why the `1;` line read as a closed list of this script's own refusals: the scrub and runtime-deps phases run bare under `set -e`, so a scrub leak reaches a caller as scrub's `1` and a scrub IO failure reaches it as scrub's `2`, neither spent by this script at all.

**A third source spends 1 silently.** The exclude filter exits 1 when it selects no lines, printing nothing, and `set -e` aborts there. `mktemp` and `cp` do the same.

So no arm is restated as a corrected list. The header states `0` and then a single complement, partitioned into refusals that print a diagnostic and statuses propagated from whatever failed, claiming to enumerate neither. There is no set left to go short.

## Why option 1 (correct the header) rather than option 2 (add a normalizing trap)

The issue offered both and left the choice open. Two measurements close it, both re-verified against the tree on this branch:

- **Nothing depends on a normalized status.** Every distribution scenario invokes the script as `"$HERE/lib/build-staging.sh" "$STAGING" || { fail ...; exit 1; }`, and the `cli-tests.yml` leak-check step runs it bare under `set -e`. No consumer reads the status at all. Option 2 would be a behavior change to a script CI runs, bought for no observed dependent.
- **The tree's newest statement of this contract already has option 1's shape.** `.claude/skills/gaia/references/wiki/sync.md` states the third arm as a complement and gives its reason. Correcting the header makes the two agree; a trap would move them apart.

## Claims verified rather than asserted

- All six of this script's own `exit 1` sites `printf` a diagnostic to stderr before exiting.
- The exclude filter exits 1 selecting nothing, with a zero-byte output and empty stderr; inside a `set -euo pipefail` script the following statement is never reached. Reproduced directly.
- Three release verbs (`scrub-wiki`, `scrub`, `runtime-deps`) are invoked bare, so their statuses propagate.
- `grep -n "exit 2"` over the file returns nothing.

## Guards

Comment-only change to a release-excluded harness file. It ships no guard, so `.claude/rules/guards-must-fail.md` has nothing to arm, and inventing a test for a comment would be worse than saying so.

## Accepted residuals

One, carried rather than fixed:

- **`.gaia/tests/distribution/lib/build-staging.sh:6`**, `holistic/incomplete-enumeration`, suggestion. The header names three replicated phases (`Stage + Scrub + Runtime-deps`) while the script runs four; the unlisted `scrub-wiki` is also the phase that deviates from the `release.yml` the line cites. Line 6 is untouched by this PR and asserts a different claim than the exit-code block, so it is out of scope here. Filed as #1909. Not folded in deliberately: the merge workflow's disposition rule sends a round carrying only accepted residuals to accept-and-note, and its caution that every widening of a prose list invites the next one argues against extending line 6 in passing.

## Audit rounds

Three, all clean (zero Critical, zero Important). Rounds 1 and 2 each returned one Suggestion inside the block under repair, and both were folded in rather than accepted, because a PR whose thesis is "do not assert a closed set" cannot ship a header that asserts one. Round 3 is clean apart from the residual above.

## Verification

Re-run after the last edit, not only before the first:

- `bash -n` on the edited script: clean
- `bash .gaia/tests/shell-lint.sh`: exit 0, passed
- `bash .gaia/scripts/bats5.sh .gaia/scripts/tests/list-tracked-paths.bats`: exit 0, 11/11, including `C1: every staging discovery site calls the shared boundary`, the assertion naming this file
- `bash .gaia/tests/whole-tree-invariants.sh`: exit 0, `all whole-tree invariants pass`
- Quality Gate: skipped on a positive answer. One `.sh` file staged; the page's own quick check ran and returned nothing.

## CHANGELOG

No `## [Unreleased]` entry. `.gaia/tests/` is release-excluded, so no adopter receives this file, and the change alters no behavior on either surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)