### PR TITLE
debt(tests): give the marker-strip shell-transform pin an end half that can fail

### DIFF
--- a/.gaia/cli/src/release/marker-strip.test.ts
+++ b/.gaia/cli/src/release/marker-strip.test.ts
@@ -107,11 +107,12 @@ const MARKER_STRIP_TRANSFORMS = loadConfig(
  * transform governs a suite is decided by the files that suite strips, which
  * no parse of the suite recovers.
  *
- * Membership alone is weaker than naming the governing transform, in exactly
- * one direction: two transforms declare the `#` pair, so a shell transform
- * that respelled while `.prettierignore` kept the old pair would leave the key
- * in this map and every shell-stripping suite passing. The last test in this
- * file closes that direction by pinning the shell transform's own pair.
+ * Membership is a weaker statement than naming the governing transform, and
+ * this map's shape is why: it is keyed by start marker, and two transforms
+ * declare the `#` start, so `get` returns whichever of them the YAML lists
+ * last. A value read out of here is therefore not safe to pin a transform
+ * against. The last test in this file names the shell transform directly and
+ * pins both halves of its pair against literals instead.
  */
 const DECLARED_DELIMITERS = new Map(
   MARKER_STRIP_TRANSFORMS.map((transform) => [transform.start, transform.end])
@@ -120,15 +121,17 @@ const DECLARED_DELIMITERS = new Map(
 /** The glob naming the transform that governs shell files. */
 const SH_TRANSFORM_GLOB = '**/*.sh';
 
-/** The pair governing shell files, the corpus below runs against it. */
+/**
+ * The pair governing shell files, the corpus below runs against it. Both halves
+ * are literals rather than lookups into `DECLARED_DELIMITERS`: that map is keyed
+ * by start marker and two transforms declare this start, so a value read out of
+ * it is whichever of them the YAML lists last, which would make an assertion
+ * pinning the shell transform against it compare a value with itself. Literals
+ * are what let the last test in this file assert both halves against the config
+ * and have either half fail.
+ */
 const START_MARKER = '# gaia:maintainer-only:start';
-const END_MARKER = DECLARED_DELIMITERS.get(START_MARKER);
-
-if (END_MARKER === undefined) {
-  throw new Error(
-    `no marker-strip transform in .gaia/release-scrub.yml declares ${START_MARKER}; that config moved, not the strip`
-  );
-}
+const END_MARKER = '# gaia:maintainer-only:end';
 
 /**
  * The suites carrying the model, discovered rather than listed: a hand-kept
@@ -292,14 +295,18 @@ describe('marker-strip lockstep (#1742)', () => {
     }
   );
 
-  // The membership check above cannot see a respelling of the shell transform
-  // alone, because `.prettierignore` declares the same pair and keeps the key
-  // alive. This pins the transform the corpus actually runs against.
+  // The membership check above asserts that each suite's pair is declared by
+  // some marker-strip transform; it does not say which one governs the corpus.
+  // This names that transform and pins both halves of its pair against the
+  // literals above, so respelling either half of it reds here. `toBeDefined`
+  // carries the case the pins cannot describe: no transform governs shell files
+  // at all, which is the config moving rather than the pair being respelled.
   test('the transform governing shell files declares the pair the corpus uses', () => {
     const shellTransform = MARKER_STRIP_TRANSFORMS.find((transform) =>
       transform.paths.includes(SH_TRANSFORM_GLOB)
     );
 
+    expect(shellTransform).toBeDefined();
     expect(shellTransform?.start).toBe(START_MARKER);
     expect(shellTransform?.end).toBe(END_MARKER);
   });

--- a/.gaia/cli/src/release/marker-strip.test.ts
+++ b/.gaia/cli/src/release/marker-strip.test.ts
@@ -28,11 +28,17 @@
  *    pass against a spelling the release retired. The pair is per suite
  *    because the surfaces differ: a suite stripping shell reads the
  *    `#`-comment transform, one stripping markdown the HTML-comment transform.
+ * 4. The marker-strip transform governing shell files declares the pair the
+ *    corpus's own literals spell, so the corpus is provably pointed at the
+ *    transform it claims to test. Assertion 3 cannot say this: it asks only
+ *    that SOME transform declare a suite's pair, and two of them declare the
+ *    `#` pair.
  *
  * The corpus runs against one delimiter pair rather than every declared pair,
  * and that is not a gap: both sides take their markers as parameters, so the
- * state machine cannot branch on the spelling. Assertion 1 proves the machine
- * and assertion 3 proves the spellings, each once.
+ * state machine cannot branch on the spelling. Assertion 1 proves the machine,
+ * assertion 3 proves each suite's spellings, and assertion 4 proves the pair
+ * the corpus itself runs against, each once.
  *
  * # What it does not catch
  *


### PR DESCRIPTION
Closes #1925

The shell-transform pin's end half compared a value against itself, so half of that assertion could not fail.

`END_MARKER` was `DECLARED_DELIMITERS.get(START_MARKER)`. That map is keyed by start marker; two marker-strip transforms in `.gaia/release-scrub.yml` declare the `#`-comment start (`.prettierignore` and the shell-and-YAML one), and the shell transform is the later of the two, so last-wins `Map` construction made `END_MARKER` the shell transform's own `end`. `expect(shellTransform?.end).toBe(END_MARKER)` was therefore `x === x` whenever the `start` pin above it passed.

## What changed

`.gaia/cli/src/release/marker-strip.test.ts`, and nothing else.

- `END_MARKER` is now a literal, symmetric with the `START_MARKER` literal beside it, so the pin asserts the config against a fixed spelling and either half can fail.
- The module-level `throw` that guarded the lookup is gone with the lookup. The test gains `expect(shellTransform).toBeDefined()`, which carries the case that throw covered (no transform governs shell files at all) and names it where a reader of the test sees it.
- Two comments the same defect falsified are narrowed to what survives: the `DECLARED_DELIMITERS` docblock claimed a shell-only respelling "would leave the key in this map and every shell-stripping suite passing" (last-wins moves the value, so those suites red), and the comment above the pin credited it with catching a respelling it could not see.

### Deviation from the issue's suggested fix, and why

The issue body suggested deriving `END_MARKER` from `shellTransform` and dropping the end pin entirely. That removes the tautology but adds no detection: the mutation would still be caught only by the membership test, exactly as it was before the fix, and there would be no end pin left to go red. The acceptance criterion on the issue asks for the end pin RED after the fix, which only the literal form satisfies. Pinning both halves against literals is strictly stronger and keeps the two halves symmetric.

## Non-vacuity control

`.claude/rules/guards-must-fail.md`'s shape applied to an assertion. Mutation is respelling **only** the shell transform's `end` in `.gaia/release-scrub.yml` (`.prettierignore` left alone):

| | start pin | end pin | membership |
|---|---|---|---|
| before, mutated | PASS | **PASS** | FAIL |
| after, mutated | PASS | **RED** | FAIL |

Third control, respelling only the shell transform's `start` after the fix: start pin RED, and it is the only failure (1 failed / 33 passed), membership correctly unaffected.

Unmutated: green throughout, 34 passed, both before and after.

## Verification

- `pnpm typecheck` (root + CLI), `pnpm lint`, `pnpm lint:cli`: clean
- `pnpm test --run`: root 159 passed / 1 skipped; CLI 2581 passed (158 files)
- `pnpm pw`: 8 passed / 1 skipped
- `pnpm build`: clean
- `bash .gaia/tests/whole-tree-invariants.sh`: all whole-tree invariants pass
- `bash .gaia/scripts/verify-cli-bundle-fresh.sh`: clean, and the rebuild it runs left the tree unchanged, confirming (rather than inheriting) that `marker-strip.test.ts` is in neither binary's entry graph and no bundle commit is owed

## CHANGELOG

No entry. `.gaia/cli/src` is release-excluded, so this is a maintainer-only test assertion with no adopter-visible surface and no behavior change to shipped code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Audit rounds

- **Round 1** (`code-audit-maintainer-node`, the only member this diff dispatches): clean, no Critical, no Important. It reproduced the non-vacuity control independently, running a mutation probe through the real `loadConfig` rather than reading the claim: old form green under the drift it was written to catch, new form red. One Suggestion (`holistic/incomplete-enumeration`), applied in `d60dc8d5` — the header's numbered list presented three assertions as the whole set and closed with "assertion 3 proves the spellings, each once", but the shell-transform pin is a fourth, independent assertion, and this branch is what turns it into a real second spelling proof. Comment-only, so the digest economics favour folding it in. A tree-wide sweep for other prose asserting the falsified claim found none.
- **Round 2**: clean, zero findings (`reason=member-clearance`, a delta review of the one comment edit).

## Out-of-scope machinery findings (recorded, not filed)

- `.github/audit/resolve-audit-base.sh:264` — the member-form stdout record prints `"$anchor_tree"` raw while the stderr diagnostic one line above prints `"${anchor_tree:--}"`, so on the `no-anchor` path stderr reports `anchor_tree=-` and stdout line 4 is an empty line. A caller reading line 4 and a human reading the log see different values for the same field. Surfaced cross-remit by `code-audit-maintainer-node`; owner is `code-audit-maintainer-shell`.
  - Dedup key: `v1 class=holistic/inconsistent-fallback path=.github/audit/resolve-audit-base.sh line=264`
  - Waived rather than filed: `audit_path_is_machinery` accepts the path, and the finding clears both disqualifiers — the asymmetry is latent at the fork point and reads identically whether or not this branch lands, and nothing in shipped content points at a separate change for it.
