### PR TITLE
wiki: sync through 486c314

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "30772cd7cb4df4fa9b40646465db3c7f5286ddb3",
-  "last_evaluated_at": "2026-09-09T19:49:31Z",
+  "last_evaluated_sha": "486c3142d9b33c0ff0d99136cb1b5f88b786e821",
+  "last_evaluated_at": "2026-09-10T04:27:24Z",
   "last_consolidated_sha": "78c69d0f81d5bc6460453391c466570f30da43c4",
   "last_consolidated_at": "2026-09-08T06:34:36Z"
 }

--- a/wiki/concepts/Audit Disposition and Debt Fix.md
+++ b/wiki/concepts/Audit Disposition and Debt Fix.md
@@ -2,7 +2,7 @@
 type: concept
 status: active
 created: 2026-06-30
-updated: 2026-08-01
+updated: 2026-09-10
 tags: [concept, claude, review]
 ---
 
@@ -85,7 +85,7 @@ A deterministic check reads that metadata back before the issue is created, and 
 
 The `file-tech-debt` skill (`.claude/skills/file-tech-debt/SKILL.md`) is the source of truth for the filing mechanics: key construction, the `--body-file` invocation, idempotent labels, the metadata check, the body schema, and the sentinel touch.
 
-Beside the dedup-key line, every dispositioned finding carries a second HTML-comment line recording the branch it was surfaced from: the branch under review, a work mode and unit derived from that branch name, whether the cited path was in the pull request's changed-file set, and the reviewed HEAD. Both lines are HTML comments, so neither appears in the rendered issue. It is diagnostic, not identity: nothing matches on it, nothing gates on it, and a disposition is never blocked, failed, or retried because provenance could not be determined; a field the route cannot determine is recorded as an explicit `unknown` rather than omitted or defaulted to a real-looking value. The line carries no version prefix, because it is not an identity that must match across time and joins none of the dedup key's lockstep consumer set. One shared helper derives every field, so every route resolves the same inputs to the same values; where a route's tool policy forbids running it, its caller runs the helper and passes the resolved values in, rather than a second implementation deriving them. Provenance is never backfilled, so an honest absence is never mistaken for a failure to write: a fail-open `unknown` records what the disposing agent observed, while a backfilled value would record a guess, and the two would sit in the same field indistinguishably.
+Beside the dedup-key line, every dispositioned finding carries a second HTML-comment line recording where it was surfaced from: fields derived from the branch under review (mode, unit, whether the cited path was in the pull request's changed-file set, the reviewed HEAD), plus a `session` field read off the filing process rather than the branch. Branch-derived fields answer WHERE, not WHO, and two sessions sharing one checkout would otherwise inherit each other's stamp; `session` is immune to that because no branch move reaches it. Both lines are HTML comments, so neither appears in the rendered issue. It is diagnostic, not identity: nothing matches on it, nothing gates on it, and a disposition is never blocked, failed, or retried because provenance could not be determined; a field the route cannot determine is recorded as an explicit `unknown` rather than omitted or defaulted to a real-looking value. The line carries no version prefix, because it is not an identity that must match across time and joins none of the dedup key's lockstep consumer set. One shared helper derives every field, so every route resolves the same inputs to the same values; where a route's tool policy forbids running it, its caller runs the helper and passes the resolved values in, rather than a second implementation deriving them. Provenance is never backfilled, so an honest absence is never mistaken for a failure to write: a fail-open `unknown` records what the disposing agent observed, while a backfilled value would record a guess, and the two would sit in the same field indistinguishably.
 
 `.claude/skills/file-tech-debt/SKILL.md` is the source of truth for the field list, the value vocabulary, and the convention table.
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,19 @@ tags: [meta, log]
 
 ## [Unreleased]
 
+- 2026-09-10 486c3142 SKIP - StrictMode canary oracle swapped (wall-clock ratio → fiber mode-bit containment) inside .playwright/ test harness; wiki/concepts/React Perf Diagnostic.md names the canary generically and claims nothing about its internal oracle
+- 2026-09-10 4db9b8ec SKIP - internal single-file refinement to lint-sigpipe-readers.sh, no wiki page claim affected
+- 2026-09-10 7af6d8b1 SKIP - tests-only
+- 2026-09-10 e9c218c8 WORTHY - wiki edit landed in-commit (wiki/concepts/Worktrees.md revised: dispatched arm has a general whole-command test too, three tests not two)
+- 2026-09-10 bad731e3 SKIP - extends the sigpipe-reader lint to workflow YAML; wiki/concepts/Release Workflow.md already describes the folded guards by pointer, not enumeration, so no page needed updating
+- 2026-09-10 f5189ecd SKIP - internal guard-awk-lib below-root bats-discovery refusal; correctness fix in release-excluded .gaia/scripts/, same family as b4c2cbf5
+- 2026-09-10 94e36cad SKIP - internal GAIA_HOOK_NAME_RE path-token anchoring fix in release-excluded .gaia/scripts/, no wiki page documents the prior matching behavior
+- 2026-09-10 ae215ccb WORTHY - debt provenance marker gains a session= field (WHO) alongside its branch-derived fields (WHERE) → wiki/concepts/Audit Disposition and Debt Fix.md
+- 2026-09-10 fdfcaeb3 WORTHY - wiki edit landed in-commit (wiki/concepts/Worktrees.md revised on the dispatched-arm keying rule)
+- 2026-09-10 b4c2cbf5 SKIP - internal guard-awk-lib below-root scan-set refusal; correctness fix in release-excluded .gaia/scripts/, no wiki page claims the prior behavior
+- 2026-09-10 7bbce928 SKIP - tests-only
+- 2026-09-10 d89eac20 SKIP - tests-only
+- 2026-09-10 0655b58a SKIP - wiki: self-referential
 - 2026-09-09 30772cd7 SKIP - errexit-source guard scan-surface derivation, internal lint-guard implementation fix, no dedicated wiki page for this guard
 - 2026-09-09 c3600d9e SKIP - tests-only
 - 2026-09-09 84a00c1e SKIP - hook_registered lifted to shared .gaia/tests/helpers/, tests-only infra


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to 486c314.