### PR TITLE
wiki: sync through 85eff7a

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "666c904bc649ebeb55ff413b4d09c02c51dd0934",
-  "last_evaluated_at": "2026-09-10T13:55:39Z",
+  "last_evaluated_sha": "85eff7a9b53107ca9dc9bb63eca6a90c04c72067",
+  "last_evaluated_at": "2026-09-11T00:04:17Z",
   "last_consolidated_sha": "78c69d0f81d5bc6460453391c466570f30da43c4",
   "last_consolidated_at": "2026-09-08T06:34:36Z"
 }

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,7 @@ tags: [meta, log]
 
 ## [Unreleased]
 
+- 2026-09-11 85eff7a9 SKIP - prior wiki-sync commit (#1965), already self-documenting via its own state/log edit
 - 2026-09-10 666c904b WORTHY - per-leg CI narrowing for wiki-only PRs → wiki/decisions/Sharded CI Test Matrix.md already updated in-commit
 - 2026-09-10 39a6a06e SKIP - shell lint-gate correctness fix, no wiki page describes this gate's match boundary
 - 2026-09-10 2f25d63f WORTHY - hypothetical-path marker replaces HYPOTHETICAL_EXAMPLE_PATHS list → wiki/decisions/{Code Audit Team,Quality Gate,Wiki Management}.md already updated in-commit


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to 85eff7a.