### PR TITLE
debt(cli): exempt the unloaded eslint-plugin-import from resolution parity

### DIFF
--- a/.gaia/cli/src/lint-pin-parity.test.ts
+++ b/.gaia/cli/src/lint-pin-parity.test.ts
@@ -228,12 +228,15 @@ const PARITY_EXEMPT: Record<string, string> = {
   // and both readings are identical in the two workspaces. Nothing in the repo
   // recounts them, because doing so needs the root workspace installed, so
   // re-take them there on either trigger: an `import-x` resolver-settings move,
-  // or a rule reaching `eslint-module-utils` being enabled, whether an
-  // `import/*` rule that resolves specifiers or any of the canonical rules the
-  // `eslint-module-utils` entry names.
+  // or a rule reaching `eslint-module-utils` being enabled, which is any
+  // `import/*` rule or any of the canonical rules the `eslint-module-utils`
+  // entry names.
   //
-  // That second trigger reaches BOTH entries, which is why it is stated here
-  // rather than on the entry that makes it obvious. `eslint-module-utils/resolve`
+  // That second trigger reaches BOTH entries whenever the enabled rule resolves
+  // specifiers, which is why it is stated here rather than on the entry that
+  // makes it obvious. An `import/*` rule that resolves nothing still loads the
+  // helper through its other submodules, so it takes the helper entry alone and
+  // leaves the resolver entry standing. `eslint-module-utils/resolve`
   // falls back to the default `node` resolver when `import/resolver` is unset,
   // and it is unset in both workspaces, and that fallback loads
   // `eslint-import-resolver-node` by conventional name. So enabling a rule that
@@ -268,9 +271,9 @@ const PARITY_EXEMPT: Record<string, string> = {
   // convergence cost applies unchanged.
   //
   // It is also the premise the `eslint-module-utils` entry above rests on for
-  // one of that helper's consumers. Enabling any `import/*` rule invalidates
-  // this entry, and the comment heading the resolver and helper entries above
-  // says when that takes those two with it.
+  // one of that helper's consumers, so enabling any `import/*` rule invalidates
+  // this entry and that one together; the comment heading the resolver and
+  // helper entries says when the resolver entry falls with them.
   'eslint-plugin-import':
     'loaded by neither workspace (no import/* rule in either resolved config), so a version difference changes no rule; converging it is churn that re-diverges on the next re-resolve',
 };

--- a/.gaia/cli/src/lint-pin-parity.test.ts
+++ b/.gaia/cli/src/lint-pin-parity.test.ts
@@ -69,13 +69,13 @@
  * package no workspace loads.
  *
  * The rule in play there is `import-x/no-unresolved`. `eslint-plugin-import`
- * contributes no enabled rule to either workspace's resolved config, and the
- * resolver list is `import-x`'s own node resolver plus
- * `eslint-import-resolver-typescript`, which is why that resolver is the one
- * family member earning a version comparison while
- * `eslint-import-resolver-node` and `eslint-module-utils` are exempted below.
- * Both readings come from `eslint --print-config`, the instrument the criterion
- * paragraph below names.
+ * contributes no enabled rule to either workspace's resolved config, so it is
+ * exempted below as a plugin no workspace loads, and the resolver list is
+ * `import-x`'s own node resolver plus `eslint-import-resolver-typescript`, which
+ * is why that resolver is the one family member earning a version comparison
+ * while `eslint-import-resolver-node` and `eslint-module-utils` are exempted
+ * below. Both readings come from `eslint --print-config`, the instrument the
+ * criterion paragraph below names.
  *
  * The criterion behind both, worth stating once: parity is worth enforcing for a
  * package whose rules a workspace actually runs, and worth nothing for one whose
@@ -223,13 +223,14 @@ const PARITY_EXEMPT: Record<string, string> = {
   '@next/eslint-plugin-next':
     'loaded by neither workspace, so a version difference changes no rule; converging it is churn that re-diverges on the next re-resolve',
 
-  // Both entries below are read with the criterion paragraph's own instrument,
+  // The next two entries are read with the criterion paragraph's own instrument,
   // `eslint --print-config`, against `app/root.tsx` and `.gaia/cli/src/exit.ts`,
   // and both readings are identical in the two workspaces. Nothing in the repo
   // recounts them, because doing so needs the root workspace installed, so
   // re-take them there on either trigger: an `import-x` resolver-settings move,
-  // or any of the canonical rules the `eslint-module-utils` entry names being
-  // enabled.
+  // or a rule reaching `eslint-module-utils` being enabled, whether an
+  // `import/*` rule that resolves specifiers or any of the canonical rules the
+  // `eslint-module-utils` entry names.
   //
   // That second trigger reaches BOTH entries, which is why it is stated here
   // rather than on the entry that makes it obvious. `eslint-module-utils/resolve`
@@ -258,7 +259,20 @@ const PARITY_EXEMPT: Record<string, string> = {
   // above with it, which is why the reason below names the rules instead of the
   // plugin.
   'eslint-module-utils':
-    'reaches a rule only through eslint-plugin-import, which contributes no enabled rule to either resolved config, and through canonical require-extension, no-barrel-import and no-export-all, each off in both workspaces; so its version reaches no rule either workspace runs',
+    'reaches a rule through two consumers and neither runs one: eslint-plugin-import, exempt below for contributing no enabled rule to either resolved config, and canonical require-extension, no-barrel-import and no-export-all, each off in both workspaces; so its version reaches no rule either workspace runs',
+
+  // Loaded by neither workspace, the same shape and the same reading as the
+  // `@next/eslint-plugin-next` entry: no `import/*` rule appears in either
+  // resolved config and neither workspace registers the plugin at all. It
+  // arrives by the same `eslint-config-airbnb-extended` caret, so the same
+  // convergence cost applies unchanged.
+  //
+  // It is also the premise the `eslint-module-utils` entry above rests on for
+  // one of that helper's consumers. Enabling any `import/*` rule invalidates
+  // this entry, and the comment heading the resolver and helper entries above
+  // says when that takes those two with it.
+  'eslint-plugin-import':
+    'loaded by neither workspace (no import/* rule in either resolved config), so a version difference changes no rule; converging it is churn that re-diverges on the next re-resolve',
 };
 
 // Anti-vacuity floor for the shared population, not a pin on its size. The live

--- a/.gaia/cli/src/lint-pin-parity.test.ts
+++ b/.gaia/cli/src/lint-pin-parity.test.ts
@@ -240,8 +240,9 @@ const PARITY_EXEMPT: Record<string, string> = {
   // falls back to the default `node` resolver when `import/resolver` is unset,
   // and it is unset in both workspaces, and that fallback loads
   // `eslint-import-resolver-node` by conventional name. So enabling a rule that
-  // reaches `eslint-module-utils` starts routing resolution through the resolver
-  // entry's subject as well, and neither exemption survives it. Reading the
+  // resolves specifiers through `eslint-module-utils` starts routing resolution
+  // through the resolver entry's subject as well, and neither exemption survives
+  // it. Reading the
   // resolver entry's own `import-x` condition as its whole trigger is the trap:
   // that condition never fires in this scenario.
   //


### PR DESCRIPTION
## Summary

The resolution-parity guard in `.gaia/cli/src/lint-pin-parity.test.ts` applied its own stated criterion ("parity is worth nothing for a package whose rules neither workspace enables", answered per package by `eslint --print-config` and recorded as a `PARITY_EXEMPT` entry) to `eslint-module-utils` and `eslint-import-resolver-node`, but not to `eslint-plugin-import`, the plugin that helper belongs to. This applies it to the plugin too (arm 1 of the issue, as settled in the issue comment).

- Adds a `PARITY_EXEMPT` entry for `eslint-plugin-import`, with the same shape and reason as the existing `@next/eslint-plugin-next` entry: loaded by neither workspace, and it arrives by the same `eslint-config-airbnb-extended` caret (`^2.32.0`), so converging it would be churn that re-diverges on the next re-resolve.
- Rewords the `eslint-module-utils` reason so its plugin-side premise points at the new entry ("exempt below for contributing no enabled rule") instead of restating the fact as a peer.
- Widens the re-take trigger in the comment heading the resolver and helper entries: enabling any `import/*` rule, or one of the named canonical rules, reaches `eslint-module-utils` (24 of the plugin's 46 rule files load `eslint-module-utils/contextCompat`, including non-resolving ones like `import/first`). Only a rule that resolves specifiers also reaches the `eslint-import-resolver-node` default fallback and takes that entry with it. The docblock sentence now says the plugin is exempted.

The entry sits last in the map because `perfectionist/sort-objects` requires sorted keys.

## Measurement, re-taken for this change

`eslint --print-config` against `app/root.tsx` (root) and `.gaia/cli/src/exit.ts` (`.gaia/cli`), identical in both workspaces:

```
import-x/* rules present: 46  enabled: 23
import/*   rules present:  0  enabled:  0
plugins containing 'import': import-x, unused-imports, no-relative-import-paths (no `import` plugin)
```

Both lockfiles resolve `eslint-plugin-import@2.32.0`, so the stale-exemption hygiene test binds the new entry.

## Scope notes

- #1755 shares this file's dedup-key path, so the same-path rule offered it as a batch. It was declined: #1755 carries an unsettled design fork and lands on the file separately.
- No CLI bundle rebuild: `PARITY_EXEMPT` appears 0 times in both `.gaia/cli/gaia` and `.gaia/cli/gaia-maintainer`, because a `.test.ts` is in neither entry graph.
- CHANGELOG: no entry. This is a test-only change to a release-excluded maintainer guard, and it changes no shipped behavior.

## Audit rounds

- Round 1 (`code-audit-maintainer-node`): clean pass, one Suggestion applied in cf035f00. Non-resolving `import/*` rules still load `eslint-module-utils`, so the helper's exemption falls with the plugin's on any enabled `import/*` rule.
- Round 2: clean pass, one Suggestion applied in 191b5814. The paragraph's conclusion was narrowed to specifier-resolving rules to match its lead.
- Round 3: clean pass, one residual accepted (below).

### Accepted residuals

- `.gaia/cli/src/lint-pin-parity.test.ts:245`: the comment wrap is ragged, because line 245 carries only "it. Reading the" ahead of a full-width line. This is cosmetic only: the sentence reads correctly and nothing parses it. Reflowing it would rotate the member's digest and buy a fourth audit round for whitespace, so it can ride the next change that reopens this file (#1755 lands here next).

## Test plan

- [x] `vitest run src/lint-pin-parity.test.ts` (`.gaia/cli`): 23/23
- [x] `pnpm lint:cli`, `.gaia/cli` typecheck: clean
- [x] Quality Gate (root typecheck, lint, unit tests, Playwright, dev smoke HTTP 200, build): green
- [x] `bash .gaia/tests/whole-tree-invariants.sh`: all pass
- [x] Mutant: misspelling the new key (`eslint-plugin-importx`) reds the stale-exemption hygiene test, so the entry is bound to a package both lockfiles resolve

Closes #1950

🤖 Generated with [Claude Code](https://claude.com/claude-code)
