### PR TITLE
debt(tests): route the last two registration assertions through the shared predicate

### DIFF
--- a/.gaia/tests/hooks/block-spec-plan-chain.bats
+++ b/.gaia/tests/hooks/block-spec-plan-chain.bats
@@ -336,17 +336,11 @@ assert_allowed() {
   local settings="${HOOKS_SRC%/hooks}/settings.json"
   # PreToolUse: the Skill arm (stamp + deny), the Bash arm (stamp), the Read arm
   # (deny). SessionStart: the /clear release.
-  local matchers
-  matchers=$(jq -r '
-    .hooks.PreToolUse[]
-    | select(.hooks[].command | test("block-spec-plan-chain"))
-    | .matcher' "$settings")
-  [[ "$matchers" == *"Skill"* ]]
-  [[ "$matchers" == *"Bash"* ]]
-  [[ "$matchers" == *"Read"* ]]
-
-  run jq -e '
-    .hooks.SessionStart[]
-    | select(.hooks[].command | test("block-spec-plan-chain"))' "$settings"
-  [ "$status" -eq 0 ]
+  hook_registered "$settings" \
+    '.hooks.PreToolUse[] | select(.matcher == "Skill")' block-spec-plan-chain.sh
+  hook_registered "$settings" \
+    '.hooks.PreToolUse[] | select(.matcher == "Bash")' block-spec-plan-chain.sh
+  hook_registered "$settings" \
+    '.hooks.PreToolUse[] | select(.matcher == "Read")' block-spec-plan-chain.sh
+  hook_registered "$settings" '.hooks.SessionStart[]' block-spec-plan-chain.sh
 }

--- a/.gaia/tests/hooks/capture-gh-artifact.bats
+++ b/.gaia/tests/hooks/capture-gh-artifact.bats
@@ -323,8 +323,8 @@ any_breadcrumb_exists() {
 # ---------- Registration ----------
 
 @test "registered in .claude/settings.json's PostToolUse Bash matcher" {
-  jq -r '.hooks.PostToolUse[] | select(.matcher == "Bash") | .hooks[].command' \
-    "$REPO_ROOT/.claude/settings.json" | grep -qF ".claude/hooks/capture-gh-artifact.sh"
+  hook_registered "$REPO_ROOT/.claude/settings.json" \
+    '.hooks.PostToolUse[] | select(.matcher == "Bash")' capture-gh-artifact.sh
 }
 
 @test "the hook file is executable" {


### PR DESCRIPTION
Closes #1923

## What

`.gaia/tests/hooks/block-spec-plan-chain.bats` and `.gaia/tests/hooks/capture-gh-artifact.bats` were the last two bats suites that read a registration out of `.claude/settings.json` without calling `hook_registered`. Both already sourced `helpers/run-hook.sh`, which re-exports the shared assertion, so each was hand-rolling a predicate with the shared one already in scope.

Each hand-rolled predicate was weaker than the shared one, in its own direction:

- `block-spec-plan-chain.bats` selected with an unanchored `test("block-spec-plan-chain")` over `.command`, so a command naming `block-spec-plan-chain-v2.sh` satisfied it.
- `capture-gh-artifact.bats` piped the matcher's commands through `grep -qF ".claude/hooks/capture-gh-artifact.sh"`, a substring match.

`hook_registered` matches the hook name with `GAIA_HOOK_NAME_RE` from `.gaia/scripts/hook-registration-lib.sh`, the one spelling of a hook name inside a registration command. A change to that pattern, or to the sanctioned registration command form, reds every `hook_registered` call site while these two stayed green asserting less. That is the drift #1911 records, in the two sites its own fix did not reach — correctly so on its own terms, since its verified scope was the `endswith` spelling and neither of these used that form.

`hook_registered` is **read, not edited**. Neither suite needed a new `source` line. No third file is touched.

## Verification

Both suites green under bash 5 (`.gaia/scripts/bats5.sh`), 51/51, zero failures.

Per `.claude/rules/guards-must-fail.md`, each converted assertion was driven into its failing state. The control is the defect #1923 names, since the converted assertion is *stronger* than what it replaces:

| Mutation to `.claude/settings.json` | Hand-rolled predicate | Converted assertion |
|---|---|---|
| `block-spec-plan-chain.sh` → `block-spec-plan-chain-v2.sh` | green (all four arms) | **red** |
| `capture-gh-artifact.sh` → `capture-gh-artifact.shim.sh` | green | **red** |
| Read-arm registration removed | n/a | **red** (per-matcher call covers it) |

Deterministic checks, per `.claude/rules/pr-merge.md`: `.gaia/tests/shell-lint.sh` passed, `.gaia/tests/whole-tree-invariants.sh` passed (all invariants).

Quality Gate: skipped on a positive answer — the staged set is two `.bats` files, no source or gate-affecting config, per `wiki/decisions/Quality Gate.md` ("When to skip the gate").

## Two notes on the issue text

**The `.bak` weakness is not closed by this conversion, and is filed separately as #1928.** #1923's failure-mode section cites a `.bak` or `.orig` suffix on the registered path as something the conversion would fix. It does not. `GAIA_HOOK_NAME_RE` is `\.claude/hooks/[A-Za-z0-9_./-]+\.sh`; against `.claude/hooks/capture-gh-artifact.sh.bak` the longest match ending in `.sh` is exactly `.claude/hooks/capture-gh-artifact.sh`, so the converted assertion stays green. Verified directly. The blind spot lives in the shared literal, not in these two suites, so repairing it here would mean editing a third file — which the dispatch note ruled out. Filed instead.

**A census figure in the issue has drifted.** The body says a tracked-file grep over `*.bats` for the three `.hooks.<event>` keys returns 17 suites, of which 15 call `hook_registered`. It now returns 16 and 14. The delta is on the calling side only; the outlier set is unchanged and is exactly the two suites named. The fix's premise re-derives.

## Scope

- Non-machinery: `audit_path_is_machinery` is false for a `.bats` suite.
- No CLI bundle rotation; nothing under `.gaia/cli/src/**` is touched.
- CHANGELOG: no entry owed. `surface:maintainer` internal test work with nothing an adopter reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
