### PR TITLE
wiki: sync through 1e74ab0

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "2b72247b7a1f09656efd0862eff4a5edff1eea8c",
-  "last_evaluated_at": "2026-09-09T06:19:29Z",
+  "last_evaluated_sha": "1e74ab09c68b75e1d839d4f38ad80d2b1a7c78c9",
+  "last_evaluated_at": "2026-09-09T09:30:07Z",
   "last_consolidated_sha": "78c69d0f81d5bc6460453391c466570f30da43c4",
   "last_consolidated_at": "2026-09-08T06:34:36Z"
 }

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,7 @@ tags: [meta, log]
 
 ## [Unreleased]
 
+- 2026-09-09 1e74ab09 SKIP - prior wiki sync's own commit (advances state/log), no new content to catalogue
 - 2026-09-09 2b72247b WORTHY - sync playbook gains Step 5c shipped-surface boundary check -> wiki/decisions/Wiki Management.md new Shipped-surface boundary check section
 - 2026-09-09 4cf1a9cc WORTHY - shared jq-availability arm closes fail-open across blocking PreToolUse hooks -> wiki/concepts/Claude Hooks.md 'Shared jq-availability decision' section already added inline
 - 2026-09-09 9a456ba3 SKIP - internal refactor routing four hand-rolled CLI tree walks through collectTreeFiles, no documented-contract change


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to 1e74ab0.