### PR TITLE
debt(shell): seat each sigpipe block comment above the test it introduces

### DIFF
--- a/.gaia/scripts/tests/lint-sigpipe-readers.bats
+++ b/.gaia/scripts/tests/lint-sigpipe-readers.bats
@@ -759,19 +759,15 @@ printf "%s" "$changed" | grep -q needle'
   [ "$status" -eq 0 ]
 }
 
-# A block ends at the dedent, so one block's arming must not reach the next
-# step. Without that boundary the armed block here would red the unarmed one
-# below it, which is the whole surface graded by whichever step armed first.
 # The mirror image of the substitution-scoped tests above, and the reason the
 # arming pattern is bound once rather than written twice. Here a genuine
-# block-level arming
-# follows a substitution-scoped one on the SAME line, and the earlier one ends
-# at a `;` where the pattern wants whitespace or end-of-line. A locator carrying
-# its own boundary-less copy of the pattern finds that earlier occurrence, asks
-# the depth test about a position inside the substitution, and reads the block
-# as unarmed: a false negative, which is the direction this gate must not be
-# wrong in. Confirmed to report clean against exactly that shape before the two
-# readers were given one pattern.
+# block-level arming follows a substitution-scoped one on the SAME line, and the
+# earlier one ends at a `;` where the pattern wants whitespace or end-of-line. A
+# locator carrying its own boundary-less copy of the pattern finds that earlier
+# occurrence, asks the depth test about a position inside the substitution, and
+# reads the block as unarmed: a false negative, which is the direction this gate
+# must not be wrong in. Confirmed to report clean against exactly that shape
+# before the two readers were given one pattern.
 @test "an arming preceded on its line by a boundary-less one still arms the block" {
   fixture_repo
   fixture_workflow 'x=$(set -o pipefail; true); set -o pipefail
@@ -781,6 +777,9 @@ printf "%s" "$a" | grep -q needle'
   grep -qF -- ".github/workflows/probe.yml:7:" <<<"$output"
 }
 
+# A block ends at the dedent, so one block's arming must not reach the next
+# step. Without that boundary the armed block here would red the unarmed one
+# below it, which is the whole surface graded by whichever step armed first.
 @test "a block's arming does not leak into the next step" {
   fixture_repo
   fixture_file .github/workflows/probe.yml 'jobs:


### PR DESCRIPTION
Closes #1939

## What

`.gaia/scripts/tests/lint-sigpipe-readers.bats` carried one comment block doing two jobs. Its opening half ("A block ends at the dedent, so one block's arming must not reach the next step") describes the leak test; its remaining half describes the boundary-less-arming test. A later insertion seated the boundary-less-arming test between the comment and the leak test it was written for, so the block introduced a fixture that is a single step with no dedent, no second step, and no unarmed block below it.

The result read as coverage that is not there: a reader checking whether the leak boundary is exercised found a comment claiming it above a test that does not test it, while the leak test itself carried no comment at all. Nothing detects this. Both tests pass, the suite is green, and the comment is syntactically fine; it is only wrong about which test it introduces.

## The change

- The dedent-boundary half moves down onto `a block's arming does not leak into the next step`, whose fixture is the armed-step / unarmed-step pair it describes.
- The mirror-image half stays above `an arming preceded on its line by a boundary-less one still arms the block`, which is the shape it actually explains.
- The stray two-word wrap the insertion left behind (`block-level arming` alone on its line) is rewrapped.

Comments only. No fixture, assertion, or test name changes.

## Verification

- `bash .gaia/scripts/bats5.sh .gaia/scripts/tests/lint-sigpipe-readers.bats` — 63/63 pass, zero failures, run under bash 5 per `.claude/rules/bats-assertions.md`.
- `bash .gaia/tests/whole-tree-invariants.sh` — all whole-tree invariants pass.
- `bash .gaia/tests/shell-lint.sh` — passed, `lint-stale-cardinals` and `lint-sigpipe-readers` among them clean.
- Quality Gate skips on a positive answer: the staged set is one `.bats` file, matching no source or gate-affecting-config pattern.

## CHANGELOG

No `## [Unreleased]` entry. `.gaia/scripts/tests` is a directory entry in `.gaia/release-exclude`, so this suite does not ship; the change is comment placement in maintainer-only test infrastructure with no adopter-visible effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)