### PR TITLE
docs(wiki): canary probe for Audit CI Tests per-leg narrowing

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "486c3142d9b33c0ff0d99136cb1b5f88b786e821",
-  "last_evaluated_at": "2026-09-10T04:27:24Z",
+  "last_evaluated_sha": "666c904bc649ebeb55ff413b4d09c02c51dd0934",
+  "last_evaluated_at": "2026-09-10T12:36:57Z",
   "last_consolidated_sha": "78c69d0f81d5bc6460453391c466570f30da43c4",
   "last_consolidated_at": "2026-09-08T06:34:36Z"
 }

--- a/wiki/concepts/GAIA Audit.md
+++ b/wiki/concepts/GAIA Audit.md
@@ -3,7 +3,7 @@ type: concept
 title: GAIA Audit
 status: active
 created: 2026-04-20
-updated: 2026-07-07
+updated: 2026-09-10
 tags: [concept, claude, skill, knowledge, hygiene]
 ---
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,7 @@ tags: [meta, log]
 
 ## [Unreleased]
 
+- 2026-09-10 666c904b SKIP - canary for the per-leg narrowing of Audit CI Tests; this probe pull request is closed unmerged
 - 2026-09-10 486c3142 SKIP - StrictMode canary oracle swapped (wall-clock ratio → fiber mode-bit containment) inside .playwright/ test harness; wiki/concepts/React Perf Diagnostic.md names the canary generically and claims nothing about its internal oracle
 - 2026-09-10 4db9b8ec SKIP - internal single-file refinement to lint-sigpipe-readers.sh, no wiki page claim affected
 - 2026-09-10 7af6d8b1 SKIP - tests-only


### PR DESCRIPTION
Post-merge canary for #1958. **Do not merge**; it is closed once read.

A wiki-sync-shaped change:
- a content-only `wiki/.state.json` rewrite, which lever one keeps from arming `code:`;
- a frontmatter bump on `wiki/concepts/GAIA Audit.md`, whose namers attribute to `lib` only;
- one `wiki/log.md` line.

Expected per step: `lib` runs its suites, while every other non-sandbox leg skips its shard run and installs. Sandbox, the hop-1 jobs and the aggregator are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
