### PR TITLE
debt(tests): pin the bats marker-strip models to the shipped parser

### DIFF
--- a/.gaia/cli/src/release/marker-strip.test.ts
+++ b/.gaia/cli/src/release/marker-strip.test.ts
@@ -2,10 +2,9 @@
  * Lockstep guard for the maintainer-only marker strip (#1742).
  *
  * `stripMarkerBlocks` is the parser the release scrub actually runs, and the
- * bats suites `MODEL_SUITES` names carry hand-written awk models of it so they
- * can strip a script and then RUN the stripped copy without taking a
- * dependency on the maintainer CLI. Nothing held those models to the parser:
- * a change to the TypeScript
+ * bats suites carry hand-written awk models of it so they can strip a script
+ * and then RUN the stripped copy without taking a dependency on the maintainer
+ * CLI. Nothing held those models to the parser: a change to the TypeScript
  * state machine left every model behind with nothing red, and the suites would
  * go on certifying a stripped copy the release scrub does not produce.
  *
@@ -18,19 +17,36 @@
  *
  * # What it asserts
  *
- * 1. `stripMarkerBlocks` and `AWK_PROGRAM` agree byte-for-byte over a fixture
- *    corpus covering every branch of the state machine.
- * 2. Every suite carries `BATS_AWK_BLOCK` verbatim, so a model that drifts
- *    from the program this file just proved faithful goes red here.
- * 3. Each suite's marker constants equal the delimiters of the one
- *    marker-strip transform that governs shell files, read out of
- *    `.gaia/release-scrub.yml` through the scrub's own loader, so a suite
- *    cannot strip and pass against a retired spelling.
+ * 1. `stripMarkerBlocks` and `AWK_PROGRAM` produce identical bytes over a
+ *    fixture corpus covering every branch of the state machine, with one
+ *    named exemption `UNTERMINATED_START` documents.
+ * 2. Every suite carrying the model holds `BATS_AWK_BLOCK` verbatim, so a
+ *    model that drifts from the program this file just proved faithful goes
+ *    red here.
+ * 3. Every such suite declares a delimiter pair that a marker-strip transform
+ *    in `.gaia/release-scrub.yml` actually uses, so a suite cannot strip and
+ *    pass against a spelling the release retired. The pair is per suite
+ *    because the surfaces differ: a suite stripping shell reads the
+ *    `#`-comment transform, one stripping markdown the HTML-comment transform.
  *
- * Assertion 3 is why the suites keep their own constants rather than gaining a
- * shell helper that reads the config: a copy of that YAML walk in every one of
- * them would recreate, in the fix, exactly the drifting-duplicate class this
- * issue is about.
+ * The corpus runs against one delimiter pair rather than every declared pair,
+ * and that is not a gap: both sides take their markers as parameters, so the
+ * state machine cannot branch on the spelling. Assertion 1 proves the machine
+ * and assertion 3 proves the spellings, each once.
+ *
+ * # What it does not catch
+ *
+ * Discovery reads the git index, so a model in a suite that is written but not
+ * yet staged is not enrolled. That fails in the safe direction: CI audits the
+ * committed tree, so the suite is enrolled by the time it can gate anything,
+ * and the miss is bounded to the authoring session that added it.
+ *
+ * A model written in some other shape entirely, a `sed` range or an awk with
+ * its own variable names, carries no `BATS_AWK_INVOCATION` and so is not
+ * discovered. That residue is not decidable by text: recognizing an arbitrary
+ * hand-rolled strip needs a reader. What the guard does guarantee is that a
+ * site converted to this invocation stays converted, and converting a site is
+ * what enrolls it.
  *
  * Maintainer-only by construction: `.gaia/cli/src` is release-excluded, so an
  * adopter clone carries neither `marker-strip.ts` nor this test.
@@ -61,60 +77,66 @@ const AWK_PROGRAM = `
   `;
 
 /**
+ * The invocation's head, which is what identifies a suite as carrying a model.
+ * Discovery keys on this rather than on the whole block below, and the split is
+ * load-bearing: keyed on the whole block, a suite whose awk body drifted would
+ * simply stop being discovered, its two assertions would vanish, and the guard
+ * would go green over a smaller set while still naming itself for every model.
+ * Keyed on the head, that suite stays in the set and reds.
+ */
+const BATS_AWK_INVOCATION =
+  'awk -v s="$MAINTAINER_START" -v e="$MAINTAINER_END"';
+
+/**
  * The whole invocation as it is written in each suite, built from
  * `AWK_PROGRAM` so the text this file proves faithful and the text it pins into
  * the suites cannot become two different things.
  */
-const BATS_AWK_BLOCK = `awk -v s="$MAINTAINER_START" -v e="$MAINTAINER_END" '${AWK_PROGRAM}'`;
-
-/** The suites carrying a model of the strip, each read once. */
-const MODEL_SUITES = [
-  '.gaia/scripts/tests/verify-audit-roster.bats',
-  '.gaia/scripts/tests/audit-write-clearance.bats',
-  '.gaia/tests/hooks/audit-scope-lib.bats',
-].map((suite) => ({
-  suite,
-  text: readFileSync(path.join(REPO_ROOT, suite), 'utf8'),
-}));
+const BATS_AWK_BLOCK = `${BATS_AWK_INVOCATION} '${AWK_PROGRAM}'`;
 
 /**
- * The glob selecting the marker-strip transform that governs shell files. A
- * sibling transform carries the same two delimiter spellings and covers
- * markdown instead, so the transform has to be picked by what it governs
- * rather than by being the first one that declares a `start`.
+ * Every marker-strip transform's delimiter pair, keyed by start marker.
+ * `.gaia/release-scrub.yml` declares more than one: the shell-and-YAML
+ * transform and the `.prettierignore` one share the `#`-comment spellings,
+ * while the markdown transform uses HTML-comment spellings. A suite is held to
+ * membership in this set rather than to one chosen transform, because which
+ * transform governs a suite is decided by the files that suite strips.
  */
-const SH_TRANSFORM_GLOB = '**/*.sh';
+const DECLARED_DELIMITERS = new Map(
+  loadConfig(path.join(REPO_ROOT, '.gaia/release-scrub.yml'))
+    .transforms.filter((transform) => transform.type === 'marker-strip')
+    .map((transform) => [transform.start, transform.end])
+);
+
+/** The pair governing shell files, the corpus below runs against it. */
+const START_MARKER = '# gaia:maintainer-only:start';
+const END_MARKER = DECLARED_DELIMITERS.get(START_MARKER);
+
+if (END_MARKER === undefined) {
+  throw new Error(
+    `no marker-strip transform in .gaia/release-scrub.yml declares ${START_MARKER}; that config moved, not the strip`
+  );
+}
 
 /**
- * The delimiters that transform declares, read through the scrub's own
- * `loadConfig` so this guard sees the config the release sees rather than
- * through a second, indentation-sensitive parser written here.
+ * The suites carrying the model, discovered rather than listed: a hand-kept
+ * list is the arming condition, and a model added to a suite the list does not
+ * name is precisely the drift this guard exists to catch.
  */
-const readShMarkerDelimiters = (): {end: string; start: string} => {
-  const transform = loadConfig(path.join(REPO_ROOT, '.gaia/release-scrub.yml'))
-    .transforms.filter((candidate) => candidate.type === 'marker-strip')
-    .find((candidate) => candidate.paths.includes(SH_TRANSFORM_GLOB));
-
-  if (!transform) {
-    throw new Error(
-      `no marker-strip transform covering ${SH_TRANSFORM_GLOB} in .gaia/release-scrub.yml; that config moved, not the strip`
-    );
+const MODEL_SUITES = execFileSync(
+  'git',
+  ['-C', REPO_ROOT, 'ls-files', '*.bats'],
+  {
+    encoding: 'utf8',
   }
-
-  return {end: transform.end, start: transform.start};
-};
-
-const {end: END_MARKER, start: START_MARKER} = readShMarkerDelimiters();
-
-/**
- * awk terminates its final record with a newline; `stripMarkerBlocks` preserves
- * whatever trailing byte the source had. That is awk's I/O contract rather than
- * the state machine, and it is reachable only on a source with no trailing
- * newline, so it is normalized here instead of being asserted on. Every other
- * byte is compared exactly.
- */
-const normalizeTrailer = (text: string): string =>
-  text === '' || text.endsWith('\n') ? text : `${text}\n`;
+)
+  .split('\n')
+  .filter((suite) => suite !== '')
+  .map((suite) => ({
+    suite,
+    text: readFileSync(path.join(REPO_ROOT, suite), 'utf8'),
+  }))
+  .filter(({text}) => text.includes(BATS_AWK_INVOCATION));
 
 const runReferenceModel = (fixture: string): string =>
   execFileSync(
@@ -122,6 +144,21 @@ const runReferenceModel = (fixture: string): string =>
     ['-v', `s=${START_MARKER}`, '-v', `e=${END_MARKER}`, AWK_PROGRAM],
     {encoding: 'utf8', input: fixture}
   );
+
+/**
+ * The one source shape on which the two sides disagree, held out of the corpus
+ * and asserted on its own below rather than normalized away. `stripMarkerBlocks`
+ * splits on `\n`, so a newline-terminated source yields a trailing empty
+ * element; inside a block that never closes the element is dropped with
+ * everything else, and the output loses its final newline, where awk terminates
+ * its last record regardless. That is the state machine, not awk's output
+ * contract, so it is written down.
+ *
+ * Unreachable through the release path: `scrub.ts` fails the build on any
+ * unbalanced marker, so a source with an unterminated start never reaches the
+ * point where the two outputs would be compared.
+ */
+const UNTERMINATED_START = `a\n${START_MARKER}\nb\n`;
 
 /**
  * Every branch of the state machine, plus the two shapes that made a real
@@ -150,7 +187,6 @@ const FIXTURES: {name: string; source: string}[] = [
     name: 'nested start',
     source: `a\n${START_MARKER}\nb\n${START_MARKER}\nc\n${END_MARKER}\nd\n`,
   },
-  {name: 'unterminated start', source: `a\n${START_MARKER}\nb\n`},
   {
     name: 'marker inside a quoted string',
     source: `a\necho "${START_MARKER}"\nb\n${END_MARKER}\nc\n`,
@@ -166,11 +202,18 @@ const FIXTURES: {name: string; source: string}[] = [
   {name: 'no markers at all', source: 'a\nb\nc\n'},
 ];
 
+/**
+ * A suite's own declaration of each delimiter, matched on its own line rather
+ * than as an adjacent pair: the two are read independently, so a suite may
+ * order or separate them however it likes.
+ */
+const START_DECLARATION = /^ *MAINTAINER_START='(?<value>[^']*)'$/mu;
+const END_DECLARATION = /^ *MAINTAINER_END='(?<value>[^']*)'$/mu;
+
 /** The fixtures that legitimately close no block, by name. */
 const NON_STRIPPING_FIXTURES = new Set([
   'end without start',
   'no markers at all',
-  'unterminated start',
 ]);
 
 describe('marker-strip lockstep (#1742)', () => {
@@ -184,9 +227,8 @@ describe('marker-strip lockstep (#1742)', () => {
   });
 
   // Non-vacuity, per fixture rather than sampled: a source with no start
-  // marker closes no block, and neither does one whose start is never
-  // terminated. Every other fixture has to report a stripped block, or the two
-  // sides below agree on output nobody transformed.
+  // marker closes no block. Every other fixture has to report a stripped
+  // block, or the two sides below agree on output nobody transformed.
   test.each(FIXTURES)(
     'strips exactly as its shape says: $name',
     ({name, source}) => {
@@ -197,15 +239,24 @@ describe('marker-strip lockstep (#1742)', () => {
   );
 
   test.each(FIXTURES)(
-    'stripMarkerBlocks matches the reference model: $name',
+    'stripMarkerBlocks is byte-identical to the reference model: $name',
     ({source}) => {
-      const parsed = stripMarkerBlocks(source, START_MARKER, END_MARKER);
-
-      expect(normalizeTrailer(parsed.output)).toBe(
-        normalizeTrailer(runReferenceModel(source))
+      expect(stripMarkerBlocks(source, START_MARKER, END_MARKER).output).toBe(
+        runReferenceModel(source)
       );
     }
   );
+
+  test('an unterminated start is the one shape the two disagree on', () => {
+    expect(
+      stripMarkerBlocks(UNTERMINATED_START, START_MARKER, END_MARKER).output
+    ).toBe('a');
+    expect(runReferenceModel(UNTERMINATED_START)).toBe('a\n');
+  });
+
+  test('the suite discovery found the models it exists to check', () => {
+    expect(MODEL_SUITES.length).toBeGreaterThan(0);
+  });
 
   test.each(MODEL_SUITES)(
     '$suite carries the reference model verbatim',
@@ -215,10 +266,13 @@ describe('marker-strip lockstep (#1742)', () => {
   );
 
   test.each(MODEL_SUITES)(
-    '$suite takes its markers from the shipped scrub config',
+    '$suite declares delimiters the shipped scrub uses',
     ({text}) => {
-      expect(text).toContain(`MAINTAINER_START='${START_MARKER}'`);
-      expect(text).toContain(`MAINTAINER_END='${END_MARKER}'`);
+      const start = START_DECLARATION.exec(text)?.groups?.value;
+      const end = END_DECLARATION.exec(text)?.groups?.value;
+
+      expect(start).toBeDefined();
+      expect(DECLARED_DELIMITERS.get(start ?? '')).toBe(end);
     }
   );
 });

--- a/.gaia/cli/src/release/marker-strip.test.ts
+++ b/.gaia/cli/src/release/marker-strip.test.ts
@@ -94,19 +94,31 @@ const BATS_AWK_INVOCATION =
  */
 const BATS_AWK_BLOCK = `${BATS_AWK_INVOCATION} '${AWK_PROGRAM}'`;
 
+const MARKER_STRIP_TRANSFORMS = loadConfig(
+  path.join(REPO_ROOT, '.gaia/release-scrub.yml')
+).transforms.filter((transform) => transform.type === 'marker-strip');
+
 /**
  * Every marker-strip transform's delimiter pair, keyed by start marker.
  * `.gaia/release-scrub.yml` declares more than one: the shell-and-YAML
  * transform and the `.prettierignore` one share the `#`-comment spellings,
  * while the markdown transform uses HTML-comment spellings. A suite is held to
  * membership in this set rather than to one chosen transform, because which
- * transform governs a suite is decided by the files that suite strips.
+ * transform governs a suite is decided by the files that suite strips, which
+ * no parse of the suite recovers.
+ *
+ * Membership alone is weaker than naming the governing transform, in exactly
+ * one direction: two transforms declare the `#` pair, so a shell transform
+ * that respelled while `.prettierignore` kept the old pair would leave the key
+ * in this map and every shell-stripping suite passing. The last test in this
+ * file closes that direction by pinning the shell transform's own pair.
  */
 const DECLARED_DELIMITERS = new Map(
-  loadConfig(path.join(REPO_ROOT, '.gaia/release-scrub.yml'))
-    .transforms.filter((transform) => transform.type === 'marker-strip')
-    .map((transform) => [transform.start, transform.end])
+  MARKER_STRIP_TRANSFORMS.map((transform) => [transform.start, transform.end])
 );
+
+/** The glob naming the transform that governs shell files. */
+const SH_TRANSFORM_GLOB = '**/*.sh';
 
 /** The pair governing shell files, the corpus below runs against it. */
 const START_MARKER = '# gaia:maintainer-only:start';
@@ -271,8 +283,24 @@ describe('marker-strip lockstep (#1742)', () => {
       const start = START_DECLARATION.exec(text)?.groups?.value;
       const end = END_DECLARATION.exec(text)?.groups?.value;
 
+      // Both sides are guarded: `get` on an absent key and an unmatched END
+      // declaration both yield undefined, so asserting only their equality
+      // would certify a suite that declares neither.
       expect(start).toBeDefined();
+      expect(end).toBeDefined();
       expect(DECLARED_DELIMITERS.get(start ?? '')).toBe(end);
     }
   );
+
+  // The membership check above cannot see a respelling of the shell transform
+  // alone, because `.prettierignore` declares the same pair and keeps the key
+  // alive. This pins the transform the corpus actually runs against.
+  test('the transform governing shell files declares the pair the corpus uses', () => {
+    const shellTransform = MARKER_STRIP_TRANSFORMS.find((transform) =>
+      transform.paths.includes(SH_TRANSFORM_GLOB)
+    );
+
+    expect(shellTransform?.start).toBe(START_MARKER);
+    expect(shellTransform?.end).toBe(END_MARKER);
+  });
 });

--- a/.gaia/cli/src/release/marker-strip.test.ts
+++ b/.gaia/cli/src/release/marker-strip.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Lockstep guard for the maintainer-only marker strip (#1742).
+ *
+ * `stripMarkerBlocks` is the parser the release scrub actually runs, and the
+ * bats suites `MODEL_SUITES` names carry hand-written awk models of it so they
+ * can strip a script and then RUN the stripped copy without taking a
+ * dependency on the maintainer CLI. Nothing held those models to the parser:
+ * a change to the TypeScript
+ * state machine left every model behind with nothing red, and the suites would
+ * go on certifying a stripped copy the release scrub does not produce.
+ *
+ * # Which direction the dependency runs, and why
+ *
+ * This guard follows `exclude-parser-parity.test.ts`: TypeScript reaches for
+ * the shell text, rather than a bats suite reaching for the CLI. The models
+ * stay dependency-free standalone bash, which is what they are for, and the
+ * binding lives here where the parser lives.
+ *
+ * # What it asserts
+ *
+ * 1. `stripMarkerBlocks` and `AWK_PROGRAM` agree byte-for-byte over a fixture
+ *    corpus covering every branch of the state machine.
+ * 2. Every suite carries `BATS_AWK_BLOCK` verbatim, so a model that drifts
+ *    from the program this file just proved faithful goes red here.
+ * 3. Each suite's marker constants equal the delimiters of the one
+ *    marker-strip transform that governs shell files, read out of
+ *    `.gaia/release-scrub.yml` through the scrub's own loader, so a suite
+ *    cannot strip and pass against a retired spelling.
+ *
+ * Assertion 3 is why the suites keep their own constants rather than gaining a
+ * shell helper that reads the config: a copy of that YAML walk in every one of
+ * them would recreate, in the fix, exactly the drifting-duplicate class this
+ * issue is about.
+ *
+ * Maintainer-only by construction: `.gaia/cli/src` is release-excluded, so an
+ * adopter clone carries neither `marker-strip.ts` nor this test.
+ */
+import {describe, expect, test} from 'vitest';
+import {execFileSync} from 'node:child_process';
+import {readFileSync} from 'node:fs';
+import path from 'node:path';
+import {resolveRepoRootFromImportMeta} from '../util/repo-root-fixture.js';
+import {stripMarkerBlocks} from './marker-strip.js';
+import {loadConfig} from './scrub.js';
+
+const REPO_ROOT = resolveRepoRootFromImportMeta(import.meta.url);
+
+/**
+ * The reference model, byte-identical to the awk each suite carries. Held here
+ * rather than extracted from a suite: extracting it would prove two copies of a
+ * model match each other, which is the state this guard exists to end.
+ */
+const AWK_PROGRAM = `
+    {
+      has_s = index($0, s) > 0
+      has_e = index($0, e) > 0
+      if (!skip && has_s) { if (!has_e) skip = 1; next }
+      if (skip) { if (has_e) skip = 0; next }
+      print
+    }
+  `;
+
+/**
+ * The whole invocation as it is written in each suite, built from
+ * `AWK_PROGRAM` so the text this file proves faithful and the text it pins into
+ * the suites cannot become two different things.
+ */
+const BATS_AWK_BLOCK = `awk -v s="$MAINTAINER_START" -v e="$MAINTAINER_END" '${AWK_PROGRAM}'`;
+
+/** The suites carrying a model of the strip, each read once. */
+const MODEL_SUITES = [
+  '.gaia/scripts/tests/verify-audit-roster.bats',
+  '.gaia/scripts/tests/audit-write-clearance.bats',
+  '.gaia/tests/hooks/audit-scope-lib.bats',
+].map((suite) => ({
+  suite,
+  text: readFileSync(path.join(REPO_ROOT, suite), 'utf8'),
+}));
+
+/**
+ * The glob selecting the marker-strip transform that governs shell files. A
+ * sibling transform carries the same two delimiter spellings and covers
+ * markdown instead, so the transform has to be picked by what it governs
+ * rather than by being the first one that declares a `start`.
+ */
+const SH_TRANSFORM_GLOB = '**/*.sh';
+
+/**
+ * The delimiters that transform declares, read through the scrub's own
+ * `loadConfig` so this guard sees the config the release sees rather than
+ * through a second, indentation-sensitive parser written here.
+ */
+const readShMarkerDelimiters = (): {end: string; start: string} => {
+  const transform = loadConfig(path.join(REPO_ROOT, '.gaia/release-scrub.yml'))
+    .transforms.filter((candidate) => candidate.type === 'marker-strip')
+    .find((candidate) => candidate.paths.includes(SH_TRANSFORM_GLOB));
+
+  if (!transform) {
+    throw new Error(
+      `no marker-strip transform covering ${SH_TRANSFORM_GLOB} in .gaia/release-scrub.yml; that config moved, not the strip`
+    );
+  }
+
+  return {end: transform.end, start: transform.start};
+};
+
+const {end: END_MARKER, start: START_MARKER} = readShMarkerDelimiters();
+
+/**
+ * awk terminates its final record with a newline; `stripMarkerBlocks` preserves
+ * whatever trailing byte the source had. That is awk's I/O contract rather than
+ * the state machine, and it is reachable only on a source with no trailing
+ * newline, so it is normalized here instead of being asserted on. Every other
+ * byte is compared exactly.
+ */
+const normalizeTrailer = (text: string): string =>
+  text === '' || text.endsWith('\n') ? text : `${text}\n`;
+
+const runReferenceModel = (fixture: string): string =>
+  execFileSync(
+    'awk',
+    ['-v', `s=${START_MARKER}`, '-v', `e=${END_MARKER}`, AWK_PROGRAM],
+    {encoding: 'utf8', input: fixture}
+  );
+
+/**
+ * Every branch of the state machine, plus the two shapes that made a real
+ * model diverge: a start and end on one line, and an end with no open block
+ * (which the shipped parser deliberately KEEPS, `marker-strip.ts:55-57`).
+ */
+const FIXTURES: {name: string; source: string}[] = [
+  {
+    name: 'plain pair',
+    source: `a\n${START_MARKER}\nsecret\n${END_MARKER}\nb\n`,
+  },
+  {
+    name: 'indented pair',
+    source: `a\n  ${START_MARKER}\n  secret\n  ${END_MARKER}\nb\n`,
+  },
+  {
+    name: 'start and end on one line',
+    source: `a\n${START_MARKER} ${END_MARKER}\nb\n`,
+  },
+  {name: 'end without start', source: `a\n${END_MARKER}\nb\n`},
+  {
+    name: 'end without start, then a real block',
+    source: `a\n${END_MARKER}\nb\n${START_MARKER}\nsecret\n${END_MARKER}\nc\n`,
+  },
+  {
+    name: 'nested start',
+    source: `a\n${START_MARKER}\nb\n${START_MARKER}\nc\n${END_MARKER}\nd\n`,
+  },
+  {name: 'unterminated start', source: `a\n${START_MARKER}\nb\n`},
+  {
+    name: 'marker inside a quoted string',
+    source: `a\necho "${START_MARKER}"\nb\n${END_MARKER}\nc\n`,
+  },
+  {
+    name: 'marker with trailing text',
+    source: `a\n${START_MARKER} rationale\nsecret\n${END_MARKER} .\nb\n`,
+  },
+  {
+    name: 'two blocks',
+    source: `a\n${START_MARKER}\nx\n${END_MARKER}\nb\n${START_MARKER}\ny\n${END_MARKER}\nc\n`,
+  },
+  {name: 'no markers at all', source: 'a\nb\nc\n'},
+];
+
+/** The fixtures that legitimately close no block, by name. */
+const NON_STRIPPING_FIXTURES = new Set([
+  'end without start',
+  'no markers at all',
+  'unterminated start',
+]);
+
+describe('marker-strip lockstep (#1742)', () => {
+  test('AWK_PROGRAM is the real model text, not a vacuous constant', () => {
+    expect(AWK_PROGRAM).toContain(
+      'if (!skip && has_s) { if (!has_e) skip = 1; next }'
+    );
+    expect(BATS_AWK_BLOCK).toContain(
+      'awk -v s="$MAINTAINER_START" -v e="$MAINTAINER_END"'
+    );
+  });
+
+  // Non-vacuity, per fixture rather than sampled: a source with no start
+  // marker closes no block, and neither does one whose start is never
+  // terminated. Every other fixture has to report a stripped block, or the two
+  // sides below agree on output nobody transformed.
+  test.each(FIXTURES)(
+    'strips exactly as its shape says: $name',
+    ({name, source}) => {
+      expect(
+        stripMarkerBlocks(source, START_MARKER, END_MARKER).blocks > 0
+      ).toBe(!NON_STRIPPING_FIXTURES.has(name));
+    }
+  );
+
+  test.each(FIXTURES)(
+    'stripMarkerBlocks matches the reference model: $name',
+    ({source}) => {
+      const parsed = stripMarkerBlocks(source, START_MARKER, END_MARKER);
+
+      expect(normalizeTrailer(parsed.output)).toBe(
+        normalizeTrailer(runReferenceModel(source))
+      );
+    }
+  );
+
+  test.each(MODEL_SUITES)(
+    '$suite carries the reference model verbatim',
+    ({text}) => {
+      expect(text).toContain(BATS_AWK_BLOCK);
+    }
+  );
+
+  test.each(MODEL_SUITES)(
+    '$suite takes its markers from the shipped scrub config',
+    ({text}) => {
+      expect(text).toContain(`MAINTAINER_START='${START_MARKER}'`);
+      expect(text).toContain(`MAINTAINER_END='${END_MARKER}'`);
+    }
+  );
+});

--- a/.gaia/scripts/tests/audit-write-clearance.bats
+++ b/.gaia/scripts/tests/audit-write-clearance.bats
@@ -20,6 +20,11 @@ setup() {
   READER="$THIS_DIR/../../../.claude/hooks/lib/audit-clearance.sh"
   DIGEST_LIB="$THIS_DIR/../../../.claude/hooks/lib/audit-digest.sh"
   RESOLVER="$THIS_DIR/../resolve-audit-members.sh"
+  # The delimiters of the marker-strip transform in .gaia/release-scrub.yml that
+  # governs shell files and .gaia/audit-ci.yml, the two shapes scrub_maintainer_only
+  # below is pointed at. marker-strip.test.ts holds these to that transform.
+  MAINTAINER_START='# gaia:maintainer-only:start'
+  MAINTAINER_END='# gaia:maintainer-only:end'
   [ -x "$WRITER" ] || skip "audit-write-clearance.sh not executable"
   [ -f "$DIGEST_LIB" ] || skip "audit-digest.sh not present"
   command -v jq >/dev/null 2>&1 || skip "jq not available"
@@ -474,13 +479,30 @@ member_digest() {
 # roster collapses to the single default member, and the shipped writer
 # produces a valid digest-keyed marker with no maintainer member.
 
-# Strip # gaia:maintainer-only:start ... :end blocks (inclusive), as the
-# bundle-time scrub does to shipped files.
+# Strips maintainer-only blocks from the file named by $1, writing the result to
+# stdout, as the bundle-time scrub does to shipped files.
+#
+# The agreement with the shipped parser (`stripMarkerBlocks` in
+# `.gaia/cli/src/release/marker-strip.ts`) is PINNED, not conventional:
+# `.gaia/cli/src/release/marker-strip.test.ts` runs this exact awk against the
+# real parser over a fixture corpus, and then asserts this file carries the
+# invocation below verbatim. Two sibling suites carry the same block
+# (`verify-audit-roster.bats`, `.gaia/tests/hooks/audit-scope-lib.bats`), so a
+# change here belongs in all of them.
+#
+# The unanchored `/gaia:maintainer-only:start/` pair this replaces was a third
+# marker vocabulary: it fired on the HTML-comment form too, which the transform
+# governing shell files does not use. The constants above are the ones that
+# transform declares, and the guard asserts they still are.
 scrub_maintainer_only() {
-  awk '
-    /gaia:maintainer-only:start/ { skip = 1 }
-    !skip { print }
-    /gaia:maintainer-only:end/   { skip = 0 }
+  awk -v s="$MAINTAINER_START" -v e="$MAINTAINER_END" '
+    {
+      has_s = index($0, s) > 0
+      has_e = index($0, e) > 0
+      if (!skip && has_s) { if (!has_e) skip = 1; next }
+      if (skip) { if (has_e) skip = 0; next }
+      print
+    }
   ' "$1"
 }
 

--- a/.gaia/scripts/tests/verify-audit-roster.bats
+++ b/.gaia/scripts/tests/verify-audit-roster.bats
@@ -62,6 +62,13 @@ assert_contains() {
 # reject a block the release strips cleanly; the branches below cover the same
 # cases the shipped state machine does, including a start and end on one line
 # and an end with no open block (which the shipped parser keeps).
+#
+# The agreement is PINNED, not conventional: `.gaia/cli/src/release/marker-strip.test.ts`
+# runs this exact awk against the real parser over a fixture corpus, and then
+# asserts this file carries the invocation below verbatim. Edit either side and
+# that guard reds. Two sibling suites carry the same block for the same reason
+# (`audit-write-clearance.bats`, `.gaia/tests/hooks/audit-scope-lib.bats`), so a
+# change here belongs in all of them.
 strip_maintainer_only() {
   awk -v s="$MAINTAINER_START" -v e="$MAINTAINER_END" '
     {

--- a/.gaia/tests/hooks/audit-scope-lib.bats
+++ b/.gaia/tests/hooks/audit-scope-lib.bats
@@ -828,12 +828,12 @@ EOF
 # ---------------------------------------------------------------------------
 
 @test "scrub markers are balanced in audit-scope.sh" {
-  starts="$(grep -c "# gaia:maintainer-only:start" "$SCOPE_LIB")"
-  ends="$(grep -c "# gaia:maintainer-only:end" "$SCOPE_LIB")"
+  starts="$(grep -cF -- "$MAINTAINER_START" "$SCOPE_LIB")"
+  ends="$(grep -cF -- "$MAINTAINER_END" "$SCOPE_LIB")"
   [ "$starts" -eq "$ends" ]
   [ "$starts" -ge 1 ]
-  start_line="$(grep -n "# gaia:maintainer-only:start" "$SCOPE_LIB" | head -1 | cut -d: -f1)"
-  end_line="$(grep -n "# gaia:maintainer-only:end" "$SCOPE_LIB" | head -1 | cut -d: -f1)"
+  start_line="$(grep -nF -- "$MAINTAINER_START" "$SCOPE_LIB" | head -1 | cut -d: -f1)"
+  end_line="$(grep -nF -- "$MAINTAINER_END" "$SCOPE_LIB" | head -1 | cut -d: -f1)"
   [ "$start_line" -lt "$end_line" ]
 }
 

--- a/.gaia/tests/hooks/audit-scope-lib.bats
+++ b/.gaia/tests/hooks/audit-scope-lib.bats
@@ -20,6 +20,11 @@ setup() {
   RESOLVER="$REPO_ROOT/.gaia/scripts/resolve-audit-members.sh"
   SPAWN="$REPO_ROOT/.gaia/scripts/resolve-audit-spawn.sh"
   HOOK="$REPO_ROOT/.claude/hooks/pr-merge-audit-check.sh"
+  # The delimiters of the marker-strip transform in .gaia/release-scrub.yml that
+  # governs shell files, the surface the strip test below is pointed at.
+  # marker-strip.test.ts holds these to that transform.
+  MAINTAINER_START='# gaia:maintainer-only:start'
+  MAINTAINER_END='# gaia:maintainer-only:end'
 
   # One entry per arm of the allowlist, not just the first. The uniqueness
   # invariant below is what stops a second copy of this set appearing in another
@@ -832,12 +837,32 @@ EOF
   [ "$start_line" -lt "$end_line" ]
 }
 
+# The awk below models `stripMarkerBlocks` in
+# `.gaia/cli/src/release/marker-strip.ts`, the parser the release scrub actually
+# runs. The agreement is PINNED, not conventional:
+# `.gaia/cli/src/release/marker-strip.test.ts` runs this exact awk against the
+# real parser over a fixture corpus, and then asserts this file carries the
+# invocation verbatim. Two sibling suites carry the same block
+# (`.gaia/scripts/tests/verify-audit-roster.bats`, `audit-write-clearance.bats`),
+# so a change here belongs in all of them.
+#
+# The two-rule form this replaces diverged from the shipped parser on two shapes
+# audit-scope.sh does not currently carry, which is the only reason it was green:
+# its `/start/` rule fired `next`, so a start and end on ONE line never reached
+# the `/end/` rule and `skip` was never cleared, swallowing the rest of the file;
+# and it DROPPED an end with no open block, where the shipped parser keeps it
+# (`marker-strip.ts:55-57`). Adding either shape to audit-scope.sh would have
+# produced a stripped copy the release scrub does not produce, with nothing red.
 @test "a marker-stripped copy of audit-scope.sh yields exactly the frontend and workflows members" {
   SCRUBBED=$(mktemp -t audit-scope-scrubbed-XXXXXX)
-  awk '
-    /gaia:maintainer-only:start/ { skip = 1; next }
-    /gaia:maintainer-only:end/   { skip = 0; next }
-    !skip { print }
+  awk -v s="$MAINTAINER_START" -v e="$MAINTAINER_END" '
+    {
+      has_s = index($0, s) > 0
+      has_e = index($0, e) > 0
+      if (!skip && has_s) { if (!has_e) skip = 1; next }
+      if (skip) { if (has_e) skip = 0; next }
+      print
+    }
   ' "$SCOPE_LIB" > "$SCRUBBED"
 
   EMPTY_ROOT=$(mktemp -d -t audit-scope-noroster-XXXXXX)

--- a/.gaia/tests/lib/doc-finding-class-seeding.bats
+++ b/.gaia/tests/lib/doc-finding-class-seeding.bats
@@ -87,22 +87,35 @@ assert_assignment_line() {
 # leaves on an adopter clone. Group I reads a member through this rather than
 # reading the file directly, because a route stated only inside those markers
 # is present in the maintainer tree and absent everywhere it is needed.
+#
+# The agreement with the shipped parser (`stripMarkerBlocks` in
+# `.gaia/cli/src/release/marker-strip.ts`) is PINNED, not conventional:
+# `.gaia/cli/src/release/marker-strip.test.ts` runs this exact awk against the
+# real parser over a fixture corpus, and asserts every suite carrying it holds
+# it verbatim. Sibling suites carry the same block, so a change here belongs in
+# all of them. The delimiters differ from theirs and that is the point of
+# parameterizing them: the members this reads are markdown, governed by the
+# HTML-comment marker-strip transform rather than the shell one.
 strip_maintainer_only() {
-  # Rule order mirrors marker-strip.ts's own branch order, including the two
-  # cases a naive start/end pair gets wrong: a line carrying BOTH markers is a
-  # self-contained block and drops alone rather than opening one, and an
-  # end-without-start line is kept, not swallowed.
-  awk '
-    skip == 1 && /gaia:maintainer-only:end/ { skip = 0; next }
-    skip == 1 { next }
-    /gaia:maintainer-only:start/ && /gaia:maintainer-only:end/ { next }
-    /gaia:maintainer-only:start/ { skip = 1; next }
-    { print }
+  awk -v s="$MAINTAINER_START" -v e="$MAINTAINER_END" '
+    {
+      has_s = index($0, s) > 0
+      has_e = index($0, e) > 0
+      if (!skip && has_s) { if (!has_e) skip = 1; next }
+      if (skip) { if (has_e) skip = 0; next }
+      print
+    }
   ' "$1"
 }
 
 setup() {
   ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+
+  # The delimiters of the marker-strip transform in .gaia/release-scrub.yml
+  # that governs markdown, the surface strip_maintainer_only above is pointed
+  # at. marker-strip.test.ts holds these to that transform.
+  MAINTAINER_START='<!-- gaia:maintainer-only:start -->'
+  MAINTAINER_END='<!-- gaia:maintainer-only:end -->'
 
   FRONTEND="$ROOT/.claude/agents/code-audit-frontend.md"
   WORKFLOWS="$ROOT/.claude/agents/code-audit-github-workflows.md"

--- a/.gaia/tests/statusline/statusline-worktree.bats
+++ b/.gaia/tests/statusline/statusline-worktree.bats
@@ -28,6 +28,12 @@ setup() {
   STATUSLINE_SRC=$(cd "$BATS_TEST_DIRNAME/../../statusline" && pwd)
   SCRIPTS_SRC=$(cd "$BATS_TEST_DIRNAME/../../scripts" && pwd)
 
+  # The delimiters of the marker-strip transform in .gaia/release-scrub.yml
+  # that governs shell files, the surface stripped_copy below is pointed at.
+  # marker-strip.test.ts holds these to that transform.
+  MAINTAINER_START='# gaia:maintainer-only:start'
+  MAINTAINER_END='# gaia:maintainer-only:end'
+
   MAIN=$(mktemp -d -t gaia-sl-main-XXXXXX)
   git -C "$MAIN" init --quiet --initial-branch=main
   git -C "$MAIN" config user.email "test@example.com"
@@ -77,12 +83,33 @@ run_statusline() {
 }
 
 # Write a copy of MAIN's script with every maintainer-only block removed, the
-# same inclusive line range `gaia-maintainer release scrub` strips at bundle
-# time, and print its path. This is what an adopter actually runs.
+# same text `gaia-maintainer release scrub` produces at bundle time, and print
+# its path. This is what an adopter actually runs.
+#
+# The agreement with the shipped parser (`stripMarkerBlocks` in
+# `.gaia/cli/src/release/marker-strip.ts`) is PINNED, not conventional:
+# `.gaia/cli/src/release/marker-strip.test.ts` runs this exact awk against the
+# real parser over a fixture corpus, and asserts every suite carrying it holds
+# it verbatim. Sibling suites carry the same block, so a change here belongs in
+# all of them.
+#
+# The `sed` range this replaces was not that text. A range checks its end
+# address only from the line AFTER the start matches, so a line carrying both
+# markers opened a range and swallowed to the next end or to EOF, where the
+# shipped parser drops that one line alone. `gaia-statusline.sh` carries only a
+# plain pair today, so the two agreed; nothing went red if a one-line marker
+# was ever added.
 stripped_copy() {
   local dst="$MAIN/.gaia/statusline/gaia-statusline-stripped.sh"
-  sed '/# gaia:maintainer-only:start/,/# gaia:maintainer-only:end/d' \
-    "$MAIN/.gaia/statusline/gaia-statusline.sh" > "$dst"
+  awk -v s="$MAINTAINER_START" -v e="$MAINTAINER_END" '
+    {
+      has_s = index($0, s) > 0
+      has_e = index($0, e) > 0
+      if (!skip && has_s) { if (!has_e) skip = 1; next }
+      if (skip) { if (has_e) skip = 0; next }
+      print
+    }
+  ' "$MAIN/.gaia/statusline/gaia-statusline.sh" > "$dst"
   printf '%s' "$dst"
 }
 


### PR DESCRIPTION
Closes #1742

## What this fixes

The bats suites model `stripMarkerBlocks` (`.gaia/cli/src/release/marker-strip.ts`), the parser the release scrub actually runs, in hand-written awk. Nothing in the tree held any model to the parser, so a change to the TypeScript state machine left every model behind with nothing red, and the suites would go on certifying a stripped copy the release scrub does not produce.

**This is not a live failure, and the PR does not claim one.** `.claude/hooks/lib/audit-scope.sh` carries exactly one balanced indented pair, no single-line pair and no stray end marker, so nothing is currently mis-stripped. What is false is the narrower claim that the models agree with the shipped parser: `.gaia/tests/hooks/audit-scope-lib.bats` has not agreed for as long as it has existed. Its mechanism is wrong and is held harmless only by its input.

Measured, importing the real `stripMarkerBlocks` and shelling out to the verbatim awk of each model:

- **A start and end on one line swallows the remainder of the file.** Its `/start/` rule fires `next`, so the `/end/` rule never runs on that line and `skip` is never cleared.
- **An end with no open block is dropped**, where the shipped parser deliberately keeps it and records `end_without_start` (`marker-strip.ts:55-57`).

Adding either shape to `audit-scope.sh` would silently produce a stripped copy the release scrub does not produce.

## What changed

- **Repaired `audit-scope-lib.bats`.** The two-rule form is replaced with the substring state machine the shipped parser implements. This is a mechanism repair, not merely a pin.
- **Converged every model onto one awk text**, `.gaia/scripts/tests/verify-audit-roster.bats`'s, which measures faithful. `audit-write-clearance.bats` also loses a third marker vocabulary on the way: its unanchored `/gaia:maintainer-only:start/` matched the HTML-comment form too, which the transform governing shell files does not use.
- **Added `.gaia/cli/src/release/marker-strip.test.ts`**, a differential oracle following `exclude-parser-parity.test.ts`. It proves the awk agrees with `stripMarkerBlocks` byte-for-byte over a fixture corpus, asserts each suite carries that awk verbatim, and asserts each suite's marker constants equal the delimiters the shell-file marker-strip transform declares in `.gaia/release-scrub.yml`, read through the scrub's own `loadConfig`.

The dependency is inverted on purpose: TypeScript reaches for the shell text, so no bats suite gains a CLI dependency and the models stay dependency-free standalone bash.

## Guard verification

Each arm was driven into its failing state and restored:

| Mutation | Result |
|---|---|
| `stripMarkerBlocks` drops the `end_without_start` line instead of keeping it | 2 differential fixtures red |
| One suite's awk edited by one character | that suite's verbatim pin red |
| `.gaia/release-scrub.yml`'s shell-file `start:` delimiter changed | all three vocabulary pins red |

The repair itself is demonstrable: on a single-line pair the old `audit-scope-lib.bats` awk emits `a` where the shipped parser emits `a b c`.

## Checks

Quality Gate green: typecheck, `lint`, `lint:cli`, `test --run`, `pw`, dev smoke (HTTP 200), `build`. Also green: the full CLI vitest suite, `shell-lint.sh`, `whole-tree-invariants.sh`, and the three touched bats suites under bash 5.

No CLI bundle rebuild: a `.test.ts` is in neither binary's entry graph, and a rebuild produces no diff. No CHANGELOG entry: every file here is release-excluded, so nothing an adopter receives or runs changes.

## Considered and not taken

A shared `.sh` helper sourced by every model-carrying suite would make drift structurally impossible rather than test-detectable. It is a real alternative and it is deliberately not taken here: it needs a new shared shell library visible to `.gaia/scripts/tests/`, `.gaia/tests/hooks/`, `.gaia/tests/lib/` and `.gaia/tests/statusline/`, which brings its own distribution decision, shell-lint coverage, and a `whole-tree-invariants.sh` justification entry, and it reaches toward #1911's fix set. That is a larger change than the arm this issue settled on. Worth revisiting as its own item if the set grows again.


## Audit rounds

Three rounds, all clean passes, no Critical and no Important at any round.

| Round | Members | Result |
|---|---|---|
| 1 | node, shell | clean; 5 Suggestions, all applied |
| 2 | node, shell | clean; shell found nothing, node's 2 Suggestions applied |
| 3 | node (shell digest unrotated) | clean; 1 Suggestion, accepted as a residual below |

Round 1 sent the change well past its opening scope, and correctly. `MODEL_SUITES` began as a hand-kept list of three; a list is the guard's arming condition, so it became a discovery over the git index. Two further hand models turned out to live outside that list, one of them (`statusline-worktree.bats`'s `sed` range) carrying the same single-line-pair divergence this branch had already repaired elsewhere. And `normalizeTrailer`, introduced to absorb awk's record terminator, was in fact masking a state-machine difference; it is gone, the corpus asserts exact bytes, and the one genuine disagreement is pinned in a test of its own.

One repair of my own is worth recording because it is the class this whole change is about. Keying discovery on the whole awk block meant a suite whose body drifted silently left the set: the suite count fell from five to four and the run stayed green. Discovery keys on the invocation's head instead, so that suite stays in the set and reds.

## Accepted residual

Round 3's single Suggestion, filed as #1925 rather than folded.

`marker-strip.test.ts:304`, `expect(shellTransform?.end).toBe(END_MARKER)` compares a value against itself: `END_MARKER` comes from a start-keyed map, and the shell transform is the later of the two entries declaring that start, so last-wins construction makes it that transform's own `end`. It has no live failure mode, because respelling the shell transform's end reds the membership test beside it; the assertion would only become load-bearing if the two `#`-pair transforms swapped order in the YAML. Deferred because the session's three-round audit cap was spent and applying it would have rotated the marker, buying a handoff session to delete a redundant line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
