### PR TITLE
debt(tests): let build-staging's phase blocks own the phase list

### DIFF
--- a/.gaia/tests/distribution/lib/build-staging.sh
+++ b/.gaia/tests/distribution/lib/build-staging.sh
@@ -3,8 +3,9 @@
 # shell expansion.
 # shellcheck disable=SC2016
 # Build a release-staging tree from the source repo into <output-dir>.
-# Pure replication of `.github/workflows/release.yml` Stage + Scrub +
-# Runtime-deps phases. Read-only on the source repo.
+# Replicates `.github/workflows/release.yml`; each phase block below names what
+# it mirrors and where it deviates, and a list of them here would go stale the
+# next time a phase is added. Read-only on the source repo.
 #
 # Usage: build-staging.sh <output-dir>
 #

--- a/.gaia/tests/distribution/lib/build-staging.sh
+++ b/.gaia/tests/distribution/lib/build-staging.sh
@@ -3,9 +3,9 @@
 # shell expansion.
 # shellcheck disable=SC2016
 # Build a release-staging tree from the source repo into <output-dir>.
-# Replicates `.github/workflows/release.yml`; each phase block below names what
-# it mirrors and where it deviates, and a list of them here would go stale the
-# next time a phase is added. Read-only on the source repo.
+# Replicates `.github/workflows/release.yml`; each phase block below says what
+# it replicates, and a list of them here would go stale the next time a phase
+# is added. Read-only on the source repo.
 #
 # Usage: build-staging.sh <output-dir>
 #
@@ -102,9 +102,11 @@ rsync -a --files-from="$INCLUDE" "$PROJECT_ROOT/" "$OUTPUT_DIR/"
 # on log content the adopter never receives.
 ( cd "$OUTPUT_DIR" && "$PROJECT_ROOT/.gaia/cli/gaia-maintainer" release scrub-wiki )
 
-# Phase 3; Scrub. Same invocation as release.yml line 82. Runs after
-# scrub-wiki so the leak-check scans the reset log.md/hot.md (see above).
+# Phase 3; Scrub. Same invocation as release.yml's "Bundle-time scrub
+# (marker-strip + leak-check)" step. Runs after scrub-wiki so the leak-check
+# scans the reset log.md/hot.md (see above).
 "$PROJECT_ROOT/.gaia/cli/gaia-maintainer" release scrub "$OUTPUT_DIR"
 
-# Phase 4; Runtime-deps. Same invocation as release.yml line 87.
+# Phase 4; Runtime-deps. Same invocation as release.yml's "Verify runtime
+# dependencies" step.
 "$PROJECT_ROOT/.gaia/cli/gaia-maintainer" release runtime-deps --staging "$OUTPUT_DIR"


### PR DESCRIPTION
Closes #1909

## What

`.gaia/tests/distribution/lib/build-staging.sh:6` named three replicated phases (`Stage + Scrub + Runtime-deps`) while the script runs four. The header now points at the phase blocks instead of listing them.

**The unlisted phase is also the one that deviates from the file the header cited.** Phase 2, Scrub-wiki, replicates the local `/gaia-release` runbook rather than `release.yml`, and its own block says so. It resets `wiki/hot.md` and `wiki/log.md` in the staged tree, which is exactly the state `.claude/skills/gaia/references/wiki/sync.md` step 5c.2 depends on, so a reader reasoning about the staged tree from the header alone reaches a wrong conclusion about the tree the leak check scans.

## Which arm, and why

The issue offered two shapes and the backlog note settled on the first. Delete the list, do not complete it:

- **This same file already takes that direction one screen away.** Its exit-code block states `0` and then a single complement rather than a corrected list of statuses, on the reasoning that there is no set left to go short (#1904, merged as #1907).
- **Naming the fourth phase is the widening the prose rules caution against.** `.claude/rules/wiki-style.md` states the corollary directly: when an enumeration is found stale, delete it and point, do not complete it, because a corrected list restarts the same decay from a fresher number. `.claude/rules/code-comments.md`'s Counts section says the same of a cardinal. Arm 2 leaves the same list to go stale the next time a phase is added.

## What round 1 of the audit changed

Two Suggestions, both real, both re-verified against the tree before applying:

- **The first header wording overclaimed.** It credited each phase block with naming "where it deviates", and Phase 1 names no deviation while it has two: `release.yml`'s Stage step splits tracked-path discovery failure into two `::error::` annotations because they send a maintainer to different places, this harness folds both into one message, and the shipped-tree leak assertion that step carries lives in `02-leak-replay.sh` instead. The header now claims only what every block does do, which is say what it replicates.
- **Phase 3 and Phase 4 cited `release.yml` by line number**, and both citations were dead: line 82 is blank, line 87 is a comment about date normalization, and the invocations they mean sit at 192 and 197. Both now name the step, the form Phase 1 uses and states its reason for three lines into the same file.

**The second is a deliberate scope departure, noted rather than assumed.** The backlog note scoped this row to the header comment at `:6` and nothing else, and that citation defect is pre-existing rather than authored here. It was folded in because the repair is two comment lines, the re-audit was already being paid by the first fix, and it is the same pointer-decay class this issue is about, sitting in the very blocks the new header now points at. Filing it instead would have left the header delegating to two pointers that go nowhere.

Round 2 came back clean, zero findings, anchored on round 1's clearance.

## Verification

Comment-only change to a release-excluded harness file. It ships no guard, so `.claude/rules/guards-must-fail.md` has nothing to arm, and no suite asserts the header text (the audit independently confirmed the eleven scenario scripts branch only on exit status, and the one bats suite touching this file asserts the shared-boundary call rather than the comment).

- `bash .gaia/tests/shell-lint.sh` — passed, both rounds. `lint-stale-cardinals` clean on the new wording.
- `bash .gaia/tests/whole-tree-invariants.sh` — all whole-tree invariants pass, both rounds.
- `bash -n` and `shellcheck` on the edited script — clean.
- All three cited `release.yml` step names verified to resolve exactly (`Stage release tree`, `Bundle-time scrub (marker-strip + leak-check)`, `Verify runtime dependencies`), and no line-number citation remains in the file.
- Quality Gate skipped by its own rule: the staged set holds one `.sh` file and no source or gate-affecting config.

## CHANGELOG

No entry. The file is release-excluded maintainer test harness, the change is comment-only, and no adopter receives it. The precedent on the same file (#1907) landed no entry either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
