### PR TITLE
debt(hooks): make the jq arm's description cut independent of key order

### DIFF
--- a/.claude/hooks/lib/jq-availability.sh
+++ b/.claude/hooks/lib/jq-availability.sh
@@ -92,7 +92,7 @@ gaia_require_jq() {
   shift 3
 
   if [ "$#" -gt 0 ]; then
-    local haystack="$payload" needle matched=0
+    local haystack="$payload" needle matched=0 cut_head cut_tail
     if [ "$region_key" != '-' ]; then
       case "$payload" in
         # The key is quoted separately inside the strip so it is matched as a
@@ -107,18 +107,52 @@ gaia_require_jq() {
       # by "latest", `env` by "environment". Left in, it denies the jq install
       # on the wording of its own description.
       #
-      # SHORTEST suffix, deliberately. `%` cuts at the LAST occurrence, so a
-      # command whose own text carries the field name only widens the haystack;
-      # `%%` would cut at the first and could drop real command text, which is
-      # the under-deny direction.
+      # TWO-SIDED, not a suffix strip, and that is the whole of why the shape is
+      # what it is. Cutting from the key to the end of the region holds only
+      # while `description` is emitted after the field the predicate reads.
+      # Emitted FIRST, that cut takes the command or path with it: nothing any
+      # binding literal would match survives in the haystack, nothing matches,
+      # and the arm allows. That is the fail-open direction on the guard whose
+      # purpose is to close it, and its trigger is emitted key order, which GAIA
+      # does not control. Keeping the text on BOTH sides and dropping only the
+      # field's own value holds for either order.
+      #
+      # Giving up and leaving the description in on an unexpected shape is NOT
+      # the safe fallback it looks like: the description is model-authored prose,
+      # so it carries the literals as substrings almost unconditionally, and
+      # leaving it in denies the jq install on the wording of its own
+      # description. That is the session with no way out the literals exist to
+      # prevent.
+      #
+      # LAST occurrence, and both expansions pick the same one: a command whose
+      # own text carries the field name leaves the real description standing,
+      # which only widens the haystack, while cutting at the first would drop
+      # real command text, the under-deny direction.
       #
       # The pattern is the quoted KEY alone, with no leading comma and no
       # trailing colon, because the separators are not stable: a compact encoder
       # writes `,"description":` while a pretty-printing one writes a newline and
       # indent between the comma and the key. Matching the key by itself holds
-      # for both, and for a payload that carries no description at all the strip
-      # matches nothing and leaves the haystack whole.
-      haystack="${haystack%\"description\"*}"
+      # for both, and for a payload that carries no description at all the case
+      # below matches nothing and leaves the haystack whole.
+      #
+      # HONEST LIMIT of the value scan: it ends the value at the first `"` after
+      # the opening one, so a description carrying an escaped quote ends it early
+      # and leaves the remainder of the prose in the haystack. That is the
+      # widening direction, the same one an unstripped description produces, and
+      # it costs a denial rather than an allow.
+      #
+      # The two sides are joined with a space so the seam cannot spell a literal
+      # that neither side carries on its own.
+      case "$haystack" in
+        *'"description"'*)
+          cut_head="${haystack%\"description\"*}"
+          cut_tail="${haystack##*\"description\"}"
+          cut_tail="${cut_tail#*\"}"
+          cut_tail="${cut_tail#*\"}"
+          haystack="$cut_head $cut_tail"
+          ;;
+      esac
     fi
     haystack=$(printf '%s' "$haystack" | tr '[:upper:]' '[:lower:]')
     for needle in "$@"; do

--- a/.claude/hooks/lib/jq-availability.sh
+++ b/.claude/hooks/lib/jq-availability.sh
@@ -49,6 +49,13 @@
 # payload that carries the key nowhere falls back to the whole document rather
 # than to an empty one, because an empty haystack would allow instead of refuse.
 #
+# That prefix strip is the first of two narrowing stages, so "a field emitted
+# after the key stays in the surface" holds for every such field except one. The
+# second stage drops the model-authored `description` field's own value, from
+# either side of the key, because no caller predicate reads it. The in-body
+# comment at that cut owns the reasoning, the ordering hazard it exists to close,
+# and the shapes it does not reach.
+#
 # The literal set is a reading of the caller's own binding predicate rather than
 # a policy choice about it, so it belongs at the call site and never here. Each
 # caller states beside its call which spellings its literals cannot reach.
@@ -124,10 +131,12 @@ gaia_require_jq() {
       # description. That is the session with no way out the literals exist to
       # prevent.
       #
-      # LAST occurrence, and both expansions pick the same one: a command whose
-      # own text carries the field name leaves the real description standing,
-      # which only widens the haystack, while cutting at the first would drop
-      # real command text, the under-deny direction.
+      # LAST occurrence, and both expansions pick the same one. In an object,
+      # which is every shape the harness emits here, a payload whose own text
+      # carries the field name leaves the real description standing, which only
+      # widens the haystack, while cutting at the first would drop real command
+      # text, the under-deny direction. The limit below is why that sentence
+      # names the object shapes rather than every payload.
       #
       # The pattern is the quoted KEY alone, with no leading comma and no
       # trailing colon, because the separators are not stable: a compact encoder
@@ -136,11 +145,20 @@ gaia_require_jq() {
       # for both, and for a payload that carries no description at all the case
       # below matches nothing and leaves the haystack whole.
       #
-      # HONEST LIMIT of the value scan: it ends the value at the first `"` after
-      # the opening one, so a description carrying an escaped quote ends it early
-      # and leaves the remainder of the prose in the haystack. That is the
-      # widening direction, the same one an unstripped description produces, and
-      # it costs a denial rather than an allow.
+      # HONEST LIMITS of the value scan, one in each direction. It ends the value
+      # at the first `"` after the opening one, so a description carrying an
+      # escaped quote ends early and leaves the remainder of the prose in the
+      # haystack: the widening direction, the same one an unstripped description
+      # produces, costing a denial rather than an allow.
+      #
+      # The other runs the under-deny way. The scan assumes the token it matched
+      # is a KEY and drops the quoted run after it. Where the token is instead a
+      # bare quoted VALUE followed by a sibling quoted run, an array of strings
+      # being the shape that does that, the sibling is what gets eaten, and a
+      # binding literal sitting there goes with it. No payload the harness emits
+      # reaches it: JSON escapes a quoted word inside a command to
+      # `\"description\"`, which the case guard does not match, and in an object
+      # only the following key NAME is eaten, never its value.
       #
       # The two sides are joined with a space so the seam cannot spell a literal
       # that neither side carries on its own.

--- a/.gaia/hook-capabilities.json
+++ b/.gaia/hook-capabilities.json
@@ -35,7 +35,7 @@
         "invokes:.claude/hooks/lib/jq-availability.sh",
         "invokes:.claude/hooks/lib/reader-operands.sh"
       ],
-      "why": "Reads a Read or Bash tool call's payload to deny a command that would read a dotenv file or dump the process environment. Sources the shared reader-operand grammar to decide which tokens in a command name a file a reader would open, which is what lets the grep family be judged without treating its pattern operand as a path. Beyond that source it is pure text inspection of the payload already on stdin: no file write and no network call.",
+      "why": "Reads a Read or Bash tool call's payload to deny a command that would read a dotenv file or dump the process environment. Sources the shared reader-operand grammar to decide which tokens in a command name a file a reader would open, which is what lets the grep family be judged without treating its pattern operand as a path. Beyond that source and the shared jq-availability arm it also sources, it is pure text inspection of the payload already on stdin: no file write and no network call.",
       "maintainer_only": false
     },
     {
@@ -61,7 +61,7 @@
         "invokes:.claude/hooks/lib/jq-availability.sh",
         "invokes:.gaia/scripts/main-root-lib.sh"
       ],
-      "why": "Denies a fourth Code Audit Team dispatch wave in one session by counting each wave's HEAD tree in a session-keyed counter under `.gaia/local/cache/`. Sources main-root-lib.sh to resolve the checkout root for that counter's path; reads no marker, makes no network call, and runs no git write.",
+      "why": "Denies a fourth Code Audit Team dispatch wave in one session by counting each wave's HEAD tree in a session-keyed counter under `.gaia/local/cache/`. Sources main-root-lib.sh to resolve the checkout root for that counter's path, and the shared jq-availability arm; reads no marker, makes no network call, and runs no git write.",
       "maintainer_only": false
     },
     {
@@ -88,7 +88,7 @@
         "invokes:.gaia/scripts/main-root-lib.sh",
         "network"
       ],
-      "why": "Denies a `git commit` to main/master and a force-push or plain push originating from main/master, by matching the intercepted Bash command's own text; it issues no git command of its own. Sources the shared repo-scope helper to exempt a command aimed at a different repository, and main-root-lib.sh to resolve the checkout root; `network` is the repo-scope helper's own `gh repo view` call, made to confirm which repository the intercepted command targets.",
+      "why": "Denies a `git commit` to main/master and a force-push or plain push originating from main/master, by matching the intercepted Bash command's own text; it issues no git command of its own. Sources the shared repo-scope helper to exempt a command aimed at a different repository, main-root-lib.sh to resolve the checkout root, and the shared jq-availability arm; `network` is the repo-scope helper's own `gh repo view` call, made to confirm which repository the intercepted command targets.",
       "maintainer_only": false
     },
     {
@@ -106,7 +106,7 @@
         "invokes:.claude/hooks/lib/repo-scope.sh",
         "network"
       ],
-      "why": "Denies a `git commit`/`git push` that carries a hook-bypass flag (`--no-verify`, `-n`, `HUSKY=0`, `-c core.hooksPath=`), by matching the intercepted Bash command's own text; it issues no git command of its own. Sources the shared repo-scope helper to exempt a command aimed at a different repository; `network` is the repo-scope helper's own `gh repo view` call, made to confirm which repository the intercepted command targets.",
+      "why": "Denies a `git commit`/`git push` that carries a hook-bypass flag (`--no-verify`, `-n`, `HUSKY=0`, `-c core.hooksPath=`), by matching the intercepted Bash command's own text; it issues no git command of its own. Sources the shared repo-scope helper to exempt a command aimed at a different repository, and the shared jq-availability arm; `network` is the repo-scope helper's own `gh repo view` call, made to confirm which repository the intercepted command targets.",
       "maintainer_only": false
     },
     {
@@ -116,7 +116,7 @@
         "invokes:.gaia/scripts/main-root-lib.sh",
         "invokes:.gaia/scripts/state-registry-lib.sh"
       ],
-      "why": "Denies a dangerous `rm -rf` invocation (root, HOME, cwd, unscoped globs, `.git`, `.claude`, `node_modules`) by matching the intercepted Bash command's own text against a repo registry of safe scratch paths; it issues no filesystem command of its own. Sources main-root-lib.sh to resolve the checkout root and state-registry-lib.sh to read that safe-scratch registry from `.gaia/state-registry.json`.",
+      "why": "Denies a dangerous `rm -rf` invocation (root, HOME, cwd, unscoped globs, `.git`, `.claude`, `node_modules`) by matching the intercepted Bash command's own text against a repo registry of safe scratch paths; it issues no filesystem command of its own. Sources main-root-lib.sh to resolve the checkout root, state-registry-lib.sh to read that safe-scratch registry from `.gaia/state-registry.json`, and the shared jq-availability arm.",
       "maintainer_only": false
     },
     {
@@ -125,7 +125,7 @@
         "invokes:.claude/hooks/lib/jq-availability.sh",
         "invokes:.claude/hooks/lib/reader-operands.sh"
       ],
-      "why": "Reads a Read or Bash tool call's payload to deny a command that would read a key, certificate, or credential path. Sources the shared reader-operand grammar for the same reason its dotenv sibling does. Beyond that source it is pure text inspection of the payload already on stdin: no file write and no network call.",
+      "why": "Reads a Read or Bash tool call's payload to deny a command that would read a key, certificate, or credential path. Sources the shared reader-operand grammar for the same reason its dotenv sibling does. Beyond that source and the shared jq-availability arm it also sources, it is pure text inspection of the payload already on stdin: no file write and no network call.",
       "maintainer_only": false
     },
     {
@@ -142,7 +142,7 @@
         "invokes:.claude/hooks/lib/audit-selfheal-paths.sh",
         "invokes:.claude/hooks/lib/jq-availability.sh"
       ],
-      "why": "Denies a Code Audit Team member's Edit/Write/MultiEdit or Bash write outside its self-heal boundary, by matching the intercepted payload's target path against the shared refusal set. Sources `.claude/hooks/lib/audit-selfheal-paths.sh`, the one refusal-set definition also read by the CI push gate; it issues no write of its own.",
+      "why": "Denies a Code Audit Team member's Edit/Write/MultiEdit or Bash write outside its self-heal boundary, by matching the intercepted payload's target path against the shared refusal set. Sources `.claude/hooks/lib/audit-selfheal-paths.sh`, the one refusal-set definition also read by the CI push gate, and the shared jq-availability arm; it issues no write of its own.",
       "maintainer_only": false
     },
     {
@@ -151,7 +151,7 @@
         "invokes:.claude/hooks/lib/jq-availability.sh",
         "invokes:.gaia/scripts/main-root-lib.sh"
       ],
-      "why": "Denies a Serena `activate_project` call whose target resolves to a different checkout of this clone than the one the session works in, by comparing the call's argument against the resolved tree identity. Sources main-root-lib.sh to resolve that identity; it issues no filesystem or network command of its own.",
+      "why": "Denies a Serena `activate_project` call whose target resolves to a different checkout of this clone than the one the session works in, by comparing the call's argument against the resolved tree identity. Sources main-root-lib.sh to resolve that identity, and the shared jq-availability arm; it issues no filesystem or network command of its own.",
       "maintainer_only": false
     },
     {
@@ -161,7 +161,7 @@
         "invokes:.claude/hooks/lib/jq-availability.sh",
         "invokes:.gaia/scripts/main-root-lib.sh"
       ],
-      "why": "Denies a session that authored a SPEC from going on to plan it in the same session, by stamping and reading a session-keyed sentinel under `.gaia/local/cache/`. Sources main-root-lib.sh to resolve the checkout root for that sentinel's path.",
+      "why": "Denies a session that authored a SPEC from going on to plan it in the same session, by stamping and reading a session-keyed sentinel under `.gaia/local/cache/`. Sources main-root-lib.sh to resolve the checkout root for that sentinel's path, and the shared jq-availability arm.",
       "maintainer_only": false
     },
     {
@@ -179,7 +179,7 @@
         "invokes:.gaia/scripts/main-root-lib.sh",
         "invokes:.gaia/scripts/state-registry-lib.sh"
       ],
-      "why": "Denies an Edit/Write/MultiEdit whose target path resolves to a checkout other than the linked worktree the session works inside. Sources main-root-lib.sh and state-registry-lib.sh to resolve tree identity and the registry of linked worktrees; it issues no write of its own.",
+      "why": "Denies an Edit/Write/MultiEdit whose target path resolves to a checkout other than the linked worktree the session works inside. Sources main-root-lib.sh and state-registry-lib.sh to resolve tree identity and the registry of linked worktrees, and the shared jq-availability arm; it issues no write of its own.",
       "maintainer_only": false
     },
     {

--- a/.gaia/tests/hooks/jq-availability.bats
+++ b/.gaia/tests/hooks/jq-availability.bats
@@ -86,6 +86,23 @@ bash_payload() {
     '$a + {tool_name: "Bash", tool_input: {command: $c, description: $d}}'
 }
 
+# The same fields with the two tool_input keys swapped. No session produces this
+# order today -- which is exactly why it needs a builder: the arm's description
+# cut must not depend on an emission order GAIA does not control, and the
+# command-first builder above pins nothing about the other order.
+#
+# Both claims the command-first pair makes are re-made against it, and each
+# catches a different way the cut can go wrong. The refusal catches a cut that
+# takes the command out of the haystack along with the description, which is the
+# fail-open direction on the guard whose purpose is to close it. The allow
+# catches a cut that gives up and leaves the description in the haystack, which
+# denies the jq install on the wording of its own description: the session with
+# no way out from inside it.
+bash_payload_description_first() {
+  jq -n --argjson a "$(ambient)" --arg c "$1" --arg d "$AMBIENT_DESCRIPTION" \
+    '$a + {tool_name: "Bash", tool_input: {description: $d, command: $c}}'
+}
+
 edit_payload() {
   jq -n --argjson a "$(ambient)" --arg p "$1" \
     '$a + {tool_name: "Edit", tool_input: {file_path: $p, new_string: "x"}}'
@@ -169,6 +186,20 @@ readonly INSTALL_CMD="brew install jq"
 @test "jq absent: block-bare-test allows the jq install" {
   local json
   json=$(bash_payload "$INSTALL_CMD")
+  without_jq block-bare-test.sh "$json"
+  assert_allowed_by_exit
+}
+
+@test "jq absent: block-bare-test refuses its literal with description emitted first" {
+  local json
+  json=$(bash_payload_description_first "pnpm test")
+  without_jq block-bare-test.sh "$json"
+  assert_blocked_by_exit
+}
+
+@test "jq absent: block-bare-test allows the jq install with description emitted first" {
+  local json
+  json=$(bash_payload_description_first "$INSTALL_CMD")
   without_jq block-bare-test.sh "$json"
   assert_allowed_by_exit
 }


### PR DESCRIPTION
Closes #1905

## What was wrong

`.claude/hooks/lib/jq-availability.sh` narrowed its haystack to the caller's region, then cut the model-authored `description` field out of it with a suffix strip from the last `"description"` to the end of the region. That is correct only while `description` is emitted **after** the field the caller's predicate reads. Emitted **first**, the cut takes the command or path with it: nothing any binding literal would match survives, nothing matches, and the arm exits 0 instead of 2.

That is the fail-open direction, on the guard whose whole purpose is to close it, and its trigger is emitted key order, which GAIA does not control.

## What changed

The cut is now **two-sided**: keep the text on both sides of `"description"` and drop only the field's own value. Correct for either emission order, with no knowledge of which one produced the payload. Still bash 3.2, still no parser, still last-occurrence on both sides so a command whose own text carries the field name only widens the haystack.

### Deviation from the issue's prescribed fix, and the evidence for it

The issue prescribed: compute the cut into a candidate, keep it only when the candidate still holds a quoted key, otherwise **fall back to the unstripped haystack**. That shape closes the fail-open and opens a worse hole, so it is not what landed.

The description is model-authored prose, so it carries the binding literals as substrings almost unconditionally (`Confirm` holds `rm`, `latest` holds `test`, and the dotenv literal sits inside ordinary words for the surroundings a session describes). Falling back to a haystack that still contains it denies the jq install on the wording of its own description: the session with no way out from inside it, which is the failure the literal-narrowing design exists to prevent, and which the file's own header calls out as the one unsafe over-deny.

This is demonstrated, not argued. Driving that fallback as a deliberate mutation reds the new allow assertion:

```
ok 1 jq absent: block-bare-test refuses its literal with description emitted first
not ok 2 jq absent: block-bare-test allows the jq install with description emitted first
```

The two-sided cut passes both.

### Second item

Ten `.gaia/hook-capabilities.json` `why` strings presented one source (or their named set) as the whole set while their entries also source the jq-availability arm. They now name it. The set was **re-derived at HEAD** rather than taken from the issue body, per the dispatch note: 18 entries declare `invokes:.claude/hooks/lib/jq-availability.sh`, 8 already named it in prose (the previously-empty ones, reworded on the arm's own PR), 10 did not. `check-hook-capabilities.sh` compares only the list and never the prose, so nothing red on them.

## TDD order

Per `.claude/rules/guards-must-fail.md`, and stated because a test written after a fix that passes immediately is the anti-pattern that rule names:

1. `bash_payload_description_first` builder and both assertions written first.
2. Refusal assertion confirmed **red** against the unchanged strip.
3. Arm fixed; all 34 suite tests green.
4. Allow assertion confirmed **red** under the naive-fallback mutation above, then restored.

Both new guards have been observed in their failing state.

## Scope

Confined to the arm, its suite, and the capability prose. Nothing here touches `.gaia/scripts/lint-hook-jq-availability.sh` or any of the six hooks #1901 converts, which the dispatch note flags as a widening into that row's scope.

## CHANGELOG

No entry. The arm's own `## [Unreleased]` bullet has not shipped, so this repairs unreleased code that no adopter has seen in its broken form; the existing claim ("Every blocking hook now refuses loudly instead") is more true after this change, not less, so it needs no amendment either.

## Verification

- `.gaia/tests/hooks/jq-availability.bats` — 34/34 green
- `block-bare-test` / `block-env-read` / `block-secrets-read` / `block-rm-rf` suites — 326/326 green
- `bash .gaia/scripts/check-hook-capabilities.sh` — clean
- `bash .gaia/tests/shell-lint.sh` — passed
- `bash .gaia/tests/whole-tree-invariants.sh` — all invariants pass
- Quality Gate correctly skipped: no staged `.ts|tsx|js|jsx|mjs|cjs|css` or gate-affecting config

🤖 Generated with [Claude Code](https://claude.com/claude-code)
