### PR TITLE
debt(tests): name the hook registration form once for the hook suites

### DIFF
--- a/.gaia/scripts/hook-registration-lib.sh
+++ b/.gaia/scripts/hook-registration-lib.sh
@@ -2,8 +2,9 @@
 # shellcheck shell=bash
 #
 # hook-registration-lib.sh: the shared read of `.claude/settings.json`'s
-# PreToolUse registrations, and the shared oracle for whether a registered hook
-# can stop a tool call. Source it; it defines functions and runs nothing.
+# PreToolUse registrations, the shared oracle for whether a registered hook can
+# stop a tool call, and the one spelling of a hook name inside a registration
+# command. Source it; it defines functions and that literal, and runs nothing.
 #
 # Two gates ask the same two questions of the same surface and must not answer
 # them differently: `.gaia/scripts/lint-hook-advisory-classification.sh` (a
@@ -11,6 +12,14 @@
 # `.gaia/scripts/lint-hook-jq-availability.sh` (a blocking hook whose jq arm
 # fails open). A second copy of either question drifts from the first silently,
 # because each gate's own suite passes against its own copy.
+#
+# `GAIA_HOOK_NAME_RE` has a consumer outside those gates, and it fails in a
+# quieter direction than they do. `.gaia/tests/hooks/helpers/run-hook.sh` feeds
+# the literal to jq's `match` builtin to assert that a hook is registered at
+# all, once per registration assertion across the hook suites. Widening the
+# class to admit a path shape a gate needs also widens what every one of those
+# assertions accepts: a wider class still matches, so they stay green while
+# asserting less. Read that consumer before changing the literal.
 #
 # Bash 3.2 compatible. Never `cd`.
 

--- a/.gaia/tests/hooks/block-env-read.bats
+++ b/.gaia/tests/hooks/block-env-read.bats
@@ -329,13 +329,11 @@ run_write_hook_edit() {
 }
 
 @test "settings.json registers block-env-read.sh under the Read matcher (UAT-008)" {
-  run jq -e '.hooks.PreToolUse[] | select(.matcher == "Read") | .hooks[] | select(.command | endswith("/.claude/hooks/block-env-read.sh\""))' "$SETTINGS_ABS"
-  [ "$status" -eq 0 ]
+  hook_registered "$SETTINGS_ABS" '.hooks.PreToolUse[] | select(.matcher == "Read")' block-env-read.sh
 }
 
 @test "settings.json registers block-env-read.sh under the Bash matcher (UAT-008)" {
-  run jq -e '.hooks.PreToolUse[] | select(.matcher == "Bash") | .hooks[] | select(.command | endswith("/.claude/hooks/block-env-read.sh\""))' "$SETTINGS_ABS"
-  [ "$status" -eq 0 ]
+  hook_registered "$SETTINGS_ABS" '.hooks.PreToolUse[] | select(.matcher == "Bash")' block-env-read.sh
 }
 
 @test "permissions.deny carries no Read() rule at all" {
@@ -441,8 +439,7 @@ run_write_hook_edit() {
 }
 
 @test "settings.json registers block-env-read.sh under the Grep matcher" {
-  run jq -e '.hooks.PreToolUse[] | select(.matcher == "Grep") | .hooks[] | select(.command | endswith("/.claude/hooks/block-env-read.sh\""))' "$SETTINGS_ABS"
-  [ "$status" -eq 0 ]
+  hook_registered "$SETTINGS_ABS" '.hooks.PreToolUse[] | select(.matcher == "Grep")' block-env-read.sh
 }
 
 # --- Fail-closed on a grammar-load failure ---

--- a/.gaia/tests/hooks/block-invalid-yaml-write.bats
+++ b/.gaia/tests/hooks/block-invalid-yaml-write.bats
@@ -266,6 +266,5 @@ run_hook_multiedit() {
 }
 
 @test "settings.json registers the hook under the Edit|Write|MultiEdit matcher" {
-  run jq -e '.hooks.PreToolUse[] | select(.matcher == "Edit|Write|MultiEdit") | .hooks[] | select(.command | endswith("/.claude/hooks/block-invalid-yaml-write.sh\""))' "$SETTINGS_ABS"
-  [ "$status" -eq 0 ]
+  hook_registered "$SETTINGS_ABS" '.hooks.PreToolUse[] | select(.matcher == "Edit|Write|MultiEdit")' block-invalid-yaml-write.sh
 }

--- a/.gaia/tests/hooks/block-lockfile-edit.bats
+++ b/.gaia/tests/hooks/block-lockfile-edit.bats
@@ -122,6 +122,5 @@ run_hook_edit() {
 }
 
 @test "settings.json registers the hook under the Edit|Write|MultiEdit matcher" {
-  run jq -e '.hooks.PreToolUse[] | select(.matcher == "Edit|Write|MultiEdit") | .hooks[] | select(.command | endswith("/.claude/hooks/block-lockfile-edit.sh\""))' "$SETTINGS_ABS"
-  [ "$status" -eq 0 ]
+  hook_registered "$SETTINGS_ABS" '.hooks.PreToolUse[] | select(.matcher == "Edit|Write|MultiEdit")' block-lockfile-edit.sh
 }

--- a/.gaia/tests/hooks/block-manifest-write.bats
+++ b/.gaia/tests/hooks/block-manifest-write.bats
@@ -272,11 +272,9 @@ run_hook_bash() {
 }
 
 @test "settings.json registers the hook under the Edit|Write|MultiEdit matcher" {
-  run jq -e '.hooks.PreToolUse[] | select(.matcher == "Edit|Write|MultiEdit") | .hooks[] | select(.command | endswith("/.claude/hooks/block-manifest-write.sh\""))' "$SETTINGS_ABS"
-  [ "$status" -eq 0 ]
+  hook_registered "$SETTINGS_ABS" '.hooks.PreToolUse[] | select(.matcher == "Edit|Write|MultiEdit")' block-manifest-write.sh
 }
 
 @test "settings.json registers the hook under the Bash matcher" {
-  run jq -e '.hooks.PreToolUse[] | select(.matcher == "Bash") | .hooks[] | select(.command | endswith("/.claude/hooks/block-manifest-write.sh\""))' "$SETTINGS_ABS"
-  [ "$status" -eq 0 ]
+  hook_registered "$SETTINGS_ABS" '.hooks.PreToolUse[] | select(.matcher == "Bash")' block-manifest-write.sh
 }

--- a/.gaia/tests/hooks/block-rm-rf.bats
+++ b/.gaia/tests/hooks/block-rm-rf.bats
@@ -1365,8 +1365,7 @@ assert_position_preserving() {
 }
 
 @test "settings.json registers the hook under the Bash matcher" {
-  run jq -e '.hooks.PreToolUse[] | select(.matcher == "Bash") | .hooks[] | select(.command | endswith("/.claude/hooks/block-rm-rf.sh\""))' "$SETTINGS_ABS"
-  [ "$status" -eq 0 ]
+  hook_registered "$SETTINGS_ABS" '.hooks.PreToolUse[] | select(.matcher == "Bash")' block-rm-rf.sh
 }
 
 # --- an unparseable registry lib degrades, it does not deny everything ---

--- a/.gaia/tests/hooks/block-secrets-read.bats
+++ b/.gaia/tests/hooks/block-secrets-read.bats
@@ -345,13 +345,11 @@ run_hook_without_library() {
 }
 
 @test "settings.json registers block-secrets-read.sh under the Read matcher" {
-  run jq -e '.hooks.PreToolUse[] | select(.matcher == "Read") | .hooks[] | select(.command | endswith("/.claude/hooks/block-secrets-read.sh\""))' "$SETTINGS_ABS"
-  [ "$status" -eq 0 ]
+  hook_registered "$SETTINGS_ABS" '.hooks.PreToolUse[] | select(.matcher == "Read")' block-secrets-read.sh
 }
 
 @test "settings.json registers block-secrets-read.sh under the Bash matcher" {
-  run jq -e '.hooks.PreToolUse[] | select(.matcher == "Bash") | .hooks[] | select(.command | endswith("/.claude/hooks/block-secrets-read.sh\""))' "$SETTINGS_ABS"
-  [ "$status" -eq 0 ]
+  hook_registered "$SETTINGS_ABS" '.hooks.PreToolUse[] | select(.matcher == "Bash")' block-secrets-read.sh
 }
 
 @test "permissions.deny carries none of the four replaced Read() globs" {
@@ -425,8 +423,7 @@ run_hook_without_library() {
 }
 
 @test "settings.json registers block-secrets-read.sh under the Grep matcher" {
-  run jq -e '.hooks.PreToolUse[] | select(.matcher == "Grep") | .hooks[] | select(.command | endswith("/.claude/hooks/block-secrets-read.sh\""))' "$SETTINGS_ABS"
-  [ "$status" -eq 0 ]
+  hook_registered "$SETTINGS_ABS" '.hooks.PreToolUse[] | select(.matcher == "Grep")' block-secrets-read.sh
 }
 
 # --- Fail-closed on a grammar-load failure ---

--- a/.gaia/tests/hooks/block-selfheal-paths.bats
+++ b/.gaia/tests/hooks/block-selfheal-paths.bats
@@ -769,11 +769,9 @@ scrub_jq_from_path() {
 }
 
 @test "settings.json registers the hook under the Edit|Write|MultiEdit matcher" {
-  run jq -e '.hooks.PreToolUse[] | select(.matcher == "Edit|Write|MultiEdit") | .hooks[] | select(.command | endswith("/.claude/hooks/block-selfheal-paths.sh\""))' "$SETTINGS_ABS"
-  [ "$status" -eq 0 ]
+  hook_registered "$SETTINGS_ABS" '.hooks.PreToolUse[] | select(.matcher == "Edit|Write|MultiEdit")' block-selfheal-paths.sh
 }
 
 @test "settings.json registers the hook under the Bash matcher" {
-  run jq -e '.hooks.PreToolUse[] | select(.matcher == "Bash") | .hooks[] | select(.command | endswith("/.claude/hooks/block-selfheal-paths.sh\""))' "$SETTINGS_ABS"
-  [ "$status" -eq 0 ]
+  hook_registered "$SETTINGS_ABS" '.hooks.PreToolUse[] | select(.matcher == "Bash")' block-selfheal-paths.sh
 }

--- a/.gaia/tests/hooks/block-serena-cross-tree-activation.bats
+++ b/.gaia/tests/hooks/block-serena-cross-tree-activation.bats
@@ -186,8 +186,7 @@ run_hook_other_tool() {
 }
 
 @test "settings.json registers the hook under the mcp__serena__activate_project matcher" {
-  run jq -e '.hooks.PreToolUse[] | select(.matcher == "mcp__serena__activate_project") | .hooks[] | select(.command | endswith("/.claude/hooks/block-serena-cross-tree-activation.sh\""))' "$SETTINGS_ABS"
-  [ "$status" -eq 0 ]
+  hook_registered "$SETTINGS_ABS" '.hooks.PreToolUse[] | select(.matcher == "mcp__serena__activate_project")' block-serena-cross-tree-activation.sh
 }
 
 # --- library-load degradation (gaia-react/gaia#1556) ------------------------

--- a/.gaia/tests/hooks/block-vitest-globals-tsconfig.bats
+++ b/.gaia/tests/hooks/block-vitest-globals-tsconfig.bats
@@ -253,6 +253,5 @@ run_hook_multiedit() {
 }
 
 @test "settings.json registers the hook under the Edit|Write|MultiEdit matcher" {
-  run jq -e '.hooks.PreToolUse[] | select(.matcher == "Edit|Write|MultiEdit") | .hooks[] | select(.command | endswith("/.claude/hooks/block-vitest-globals-tsconfig.sh\""))' "$SETTINGS_ABS"
-  [ "$status" -eq 0 ]
+  hook_registered "$SETTINGS_ABS" '.hooks.PreToolUse[] | select(.matcher == "Edit|Write|MultiEdit")' block-vitest-globals-tsconfig.sh
 }

--- a/.gaia/tests/hooks/block-worktree-path-mismatch.bats
+++ b/.gaia/tests/hooks/block-worktree-path-mismatch.bats
@@ -784,8 +784,7 @@ make_other_repo() {
 }
 
 @test "settings.json registers the hook under the Edit|Write|MultiEdit matcher" {
-  run jq -e '.hooks.PreToolUse[] | select(.matcher == "Edit|Write|MultiEdit") | .hooks[] | select(.command | endswith("/.claude/hooks/block-worktree-path-mismatch.sh\""))' "$SETTINGS_ABS"
-  [ "$status" -eq 0 ]
+  hook_registered "$SETTINGS_ABS" '.hooks.PreToolUse[] | select(.matcher == "Edit|Write|MultiEdit")' block-worktree-path-mismatch.sh
 }
 
 # --- library-load degradation (gaia-react/gaia#1556) ------------------------

--- a/.gaia/tests/hooks/check-i18n-strings.bats
+++ b/.gaia/tests/hooks/check-i18n-strings.bats
@@ -162,6 +162,5 @@ run_hook_edit() {
 }
 
 @test "settings.json registers the hook under the Edit|Write|MultiEdit matcher" {
-  run jq -e '.hooks.PreToolUse[] | select(.matcher == "Edit|Write|MultiEdit") | .hooks[] | select(.command | endswith("/.claude/hooks/check-i18n-strings.sh\""))' "$SETTINGS_ABS"
-  [ "$status" -eq 0 ]
+  hook_registered "$SETTINGS_ABS" '.hooks.PreToolUse[] | select(.matcher == "Edit|Write|MultiEdit")' check-i18n-strings.sh
 }

--- a/.gaia/tests/hooks/check-story-exists.bats
+++ b/.gaia/tests/hooks/check-story-exists.bats
@@ -121,6 +121,5 @@ run_hook_edit() {
 }
 
 @test "settings.json registers the hook under the Edit|Write|MultiEdit matcher" {
-  run jq -e '.hooks.PreToolUse[] | select(.matcher == "Edit|Write|MultiEdit") | .hooks[] | select(.command | endswith("/.claude/hooks/check-story-exists.sh\""))' "$SETTINGS_ABS"
-  [ "$status" -eq 0 ]
+  hook_registered "$SETTINGS_ABS" '.hooks.PreToolUse[] | select(.matcher == "Edit|Write|MultiEdit")' check-story-exists.sh
 }

--- a/.gaia/tests/hooks/helpers/run-hook.sh
+++ b/.gaia/tests/hooks/helpers/run-hook.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Shared harness for the .gaia/tests/hooks bats suites: one quote-safe hook
-# invocation, and one assertion form per decision mechanism.
+# invocation, one assertion form per decision mechanism, and one assertion that
+# a hook is registered in `.claude/settings.json` at all.
 #
 # The directive below is the one thing this file needs that a suite does not:
 # `status` and `output` are set by bats' own `run`, which is invisible to the
@@ -49,6 +50,15 @@
 # tree-scoped or environment-scoped runner, capture stdout alone, or drive a
 # hook purely for its side effect. Keep the two in step by name; a change to
 # the invocation below almost certainly applies there too.
+
+# `GAIA_HOOK_NAME_RE`, which the registration assertion at the foot of this file
+# matches with, comes from the gates' own library rather than a copy here: it is
+# the one spelling of a hook name inside a registration command, and a copy of it
+# would drift from the original silently, because each holder keeps passing
+# against the copy it reads. Rooted at this file's own on-disk location, so it
+# resolves however a suite is invoked.
+# shellcheck source=../../../scripts/hook-registration-lib.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../../../scripts/hook-registration-lib.sh"
 
 # invoke_hook PAYLOAD HOOK
 # Pipes PAYLOAD to HOOK, capturing status/output through bats' `run`.
@@ -107,4 +117,40 @@ assert_allowed_by_json() {
 assert_asked_by_json() {
   [ "$status" -eq 0 ]
   grep -qF -- '"permissionDecision": "ask"' <<<"$output"
+}
+
+# --- registration: is the hook wired into settings.json at all? ------------
+# Separate from the three mechanisms above: those drive a hook and read its
+# verdict, this one reads the file that decides whether the hook is reached.
+#
+# It answers REGISTRATION and nothing else, deliberately. Whether a registration
+# names its script in a form that resolves independently of the shell's working
+# directory is a different question, and it already has an owner:
+# .gaia/scripts/check-hook-command-rooting.sh tests it as a property over every
+# registered command, under .gaia/tests/whole-tree-invariants.sh, and
+# .claude/rules/maintainers/hook-registration.md states the sanctioned form in
+# prose. A suite that pinned the spelling here instead would hold a second,
+# weaker copy of that claim, one that goes green against itself while the form
+# it encodes moves, which is exactly what having the form named once prevents.
+#
+# hook_registered SETTINGS EVENT_FILTER HOOK_NAME
+# Asserts that the entries EVENT_FILTER selects in the settings file SETTINGS
+# carry a command that runs HOOK_NAME. EVENT_FILTER is a jq expression,
+# `.hooks.PreToolUse[] | select(.matcher == "Bash")` for a matcher-scoped event
+# or `.hooks.PostCompact[]` for one registered without a matcher; HOOK_NAME is
+# the bare script name. Fails when the event key is absent, when the filter
+# selects nothing, and when nothing it selects runs the hook, so an assertion
+# cannot pass over an empty set.
+#
+# SETTINGS is an argument rather than the `SETTINGS_ABS` every suite here
+# already resolves, because a suite whose only remaining read of that variable
+# happened inside this function would assign it and never mention it again,
+# which is an unused-variable warning at the `.bats` severity floor.
+hook_registered() {
+  local settings="$1" filter="$2" hook="$3"
+  run jq -e --arg re "$GAIA_HOOK_NAME_RE" --arg hook "$hook" \
+    "[ $filter | .hooks[] | .command // empty ] |
+       any([match(\$re; \"g\").string] | any(. == \".claude/hooks/\" + \$hook))" \
+    "$settings"
+  [ "$status" -eq 0 ]
 }

--- a/.gaia/tests/hooks/wiki-recompact-inject.bats
+++ b/.gaia/tests/hooks/wiki-recompact-inject.bats
@@ -153,6 +153,5 @@ arm_sentinel() {
 }
 
 @test "settings.json registers the hook under UserPromptSubmit" {
-  run jq -e '.hooks.UserPromptSubmit[] | .hooks[] | select(.command | endswith("/.claude/hooks/wiki-recompact-inject.sh\""))' "$SETTINGS_ABS"
-  [ "$status" -eq 0 ]
+  hook_registered "$SETTINGS_ABS" '.hooks.UserPromptSubmit[]' wiki-recompact-inject.sh
 }

--- a/.gaia/tests/hooks/wiki-recompact-sentinel.bats
+++ b/.gaia/tests/hooks/wiki-recompact-sentinel.bats
@@ -130,8 +130,7 @@ seed_hot_cache() {
 }
 
 @test "settings.json registers the hook under PostCompact" {
-  run jq -e '.hooks.PostCompact[] | .hooks[] | select(.command | endswith("/.claude/hooks/wiki-recompact-sentinel.sh\""))' "$SETTINGS_ABS"
-  [ "$status" -eq 0 ]
+  hook_registered "$SETTINGS_ABS" '.hooks.PostCompact[]' wiki-recompact-sentinel.sh
 }
 
 @test "the sentinel path matches the one wiki-recompact-inject.sh consumes" {

--- a/.gaia/tests/hooks/wiki-session-start.bats
+++ b/.gaia/tests/hooks/wiki-session-start.bats
@@ -198,6 +198,5 @@ install_hook() {
 }
 
 @test "settings.json registers the hook under SessionStart startup|resume" {
-  run jq -e '.hooks.SessionStart[] | select(.matcher == "startup|resume") | .hooks[] | select(.command | endswith("/.claude/hooks/wiki-session-start.sh\""))' "$SETTINGS_ABS"
-  [ "$status" -eq 0 ]
+  hook_registered "$SETTINGS_ABS" '.hooks.SessionStart[] | select(.matcher == "startup|resume")' wiki-session-start.sh
 }

--- a/.gaia/tests/whole-tree-invariants.sh
+++ b/.gaia/tests/whole-tree-invariants.sh
@@ -152,7 +152,7 @@ readonly WTI_EXCLUDED='.gaia/scripts/check-debt-issue-metadata.sh|argument-drive
 .gaia/scripts/lint-sigpipe-readers.sh|runs transitively, shell-lint.sh invokes it and shell-lint.sh is itself a member
 .gaia/scripts/lint-hook-cwd-relative-loads.sh|runs transitively, shell-lint.sh invokes it and shell-lint.sh is itself a member
 .gaia/scripts/lint-hook-jq-availability.sh|runs transitively, shell-lint.sh invokes it and shell-lint.sh is itself a member
-.gaia/scripts/hook-registration-lib.sh|a sourced library defining functions and running nothing; the two gates that source it are members by the line above and by shell-lint.sh
+.gaia/scripts/hook-registration-lib.sh|a sourced library defining functions and running nothing; every gate that sources it is a member by the lines above and by shell-lint.sh, and its other consumer is a bats helper covered by the hooks suites in Audit CI Tests
 .gaia/tests/bats-shards.sh|harness plumbing, it partitions suites into shards rather than asserting anything; the partition itself is the bats member above
 .gaia/tests/install-bats.sh|harness plumbing, it installs the pinned bats and asserts no invariant
 .gaia/tests/run-bats-parallel.sh|harness plumbing, the hand-run entry point for the same partition


### PR DESCRIPTION
Closes #1753

## What moved

Every hook suite carried its own copy of one claim about `.claude/settings.json`: that a registered command *ends with* the quoted script path. The claim is about the sanctioned registration **form**, and nothing in the tree named that form once, so a change to it reds every suite at once with no pointer back to what moved, and any site a repair sweep misses diverges in silence.

The assertions now go through a shared `hook_registered` in `.gaia/tests/hooks/helpers/run-hook.sh`, which every one of these suites already sources.

## The posture change, which is deliberate

The helper asserts **registration**, not spelling: *is this hook registered under this event?* It matches the hook path with `GAIA_HOOK_NAME_RE`, sourced from `.gaia/scripts/hook-registration-lib.sh`, rather than writing another encoding of it.

Re-encoding the leading `/` and trailing `\"` inside the helper would have moved one copy to a better address rather than retiring it. The form question already has an owner in both halves it needs:

- `.gaia/scripts/check-hook-command-rooting.sh` tests it as a *property* over every registered command (every event plus `statusLine`, not just `PreToolUse`), and runs inside `.gaia/tests/whole-tree-invariants.sh`.
- `.claude/rules/maintainers/hook-registration.md` states the sanctioned form in prose under **Rooting obligation**.

`hook-registration-lib.sh`'s own docblock is the generating rule this follows: *"A second copy of either question drifts from the first silently, because each gate's own suite passes against its own copy."*

## The settings path is an argument

`hook_registered` takes the settings file as its first argument rather than reading each suite's `SETTINGS_ABS`. Reading the global would leave eight suites assigning a variable they never mention again, which is an unused-variable warning at the `.bats` severity floor, and it would make the helper's input implicit for no gain.

## Verification

- All 15 changed suites: 658 tests, 0 failures, under bash 5 via `.gaia/scripts/bats5.sh`.
- Every `.gaia/tests/hooks` suite (69 files, ~2140 tests) green, which covers the 46 suites that source the harness this change edits.
- `bash .gaia/tests/whole-tree-invariants.sh`: all invariants pass, including `shell-lint` and `check-hook-command-rooting`.
- Adversarial fixture, run against the helper before relying on it: it greens on the live registration and reds on each of a deleted registration, a hook re-registered under another name, a missing event key, and a matcher that selects nothing. A sixth case pins the posture change positively: a command with an argument appended after the script path still greens, where the old `endswith` assertion would have red.

## Corrections to the issue, from its own comment thread

The issue body's counts were stale and its suggested shape was superseded by a maintainer comment, which this PR follows:

- The encoding stood at 21 sites over 15 files at HEAD, not the 17 over 14 the body records. `block-secrets-read.bats` is the file the body's list does not have.
- The comment's terms 2 and 3 (assert registration not spelling; reuse `GAIA_HOOK_NAME_RE`) are what the helper implements, in place of the body's "build the jq filter from the hook name".

## Not in scope

`.gaia/scripts/tests/check-cli-workspace-floors.bats` reds in any freshly created worktree because `.gaia/cli/node_modules` is not installed there; the check says so itself and tells you to run `pnpm -C .gaia/cli install`. It passes in the main checkout and is unrelated to this diff.

## Audit dispositions

Round 1 (`code-audit-maintainer-shell`) returned clean: no Critical, no Important, two Suggestions.

- **In scope, fixed here.** `.gaia/scripts/hook-registration-lib.sh` presented its two lint gates as the whole consumer set of `GAIA_HOOK_NAME_RE`, and this branch gave it another. The header now names the suites as a holder and states the direction that consumer fails in: widening the class to admit a shape a gate needs also widens what every registration assertion accepts, silently.
- **Out of scope, filed as #1911.** Two copies of the retired `endswith` form survive in `.gaia/tests/sandbox/spec-028-composition.bats` (`:112`, `:117`), the only ones left tree-wide. That suite is outside the set this issue's own scoping comment sanctioned, and that comment instructed the drainer to stop and say so rather than widen in place. Not waived: this change is what turns one form in many copies into two independent forms, so the asymmetry is authored here and owes a tracked destination rather than a note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
