### PR TITLE
debt(shell): terminate the shared hook-name match at the path token

### DIFF
--- a/.gaia/scripts/hook-registration-lib.sh
+++ b/.gaia/scripts/hook-registration-lib.sh
@@ -31,13 +31,39 @@ GAIA_HOOK_REGISTRATION_LIB=1
 # The one spelling of a hook name inside a registration command, named once.
 # `readonly` is safe under the source guard above: a second source returns before
 # reaching this line, so it can never re-assign a readonly name and error.
-readonly GAIA_HOOK_NAME_RE='\.claude/hooks/[A-Za-z0-9_./-]+\.sh'
+#
+# The trailing group is what makes the path token TERMINATE at `.sh`, and it is
+# load-bearing. The class has to be unanchored on the left, because a
+# registration command wraps the path in a `"$(git rev-parse --show-toplevel
+# …)"` prefix, and it has to end in `.sh`. Those two together let a longer path
+# whose prefix ends in `.sh` yield a match equal to the shorter name: against
+# `.claude/hooks/capture-gh-artifact.sh.bak`, the longest match ending in `.sh`
+# is the real hook's own name. A settings entry pointing at a `.bak`, `.orig` or
+# `.disabled` copy then reads as the hook being registered while no tool call
+# ever reaches the hook. Requiring the next character to be one that cannot
+# continue a path, or requiring there to be no next character, is what closes
+# that.
+#
+# Both consumers drop that trailing group from the value they compare:
+# `gaia_pretooluse_hooks` below strips it with `sed`, and
+# `.gaia/tests/helpers/hook-registration.sh` reads the first capture rather than
+# the whole match. A consumer comparing the raw match instead compares a name
+# with the quote or space that terminated it still attached, and matches
+# nothing.
+readonly GAIA_HOOK_NAME_RE='(\.claude/hooks/[A-Za-z0-9_./-]+\.sh)([^A-Za-z0-9_./-]|$)'
 
 # gaia_pretooluse_hooks <repo_root>
 #
 # Print every hook script registered under `.hooks.PreToolUse` as its path
 # relative to `.claude/hooks/`, one per line, sorted and deduplicated. Needs jq
 # on PATH; the caller checks that and reports its own diagnostic.
+#
+# `grep -oE` prints the whole match, capture groups included, so the second
+# `sed` expression drops the one character `GAIA_HOOK_NAME_RE`'s trailing group
+# may have consumed. The path token always ends in `.sh`, which is what lets
+# that strip be written without a second copy of the path character class: a
+# match is the path plus at most one character, and a match that ended at the
+# end of the command carries none.
 gaia_pretooluse_hooks() {
   local root="$1"
   jq -r '
@@ -48,7 +74,7 @@ gaia_pretooluse_hooks() {
   ' "$root/.claude/settings.json" 2>/dev/null |
     grep -F '.claude/hooks/' |
     grep -oE "$GAIA_HOOK_NAME_RE" |
-    sed -e 's#^\.claude/hooks/##' |
+    sed -e 's#^\.claude/hooks/##' -e 's#\(\.sh\).$#\1#' |
     sort -u
 }
 

--- a/.gaia/scripts/tests/hook-registration-lib.bats
+++ b/.gaia/scripts/tests/hook-registration-lib.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+# SC2016 is intentional file-wide: the fixture writer below is single-quoted
+# precisely so the command-substitution form in a registration reaches the file
+# as literal text, which is what makes it a fixture of the real spelling rather
+# than of what this shell would expand it to.
+# shellcheck disable=SC2016
+#
+# Conformance suite for `GAIA_HOOK_NAME_RE` in
+# .gaia/scripts/hook-registration-lib.sh -- the one spelling of a hook name
+# inside a registration command -- driven through both of its consumers:
+# `gaia_pretooluse_hooks` in the same file, which reads it with `grep -oE`, and
+# `hook_registered` in .gaia/tests/helpers/hook-registration.sh, which reads it
+# with jq's `match` builtin.
+#
+# WHY BOTH CONSUMERS ARE DRIVEN. They read one literal through two different
+# regex engines and each drops the trailing terminator its own way, so a change
+# that repairs one and not the other is green in whichever half the author
+# happened to run. The gates that source the library
+# (lint-hook-advisory-classification.sh, lint-hook-jq-availability.sh) reach the
+# literal only through `gaia_pretooluse_hooks`, so the live-tree test at the
+# bottom re-verifies them rather than driving each one separately here.
+#
+# Run under bash 5: `bash .gaia/scripts/bats5.sh .gaia/scripts/tests/hook-registration-lib.bats`.
+#
+# Assertion style: bash-3.2-safe per .claude/rules/bats-assertions.md.
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+  # shellcheck source=../hook-registration-lib.sh
+  . "$REPO_ROOT/.gaia/scripts/hook-registration-lib.sh"
+  # The helper sources the library too; the library's own source guard makes
+  # that second source a no-op, so `GAIA_HOOK_NAME_RE` is read once here.
+  # shellcheck source=../../tests/helpers/hook-registration.sh
+  . "$REPO_ROOT/.gaia/tests/helpers/hook-registration.sh"
+}
+
+# write_settings <dir> <command-path>
+#
+# Register one PreToolUse entry whose command points at <command-path> under
+# `.claude/hooks/`, in the rooted, quoted spelling .claude/settings.json
+# actually uses. <command-path> is the text after `.claude/hooks/`, so a caller
+# passes a bare hook name for the sanctioned form and a suffixed one for the
+# shapes this suite exists to reject. There is no teardown, deliberately: every
+# fixture lives under BATS_TEST_TMPDIR, which bats removes per test.
+write_settings() {
+  local dir="$1" command_path="$2"
+  mkdir -p "$dir/.claude"
+  {
+    printf '{\n  "hooks": {\n    "PreToolUse": [\n'
+    printf '      {\n        "matcher": "Bash",\n        "hooks": [\n'
+    printf '          {\n            "type": "command",\n'
+    printf '            "command": "\\"$(git rev-parse --show-toplevel)/.claude/hooks/%s\\""\n' "$command_path"
+    printf '          }\n        ]\n      }\n'
+    printf '    ]\n  }\n}\n'
+  } >"$dir/.claude/settings.json"
+}
+
+@test "gaia_pretooluse_hooks resolves a hook the sanctioned registration names" {
+  write_settings "$BATS_TEST_TMPDIR/sanctioned" 'capture-gh-artifact.sh'
+  run gaia_pretooluse_hooks "$BATS_TEST_TMPDIR/sanctioned"
+  [ "$status" -eq 0 ]
+  [ "$output" = 'capture-gh-artifact.sh' ]
+}
+
+@test "gaia_pretooluse_hooks resolves nothing from a registration pointing at a suffixed copy" {
+  write_settings "$BATS_TEST_TMPDIR/suffixed" 'capture-gh-artifact.sh.bak'
+  run gaia_pretooluse_hooks "$BATS_TEST_TMPDIR/suffixed"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "gaia_pretooluse_hooks resolves a sibling-named hook as itself" {
+  write_settings "$BATS_TEST_TMPDIR/sibling" 'capture-gh-artifact.shim.sh'
+  run gaia_pretooluse_hooks "$BATS_TEST_TMPDIR/sibling"
+  [ "$status" -eq 0 ]
+  [ "$output" = 'capture-gh-artifact.shim.sh' ]
+}
+
+@test "hook_registered accepts the sanctioned registration" {
+  write_settings "$BATS_TEST_TMPDIR/sanctioned" 'capture-gh-artifact.sh'
+  run hook_registered "$BATS_TEST_TMPDIR/sanctioned/.claude/settings.json" \
+    '.hooks.PreToolUse[] | select(.matcher == "Bash")' 'capture-gh-artifact.sh'
+  [ "$status" -eq 0 ]
+}
+
+@test "hook_registered rejects a registration pointing at a suffixed copy" {
+  write_settings "$BATS_TEST_TMPDIR/suffixed" 'capture-gh-artifact.sh.bak'
+  run hook_registered "$BATS_TEST_TMPDIR/suffixed/.claude/settings.json" \
+    '.hooks.PreToolUse[] | select(.matcher == "Bash")' 'capture-gh-artifact.sh'
+  [ "$status" -ne 0 ]
+}
+
+@test "hook_registered rejects a sibling-named registration" {
+  write_settings "$BATS_TEST_TMPDIR/sibling" 'capture-gh-artifact.shim.sh'
+  run hook_registered "$BATS_TEST_TMPDIR/sibling/.claude/settings.json" \
+    '.hooks.PreToolUse[] | select(.matcher == "Bash")' 'capture-gh-artifact.sh'
+  [ "$status" -ne 0 ]
+}
+
+# The coverage half. Narrowing the literal fails in the direction of resolving
+# FEWER hooks, and the two gates that source the library judge every hook they
+# reach through `gaia_pretooluse_hooks`, so a hook the literal stops resolving
+# is a hook they stop judging. The expected set is derived from
+# .claude/settings.json by a rule that does not share the literal -- the text
+# after the last `/.claude/hooks/` in each PreToolUse command, up to the quote
+# that closes it -- so the two agree only while the literal terminates at the
+# path token. An empty derivation is a failure here rather than a vacuous pass.
+@test "gaia_pretooluse_hooks resolves every hook this repo's own settings register" {
+  local settings="$REPO_ROOT/.claude/settings.json"
+  local expected
+  expected="$(jq -r '.hooks.PreToolUse // [] | .[] | .hooks[]? | .command // empty' "$settings" |
+    grep -F '.claude/hooks/' |
+    sed -e 's#^.*/\.claude/hooks/##' -e 's#".*$##' |
+    sort -u)"
+  [ -n "$expected" ]
+  run gaia_pretooluse_hooks "$REPO_ROOT"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}

--- a/.gaia/tests/helpers/hook-registration.sh
+++ b/.gaia/tests/helpers/hook-registration.sh
@@ -59,8 +59,8 @@
 #
 # The literal's first capture is the path token and its second is the character
 # that terminated it, so the assertion below compares `.captures[0]` rather than
-# the whole match. Comparing the whole match would compare a name with the
-# closing quote still attached and never match; the library's own header carries
+# the whole match. Comparing the whole match would compare a name with the quote
+# or space that terminated it still attached; the library's own header carries
 # why the terminator is in the literal at all.
 # shellcheck source=../../scripts/hook-registration-lib.sh
 . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../../scripts/hook-registration-lib.sh"

--- a/.gaia/tests/helpers/hook-registration.sh
+++ b/.gaia/tests/helpers/hook-registration.sh
@@ -56,6 +56,12 @@
 # original silently, because each holder keeps passing against the copy it
 # reads. Rooted at this file's own on-disk location, so it resolves however a
 # suite is invoked.
+#
+# The literal's first capture is the path token and its second is the character
+# that terminated it, so the assertion below compares `.captures[0]` rather than
+# the whole match. Comparing the whole match would compare a name with the
+# closing quote still attached and never match; the library's own header carries
+# why the terminator is in the literal at all.
 # shellcheck source=../../scripts/hook-registration-lib.sh
 . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../../scripts/hook-registration-lib.sh"
 
@@ -93,7 +99,7 @@ hook_registered() {
   local settings="$1" filter="$2" hook="$3"
   run jq -e --arg re "$GAIA_HOOK_NAME_RE" --arg hook "$hook" \
     "[ $filter | .hooks[] | .command // empty ] |
-       any([match(\$re; \"g\").string] | any(. == \".claude/hooks/\" + \$hook))" \
+       any([match(\$re; \"g\").captures[0].string] | any(. == \".claude/hooks/\" + \$hook))" \
     "$settings"
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## What

`GAIA_HOOK_NAME_RE` (`.gaia/scripts/hook-registration-lib.sh`) is the one spelling of a hook name inside a registration command. It has to be unanchored on the left, because a registration wraps the path in a `"$(git rev-parse --show-toplevel …)"` prefix, and the class it names has to end in `.sh`. Those two together let a **longer** path whose prefix ends in `.sh` yield a match equal to the shorter name: against `.claude/hooks/capture-gh-artifact.sh.bak`, the longest match ending in `.sh` is the real hook's own name.

So a settings entry pointing at a `.bak`, `.orig` or `.disabled` copy of a hook satisfied every `hook_registered` assertion in the tree while the real hook was never registered and no tool call ever reached it.

The literal now requires the path token to **terminate** at `.sh`: the next character has to be one that cannot continue a path, or there has to be no next character. Both consumers drop that trailing group from the value they compare, `gaia_pretooluse_hooks` with `sed` and `.gaia/tests/helpers/hook-registration.sh` by reading the first capture.

## The risk runs the safe way

The library's own header warns that **widening** the class silently weakens every registration assertion in the tree. This **narrows** it, so the failure direction is a gate that resolves *fewer* hooks, which is loud, rather than assertions that quietly assert less.

That makes the acceptance check a **coverage** check rather than a regression check. `.gaia/scripts/lint-hook-advisory-classification.sh` and `.gaia/scripts/lint-hook-jq-availability.sh` are re-verified, not edited, and they resolve the identical hook set before and after:

| | hooks resolved by `gaia_pretooluse_hooks` | advisory gate | jq-availability gate |
|---|---|---|---|
| before | 28 | clean | clean |
| after | 28 (`diff` empty) | clean | clean |

The live-tree test in the new suite pins that property permanently, deriving the expected set from `.claude/settings.json` by a rule that does not share the literal.

## Proving the guard can fail

`.claude/rules/guards-must-fail.md`. The new suite drives both consumers, because they read one literal through two different regex engines and a half-fix is green in whichever half the author happened to run.

Against the **pre-fix** literal, run under bash 5:

```
ok 1 gaia_pretooluse_hooks resolves a hook the sanctioned registration names
not ok 2 gaia_pretooluse_hooks resolves nothing from a registration pointing at a suffixed copy
ok 3 gaia_pretooluse_hooks resolves a sibling-named hook as itself
ok 4 hook_registered accepts the sanctioned registration
not ok 5 hook_registered rejects a registration pointing at a suffixed copy
ok 6 hook_registered rejects a sibling-named registration
ok 7 gaia_pretooluse_hooks resolves every hook this repo's own settings register
```

Both `.bak` tests red before and green after, one per consumer. The sibling-name fixtures (`capture-gh-artifact.shim.sh`) red on both literals, which is the control that shows the blind spot is the trailing-suffix shape specifically rather than a vacuous assertion, and that the narrowing has not made the matcher inert.

## Verification

- `.gaia/scripts/tests/hook-registration-lib.bats` (new): 7/7, bash 5.
- `.gaia/tests/hooks/` (every `hook_registered` call site): 2156 tests, exit 0.
- `.gaia/tests/sandbox/spec-028-composition.bats`: 2/2.
- `.gaia/scripts/tests/` gate suites for both sourcing gates, plus `check-hook-command-rooting.bats` and `check-hook-capabilities.bats`: clean.
- `bash .gaia/tests/shell-lint.sh`: passed, re-run after staging so its tracked-file discovery sees the new suite.
- `bash .gaia/tests/whole-tree-invariants.sh`: all pass.
- `bash .gaia/tests/bats-shards.sh files scripts-1` lists the new suite, so CI runs it.
- Quality Gate: skipped by its own rule, no staged `.ts|.tsx|.js|.jsx|.mjs|.cjs|.css` or gate-affecting config.

## Notes

This records that #1923's stated weakness is not closed by #1923's fix: the drift half it scoped is fixed, and the suffix half lived in the shared literal rather than in the two suites it converted. That is not a re-open of #1923.

CHANGELOG: no entry. All three paths are maintainer-only, `.gaia/scripts/hook-registration-lib.sh` carries a literal `.gaia/release-exclude` entry and `.gaia/scripts/tests` and `.gaia/tests` are excluded wholesale, so nothing here reaches an adopter bundle.

Closes #1928

🤖 Generated with [Claude Code](https://claude.com/claude-code)
