### PR TITLE
debt(scripts): stop a quoted $( from disarming the sigpipe gate's carry

### DIFF
--- a/.gaia/scripts/lint-sigpipe-readers.sh
+++ b/.gaia/scripts/lint-sigpipe-readers.sh
@@ -188,7 +188,11 @@
 # scoped. The minimum cannot rise above the raw count: the depth walk is
 # monotone in the depth it starts from, so from zero, by induction, every line
 # ends at or below where the raw count would end it, and the strip can remove a
-# false negative but never add one. The arming test itself reads the raw line.
+# false negative but never add one. The same misalignment can pull the carry
+# BELOW the true depth, when an apostrophe inside a double-quoted word pairs
+# across a real open `$(`: an arming scoped to that substitution then reads as
+# file-level and the file over-reports, the direction that costs a correct
+# edit. The arming test itself reads the raw line.
 #
 # The script arm applies the same depth test to a FILE, and TWO shapes reach a
 # false negative through it, the direction this gate must not be wrong in, so
@@ -225,8 +229,11 @@
 # code, whatever its delimiter's quoting), or escaped as `\$(` inside double
 # quotes (a backslash is not read); and an unbalanced quoted `$(` on the SAME
 # line as the arming, `grep -nF 'x=$(' f; set -euo pipefail`, because the
-# arming test reads the raw line. Each needs the quote state a shell tokenizer
-# carries across lines, rather than a per-line character count.
+# arming test reads the raw line. The multi-line program and the heredoc body
+# need state carried across lines; the others need a tokenizer's reading of one
+# line rather than a character count, and the same-line arming needs less than
+# that: the minimum the carry takes at end of line, taken at the arming
+# position instead.
 #
 # Neither shape changes what this tree reports, and the honest form of that is
 # a differential rather than an absence. Run the gate with the cross-line carry

--- a/.gaia/scripts/lint-sigpipe-readers.sh
+++ b/.gaia/scripts/lint-sigpipe-readers.sh
@@ -167,15 +167,32 @@
 # tree writes, and reading it as block-level arming would report every one of
 # those blocks. So the body-text test fires only at command-substitution depth
 # zero, tracked by counting `$(` against `)` across the block and clamped at
-# zero. The clamp is what makes a miscount safe rather than merely bounded: a
-# stray `)` (a `case` pattern, an arithmetic `))`) can only push the depth DOWN
-# toward zero, which reads a substitution-scoped `set` as block-level and
-# reports a block that was not armed. That direction costs a correct edit; the
-# other direction is the missed defect this gate exists to prevent.
+# zero. A miscount can go either way, and the two ways are not equally safe. A
+# stray `)` (a `case` pattern, an arithmetic `))`) pushes the depth DOWN, which
+# reads a substitution-scoped `set` as block-level and reports a block that was
+# not armed: that direction costs a correct edit, and the clamp keeps it from
+# going below zero. A `$(` that is data rather than code pushes the depth UP,
+# which reads a real arming as scoped and reports nothing: that is the missed
+# defect this gate exists to prevent, and the carry below is built against it.
 #
-# The script arm applies the same depth test to a FILE, and TWO shapes reach the
-# same accepted blind spot through it. Both are false negatives, the direction
-# this gate must not be wrong in, so neither is left implied by the other.
+# The depth a line hands the next one is the LOWER of two counts over that
+# line, both walked from the same carried-in depth: the raw line, and a copy
+# with each single-quoted span removed, from one quote to the next, where an
+# unterminated quote stays with everything after it. Single quotes are the
+# tractable case because shell allows no escape inside them, so a literal `$(`
+# in a single-quoted `grep -F` pattern drops out while a live `$(` inside double
+# quotes stays. The stripped count alone is not safe: a strip cannot tell a
+# quote that opens a span from an apostrophe inside a double-quoted string, so
+# `x=$(echo "it's"); y='z'` strips to an unbalanced `$(` on a line whose raw
+# count is balanced, and a stripped-only carry would read the next arming as
+# scoped. The minimum cannot rise above the raw count: the depth walk is
+# monotone in the depth it starts from, so from zero, by induction, every line
+# ends at or below where the raw count would end it, and the strip can remove a
+# false negative but never add one. The arming test itself reads the raw line.
+#
+# The script arm applies the same depth test to a FILE, and TWO shapes reach a
+# false negative through it, the direction this gate must not be wrong in, so
+# neither is left implied by the other.
 #
 # The first is a multi-line
 #
@@ -191,19 +208,19 @@
 # identical shape in a `run:` body already reads clean, so what changed is that
 # the two arms now agree about it.
 #
-# The second is an UNBALANCED literal `$(` sitting on an earlier non-comment
-# line, in a `grep -F` pattern or a `printf` template rather than in real code.
-# The carry is a plain character count, so it cannot tell a quoted one from a
-# live one, and the depth it hands the next line does not return to zero until
-# some later line spends a `)`: a genuine file-level `set -euo pipefail` in
-# between reads at depth above zero and does not arm, and every reader in that
-# file goes unreported. This one is NOT
-# inherited from the workflow arm by analogy, it is the same defect standing on
-# both arms, since that arm carries `subdepth` across a block the same way and
-# has since gaia-react/gaia#1936. Closing it needs the carry computed from a
-# copy of the line with single-quoted spans removed, in both arms, which is a
-# behaviour change on a live tree rather than a comment, so it is tracked
-# separately rather than folded in here.
+# The second is a literal `$(` that is DATA rather than code, sitting unbalanced
+# on an earlier non-comment line: a `grep -F` pattern, a `printf` template. It
+# holds the carry above zero until some later line spends a `)`, so a genuine
+# file-level `set -euo pipefail` in between reads as scoped and every reader in
+# the file goes unreported. It stands on both arms alike, since both carry
+# through the one function. The single-quoted form is closed by the minimum
+# above and pinned by a fixture on each arm. What the strip does not reach stays
+# open on both: a literal `$(` in a trailing `#` comment (only a full-line
+# comment is skipped), in a heredoc body (a body is scanned as code, whatever
+# its delimiter's quoting), or escaped as `\$(` inside double quotes (a
+# backslash is not read), and an unbalanced quoted `$(` on the SAME line as the
+# arming, `grep -nF 'x=$(' f; set -euo pipefail`, because the arming test reads
+# the raw line. Each needs a shell tokenizer rather than a character count.
 #
 # Neither shape changes what this tree reports, and the honest form of that is
 # a differential rather than an absence. Run the gate with the cross-line carry
@@ -211,19 +228,16 @@
 # so nothing in this tree has an arming status that turns on the carry. That is
 # the claim; it is cheap to re-check and it is the one that matters.
 #
-# What is NOT true, and was asserted here once: that no line ends at a positive
-# carry. Hundreds do, across dozens of tracked files, wherever a quoted `$(`
-# sits in a pattern or a message. They are harmless for two reasons this file
-# should name rather than imply. Every one of them is spent by a later `)`, so
-# no tracked file reaches end of file still carrying depth. And a file like
-# .claude/hooks/block-secrets-write.sh arms far above its literal block, so
-# `armed` is already 1 by the time the carry rises and nothing downstream can
-# lower it. Neither reason is a property of the carry being safe in general,
-# which is exactly why the differential above is what the claim rests on.
+# Lines that end at a positive carry are common, and they are not this defect:
+# nearly all are genuine multi-line substitutions, which the carry is right to
+# scope, and every one is spent by a later `)`, so no tracked file reaches end
+# of file still carrying depth. A repair that drove the carry to zero
+# everywhere would stop scoping those to correct a handful of literals, which
+# is why the strip only ever lowers the carry, and why a fixture pins the script
+# arm's cross-line carry directly.
 #
-# The balanced case, a whole `$( ... )` inside one quoted argument, is NOT
-# affected and is pinned by a fixture, because it is the half that has to keep
-# working for the carry to be worth having at all.
+# The balanced case, a whole `$( ... )` inside one quoted argument, returns to
+# zero on its own line under either count and is pinned by a fixture.
 #
 # `defaults.run.shell`, at job or workflow level, would move the resolved shell
 # for every step under it. This gate REFUSES rather than resolves it: a
@@ -422,9 +436,10 @@ function carries_pipe(l,   tail) {
 # The command-substitution nesting depth at character `upto` of `s`, starting
 # from the carried-in `subdepth` and clamped at zero. Clamped, not merely
 # bounded: the header states why that direction is the safe one. Both arms carry
-# `subdepth` from one line to the next, and each resets it where its own unit of
-# arming begins: the workflow arm at every run: key, the shell arm never, since
-# that arm is handed one file per awk invocation and the file IS the unit.
+# `subdepth` from one line to the next through carry_at below, and each resets
+# it where its own unit of arming begins: the workflow arm at every run: key,
+# the shell arm never, since that arm is handed one file per awk invocation and
+# the file IS the unit.
 function depth_at(s, upto,   i, d, c) {
   d = subdepth
   for (i = 1; i < upto; i++) {
@@ -433,6 +448,34 @@ function depth_at(s, upto,   i, d, c) {
     else if (c == ")" && d > 0) d--
   }
   return d
+}
+
+# The line with every single-quoted span removed, a quote through the next
+# quote. An unterminated quote stays, with everything after it, so that tail
+# counts as raw. Double-quoted text is left alone, since a `$( )` inside double
+# quotes is live.
+function strip_squoted(s,   out, q, rest, e) {
+  out = ""
+  while ((q = index(s, "\047")) > 0) {
+    rest = substr(s, q + 1)
+    e = index(rest, "\047")
+    if (e == 0) break
+    out = out substr(s, 1, q - 1)
+    s = substr(rest, e + 1)
+  }
+  return out s
+}
+
+# The depth this line hands the next one: the LOWER of the raw count and the
+# count over the stripped copy, both walked from the same carried-in depth. The
+# stripped count alone can rise above the raw one; the header states why only
+# the lower of the two keeps the carry from disarming anything the raw count
+# arms.
+function carry_at(l,   raw, t, cut) {
+  raw = depth_at(l, length(l) + 1)
+  t = strip_squoted(l)
+  cut = depth_at(t, length(t) + 1)
+  return (cut < raw) ? cut : raw
 }
 
 # Whether this line arms pipefail for the file or block AROUND it, which is the
@@ -488,7 +531,7 @@ readonly SHELL_AWK='
   # reason: a substitution opened on one line and closed on another scopes every
   # arming between them.
   if (!armed && arms_at_depth_zero(line)) armed = 1
-  subdepth = depth_at(line, length(line) + 1)
+  subdepth = carry_at(line)
 
   # A source edge. The load token is recognized anywhere a command may start,
   # not at line start only, because the bracketed load this tree uses for an
@@ -666,7 +709,7 @@ function body(l, n,   i, k) {
   # would drift the depth against real code.
   if (bare ~ /^#/) return
   if (!armed && arms_at_depth_zero(l)) armed = 1
-  subdepth = depth_at(l, length(l) + 1)
+  subdepth = carry_at(l)
   k = scan_pipeline(l)
   for (i = 1; i <= k; i++) { pend++; pline[pend] = n; ptext[pend] = hitbuf[i] }
   prev_pipe = carries_pipe(l)

--- a/.gaia/scripts/lint-sigpipe-readers.sh
+++ b/.gaia/scripts/lint-sigpipe-readers.sh
@@ -213,14 +213,20 @@
 # holds the carry above zero until some later line spends a `)`, so a genuine
 # file-level `set -euo pipefail` in between reads as scoped and every reader in
 # the file goes unreported. It stands on both arms alike, since both carry
-# through the one function. The single-quoted form is closed by the minimum
-# above and pinned by a fixture on each arm. What the strip does not reach stays
-# open on both: a literal `$(` in a trailing `#` comment (only a full-line
-# comment is skipped), in a heredoc body (a body is scanned as code, whatever
-# its delimiter's quoting), or escaped as `\$(` inside double quotes (a
-# backslash is not read), and an unbalanced quoted `$(` on the SAME line as the
-# arming, `grep -nF 'x=$(' f; set -euo pipefail`, because the arming test reads
-# the raw line. Each needs a shell tokenizer rather than a character count.
+# through the one function. The minimum closes the single-quoted form, and a
+# fixture on each arm pins it, only where the span opens and closes on one line
+# with no earlier stray quote on that line, because the strip reads one line at
+# a time and pairs quotes by position. Everything outside that stays open on
+# both arms, among it: a literal `$(` on a quote-free line inside a
+# single-quoted program spanning several lines (an awk or jq body); an
+# apostrophe inside double quotes ahead of the literal on the same line,
+# `echo "it's"; grep -nF 'x=$(' f`; a literal `$(` in a trailing `#` comment
+# (only a full-line comment is skipped), in a heredoc body (a body is scanned as
+# code, whatever its delimiter's quoting), or escaped as `\$(` inside double
+# quotes (a backslash is not read); and an unbalanced quoted `$(` on the SAME
+# line as the arming, `grep -nF 'x=$(' f; set -euo pipefail`, because the
+# arming test reads the raw line. Each needs the quote state a shell tokenizer
+# carries across lines, rather than a per-line character count.
 #
 # Neither shape changes what this tree reports, and the honest form of that is
 # a differential rather than an absence. Run the gate with the cross-line carry

--- a/.gaia/scripts/tests/lint-sigpipe-readers.bats
+++ b/.gaia/scripts/tests/lint-sigpipe-readers.bats
@@ -448,24 +448,68 @@ printf "%s" "$changed" | grep -q needle'
   [ "$status" -eq 0 ]
 }
 
-# The depth the script arm now carries from one line to the next is a plain
-# character count, so a `$( ... )` written as DATA rather than as code counts
-# too: a grep pattern, a printf template, a message. Balanced, it opens and
-# closes on the same line and the carry returns to zero, so a real arming below
-# it still arms and the reader below THAT is still reported. That is the half
-# that has to keep working for the carry to be worth having, and it is the half
-# a repair to the carry could break silently, since breaking it reports nothing
-# rather than reporting too much.
-#
-# The unbalanced case is the accepted blind spot the gate header states: the
-# carry never returns to zero, the arming below reads as scoped, and the file
-# goes unreported. It is deliberately NOT pinned by a fixture here. A test
-# asserting a false negative reds on the day somebody repairs it, which is
-# backwards for a suite whose job is to red when the gate goes quiet.
+# The script arm's cross-line carry, and the fixture that fails when it is
+# driven to zero. The mirror of the workflow arm's split-across-lines test: a
+# substitution opened on one line scopes the arming on the next, so the file
+# stays unarmed and the reader below the closing paren is not reported. Most
+# positive carries in the tree are exactly this shape, which is why the repair
+# for a quoted `$(` lowers the carry rather than dropping it.
+@test "a substitution-scoped set -o pipefail does not arm the file: split across lines" {
+  fixture_repo
+  fixture_script_unarmed 'changed=$(
+  set -o pipefail
+  git diff --name-only -z | tr "\0" "\n"
+)
+printf "%s" "$changed" | grep -q needle'
+  run_linter
+  [ "$status" -eq 0 ]
+}
+
+# The depth both arms carry is a character count, so a `$( ... )` written as
+# DATA rather than as code counts too: a grep pattern, a printf template, a
+# message. Balanced, it opens and closes on the same line and the carry returns
+# to zero, so a real arming below it still arms and the reader below THAT is
+# still reported. What this pins is the same-line `)` decrement; it stays green
+# with the cross-line carry removed, so the split-substitution fixture above is
+# what pins the carry.
 @test "a balanced dollar-paren inside a quoted argument leaves the file armed" {
   fixture_repo
   fixture_file check.sh '#!/usr/bin/env bash
 grep -nF "x=$(cmd)" file.txt
+set -euo pipefail
+printf "%s" "$a" | grep -q needle'
+  run_linter
+  [ "$status" -eq 1 ]
+  grep -qF -- "check.sh:4:" <<<"$output"
+}
+
+# Unbalanced, a quoted `$(` never spends its `)` on its own line. Counted raw it
+# leaves the carry above zero, the file-level arming below reads as scoped, and
+# every reader in the file goes unreported with nothing said. The carry takes
+# the lower of the raw count and a count with single-quoted spans removed, and
+# the removed span is where the literal sits.
+@test "an unbalanced dollar-paren inside a single-quoted argument leaves the file armed" {
+  fixture_repo
+  fixture_file check.sh '#!/usr/bin/env bash
+grep -nF '"'"'x=$('"'"' file.txt
+set -euo pipefail
+printf "%s" "$a" | grep -q needle'
+  run_linter
+  [ "$status" -eq 1 ]
+  grep -qF -- "check.sh:4:" <<<"$output"
+}
+
+# Why the carry is the LOWER of the two counts rather than the stripped count
+# alone. A strip cannot tell a quote opening a span from an apostrophe inside a
+# double-quoted string, so here it pairs the apostrophe with the first quote of
+# the later single-quoted word, deletes the `)` between them, and leaves an
+# unbalanced `$(` on a line whose raw count is balanced. A stripped-only carry
+# reads the arming below as scoped and reports nothing; this reds if the
+# minimum is ever simplified to the strip.
+@test "a single-quote strip that would raise the carry does not disarm the file" {
+  fixture_repo
+  fixture_file check.sh '#!/usr/bin/env bash
+x=$(echo "it'"'"'s"); y='"'"'z'"'"'
 set -euo pipefail
 printf "%s" "$a" | grep -q needle'
   run_linter
@@ -854,6 +898,30 @@ changed=$(
 printf "%s" "$changed" | grep -q needle'
   run_linter
   [ "$status" -eq 0 ]
+}
+
+# The workflow arm carries its depth across a block the same way the script arm
+# carries it across a file, through the same carry, so both quoted-literal
+# fixtures the script arm pins are pinned here too: a repair reaching one arm
+# and not the other reopens the asymmetry the shared carry exists to prevent.
+@test "an unbalanced dollar-paren inside a single-quoted argument leaves the block armed" {
+  fixture_repo
+  fixture_workflow 'grep -nF '"'"'x=$('"'"' file.txt
+set -euo pipefail
+printf "%s" "$a" | grep -q needle'
+  run_linter
+  [ "$status" -eq 1 ]
+  grep -qF -- ".github/workflows/probe.yml:8:" <<<"$output"
+}
+
+@test "a single-quote strip that would raise the carry does not disarm the block" {
+  fixture_repo
+  fixture_workflow 'x=$(echo "it'"'"'s"); y='"'"'z'"'"'
+set -euo pipefail
+printf "%s" "$a" | grep -q needle'
+  run_linter
+  [ "$status" -eq 1 ]
+  grep -qF -- ".github/workflows/probe.yml:8:" <<<"$output"
 }
 
 # The mirror image of the substitution-scoped tests above, and the reason the

--- a/.gaia/scripts/tests/lint-sigpipe-readers.bats
+++ b/.gaia/scripts/tests/lint-sigpipe-readers.bats
@@ -901,9 +901,11 @@ printf "%s" "$changed" | grep -q needle'
 }
 
 # The workflow arm carries its depth across a block the same way the script arm
-# carries it across a file, through the same carry, so both quoted-literal
-# fixtures the script arm pins are pinned here too: a repair reaching one arm
-# and not the other reopens the asymmetry the shared carry exists to prevent.
+# carries it across a file, through the same carry, so the script arm's
+# unbalanced-literal and strip-raise fixtures are mirrored here: a repair
+# reaching one arm and not the other reopens the asymmetry the shared carry
+# exists to prevent. The balanced fixture is not mirrored, because what it pins
+# is the same-line `)` decrement in depth_at, which both arms share.
 @test "an unbalanced dollar-paren inside a single-quoted argument leaves the block armed" {
   fixture_repo
   fixture_workflow 'grep -nF '"'"'x=$('"'"' file.txt


### PR DESCRIPTION
## Summary

The sigpipe gate (`.gaia/scripts/lint-sigpipe-readers.sh`) carries a command-substitution depth from one line to the next, and that carry counted a quoted `$(` as code. An unbalanced literal such as `grep -nF 'x=$(' file.txt` held the depth above zero, so a genuine file-level `set -euo pipefail` below it armed nothing and every short-circuiting reader in that file (or `run:` block) went unreported, silently. That is a false negative, the one direction the gate's header says it must not be wrong in.

Implements the fork settled in the issue's second comment: **in both arms, the end-of-line carry is `min(depth over the raw line, depth over the line with single-quoted spans removed)`**, both walked from the same carried-in depth. `arms_at_depth_zero` still reads the raw line.

- The minimum cannot rise above the raw count (the depth walk is monotone in its carry-in), so it cannot disarm anything the raw count arms. A plain strip can: `x=$(echo "it's"); y='z'` strips to an unbalanced `$(`.
- The header's claim that "a miscount can only push the depth DOWN" was false. It now states both directions and the minimum's safety argument, including the one case where the strip over-reports.
- It scopes what the strip closes to a single-quoted span that opens and closes on one line, and names the shapes it leaves open. Those include a literal inside a multi-line single-quoted program, an apostrophe inside double quotes ahead of the literal, a trailing `#` comment, a heredoc body, `\$(` inside double quotes, and a literal on the arming line itself.

## Tests

- Unbalanced single-quoted `$(` before the arming, in both arms: the reader **is** reported. Red before the fix, green after.
- The no-rise shape (`x=$(echo "it's"); y='z'`), in both arms: the reader is still reported. Red under a plain-strip mutant.
- Script arm cross-line carry (the mirror of the workflow arm's split-across-lines test): nothing pinned it before. Red when the script arm's carry is driven to zero.
- The balanced-literal test's comment now says what it actually pins (the same-line `)` decrement), which was verified with a mutant.

## Verification

- `bash .gaia/scripts/bats5.sh .gaia/scripts/tests/lint-sigpipe-readers.bats`: 74/74.
- Mutants, each against the suite: `min` changed to strip-only reds both no-rise tests. `min` changed to raw-only reds both unbalanced tests. Script carry at 0 reds the new split test. Workflow carry at 0 reds the existing split test. Dropping the `)` decrement reds the balanced test.
- Real-tree differential: the pre-fix gate, the fixed gate, and a copy with the carry disabled in both arms give byte-identical stdout, stderr, exit code, armed closure (201 files), hit and workflow record streams. No tracked file ends at a nonzero depth.
- `bash .gaia/tests/whole-tree-invariants.sh`: all pass.

## Audit dispositions

- **Round 1, `code-audit-maintainer-shell`, Important** (header overstated what the strip closes): fixed in 82e9863d. Both shapes were reproduced as still open before the header was narrowed.
- **Round 2 cleared.** Three comment-only Suggestions on prose this branch wrote were applied in 4d5f60b0:
  - the strip's over-report direction, verified with a probe
  - the split between cross-line and per-line open shapes
  - the workflow-arm fixture comment's counted set, replaced with named fixtures
- **Filed, not folded:** the same-line arming closure is a behaviour change and is tracked as #1979.
- **Accepted no-change, rounds 1 and 2:** shellcheck SC1091 at `lint-sigpipe-readers.sh`'s source line, and SC2030/SC2031 at `lint-sigpipe-readers.bats:1064`. Both are info-level, predate this PR, sit below `.gaia/tests/shell-lint.sh`'s floor, and carry no failure mode.

## Scope notes

- Ran alone rather than batched with #1672 (same class and dirname): #1672 carries an unsettled design fork.
- Release-excluded files only. No CLI bundle. No CHANGELOG entry, per the issue's settled scope.

Closes #1954

🤖 Generated with [Claude Code](https://claude.com/claude-code)
