### PR TITLE
debt(shell): replace the yaml_key block-scalar enumeration with its criterion

### DIFF
--- a/.gaia/scripts/lint-sigpipe-readers.sh
+++ b/.gaia/scripts/lint-sigpipe-readers.sh
@@ -410,16 +410,20 @@ readonly YAML_AWK='
 # scalar rather than a key at all. Sets keyname, keycol and islist; answers 0
 # when the line carries no key to read.
 #
-# The block-scalar half is load-bearing rather than tidiness, and it is worth
-# being exact about which case needs it. What it holds is `defaults:` detection
-# and pass-two `run:` detection, both of which read a key at ANY column and so
-# have no column test to fall back on: a `run:` body quoting either word would
-# otherwise be read as the key itself. It is NOT what saves the two lines
-# spelled `shell:` inside the `filters: |` body of
-# .github/workflows/shell-lint.yml, tempting as that reading is. Block-scalar
-# content is necessarily indented deeper than the key that opened it, and that
-# key is already deeper than the step column, so the step-column test decides
-# those two on its own and would still decide them with this half removed.
+# The block-scalar half is load-bearing rather than tidiness, and which cases
+# need it is a criterion rather than a list: any caller that acts on this
+# answer without the step-column test gating it reads a key at ANY column, so
+# it has nothing to fall back on, and a `run:` body quoting the word that
+# caller tests for would be taken for the key itself. Both passes below carry
+# such callers, the `islist` arm among them, since the arm that sets the step
+# column necessarily runs ahead of the test against it. Take them off the call
+# sites rather than off a list here, which goes stale the round another one is
+# added. It is NOT what saves the two lines spelled `shell:` inside the
+# `filters: |` body of .github/workflows/shell-lint.yml, tempting as that
+# reading is. Block-scalar content is necessarily indented deeper than the key
+# that opened it, and that key is already deeper than the step column, so the
+# step-column test decides those two on its own and would still decide them
+# with this half removed.
 function yaml_key(l,   col, rest) {
   if (l ~ /^[[:space:]]*$/) return 0
   col = match(l, /[^ ]/)

--- a/.gaia/scripts/lint-sigpipe-readers.sh
+++ b/.gaia/scripts/lint-sigpipe-readers.sh
@@ -413,17 +413,18 @@ readonly YAML_AWK='
 # The block-scalar half is load-bearing rather than tidiness, and which cases
 # need it is a criterion rather than a list: any caller that acts on this
 # answer without the step-column test gating it reads a key at ANY column, so
-# it has nothing to fall back on, and a `run:` body quoting the word that
-# caller tests for would be taken for the key itself. Both passes below carry
-# such callers, the `islist` arm among them, since the arm that sets the step
-# column necessarily runs ahead of the test against it. Take them off the call
-# sites rather than off a list here, which goes stale the round another one is
-# added. It is NOT what saves the two lines spelled `shell:` inside the
-# `filters: |` body of .github/workflows/shell-lint.yml, tempting as that
-# reading is. Block-scalar content is necessarily indented deeper than the key
-# that opened it, and that key is already deeper than the step column, so the
-# step-column test decides those two on its own and would still decide them
-# with this half removed.
+# it has nothing to fall back on, and a `run:` body carrying whatever shape
+# that caller keys on, a quoted keyword or a dash-led item alike, would be
+# taken for the key itself. Both passes below carry such callers, the `islist`
+# arm among them, since the arm that sets the step column necessarily runs
+# ahead of the test against it, and it keys on the dash rather than on any
+# word. Take them off the call sites rather than off a list here, which goes
+# stale the round another one is added. It is NOT what saves the two lines
+# spelled `shell:` inside the `filters: |` body of
+# .github/workflows/shell-lint.yml, tempting as that reading is. Block-scalar
+# content is necessarily indented deeper than the key that opened it, and that
+# key is already deeper than the step column, so the step-column test decides
+# those two on its own and would still decide them with this half removed.
 function yaml_key(l,   col, rest) {
   if (l ~ /^[[:space:]]*$/) return 0
   col = match(l, /[^ ]/)


### PR DESCRIPTION
## What

The docblock over `yaml_key` in `.gaia/scripts/lint-sigpipe-readers.sh` stated what the block-scalar half is load-bearing for as a two-item list presented as complete: `defaults:` detection and pass-two `run:` detection. A third read meets the same criterion and was not named.

Pass one's `islist` arm calls `flush_step()` and reassigns `stepkeycol` unconditionally, ahead of the `keycol != stepkeycol` test, so it too reads a key at any column with nothing to fall back on. Without the block-scalar half, a line spelled `- key:` inside a `run:` body would move the step key column and the step's own `shell:` key would never be read as a step key.

The guard as shipped is correct, so this is not a live defect. What was wrong is that a reader auditing whether the half still earns its place checks the two named cases and can reach the wrong conclusion, and the omitted case is the one whose removal is silent.

## Why this form

`.claude/rules/wiki-style.md` is explicit that a corrected enumeration restarts the same decay from a fresher number: when an enumeration is found stale, delete it and point rather than complete it. `.claude/rules/code-comments.md` says the same from the other side ("Name less, explain more"). So the list becomes a criterion, and the surprising member is named with the reason it qualifies rather than as a roster entry.

## Batch note

`/gaia-debt` offered this issue and #1941 together as a same-path cluster (both key on `.gaia/scripts/lint-sigpipe-readers.sh`). The batch was declined, per the placement note on both issues: #1941 carries a live, unsettled design decision (`severity:important`, and the issue states plainly that the naive fix is wrong), and a mechanical docblock fix must not be held behind it. This row runs first and alone; #1941 rebases onto it.

## Verification

- `bash .gaia/scripts/lint-sigpipe-readers.sh` -> clean, exit 0
- `.gaia/scripts/bats5.sh .gaia/scripts/tests/lint-sigpipe-readers.bats` -> 63/63 pass
- `bash .gaia/tests/shell-lint.sh` -> passed (all lenses clean)
- `bash .gaia/tests/whole-tree-invariants.sh` -> all whole-tree invariants pass

Comment-only, no behavior change. Quality Gate skipped: no staged file matches its source or gate-affecting-config set. No CHANGELOG entry: `.gaia/scripts/lint-sigpipe-readers.sh` carries a literal `.gaia/release-exclude` entry, so nothing here reaches an adopter clone.

## Audit rounds

Round one reported one in-scope Suggestion: the criterion clause was complete, but the consequence clause narrowed to "a `run:` body quoting the word that caller tests for", while the `islist` arm the next sentence names as covered keys on a dash-led shape and tests no word at all. Repaired in `a3b10ae8`, which states the consequence as the shape each caller keys on and says plainly that `islist` keys on the dash. Round two: clean, zero findings.

## Out-of-scope machinery findings (recorded, not filed)

- `.gaia/scripts/lint-sigpipe-readers.sh:212` — the guarded `source` of `guard-awk-lib.sh` carries no `# shellcheck disable=SC1091`, so shellcheck emits an info-level `SC1091` there while the sibling scripts under `.gaia/scripts/` that source the same library carry the directive. No live failure mode: the source is already guarded by `[ -f ... ] &&` with `set +e`/`set -e` around it. Latent at the fork point and outside this comment-only diff, so it reads the same whether or not this change lands. Dedup key: `v1 class=holistic/unclassified path=.gaia/scripts/lint-sigpipe-readers.sh line=212`

Closes #1940

🤖 Generated with [Claude Code](https://claude.com/claude-code)
