### PR TITLE
debt(tests): gate git's background maintenance in plan-resume-point.bats fixtures

### DIFF
--- a/.gaia/tests/lib/plan-resume-point.bats
+++ b/.gaia/tests/lib/plan-resume-point.bats
@@ -23,6 +23,17 @@ setup() {
   git -C "$REPO" config user.email test@example.com
   git -C "$REPO" config user.name Test
   git -C "$REPO" config commit.gpgsign false
+  # Left ungated, every `git commit` spawns a detached `git maintenance run
+  # --auto`, a git process that can outlive the test; a late write of its into
+  # .git/objects fails teardown's `rm -rf` with "Directory not empty".
+  # maintenance.auto is the gate on modern git, gc.auto on git predating the
+  # maintenance task set; the autoDetach pair (both spellings, since modern git
+  # reads maintenance.autoDetach first) keeps any run that starts anyway in the
+  # foreground, finished before the commit returns.
+  git -C "$REPO" config gc.auto 0
+  git -C "$REPO" config maintenance.auto false
+  git -C "$REPO" config gc.autoDetach false
+  git -C "$REPO" config maintenance.autoDetach false
   PLAN="$REPO/plan"
   mkdir -p "$PLAN"
 }
@@ -452,4 +463,44 @@ EOF
   [ "${lines[1]}" = "COMPLETE 1 $sha1" ]
   [ "${lines[2]}" = "COMPLETE 2 $sha2" ]
   [ "${#lines[@]}" -eq 3 ]
+}
+
+# --- fixture: no background maintenance survives into teardown --------------
+# GIT_TRACE2_EVENT records a child's argv as a `child_start` event in the
+# spawning process's trace, so a --detach run is visible without waiting on it.
+# Both argv spellings count: modern git spawns `maintenance`, older git `gc`.
+# A bare "no spawn" also holds when the trace saw nothing, so the control arm
+# commits into a repo that writes git's own defaults for the gates (a personal
+# ~/.gitconfig carrying gc.auto=0 would otherwise gate it) and must see one.
+# Limit: on git 2.55 either gate alone suppresses the spawn, so the subject arm
+# reds only when setup() drops both; it pins the pair, not each key.
+
+_maintenance_spawns() {
+  grep -F '"child_start"' "$1" 2>/dev/null | grep -cE '"(maintenance|gc)"' || true
+}
+
+@test "fixture: a repo with the maintenance gates at git's defaults spawns maintenance on commit (control)" {
+  ctl="$(mktemp -d -t gaia-resume-ctl-XXXXXX)"
+  git -C "$ctl" init --quiet --initial-branch=main
+  git -C "$ctl" config user.email test@example.com
+  git -C "$ctl" config user.name Test
+  git -C "$ctl" config commit.gpgsign false
+  git -C "$ctl" config gc.auto 6700
+  git -C "$ctl" config maintenance.auto true
+  # Not gates: they keep the control's own run in the foreground, so it cannot
+  # outlive the commit into the rm -rf below.
+  git -C "$ctl" config gc.autoDetach false
+  git -C "$ctl" config maintenance.autoDetach false
+  GIT_TRACE2_EVENT="$ctl.trace" git -C "$ctl" commit --quiet --allow-empty -m control
+  n="$(_maintenance_spawns "$ctl.trace")"
+  rm -rf "$ctl" "$ctl.trace"
+  [ "$n" -gt 0 ]
+}
+
+@test "fixture: committing into the setup() repo spawns no background maintenance" {
+  trace="$(mktemp -t gaia-resume-trace-XXXXXX)"
+  GIT_TRACE2_EVENT="$trace" git -C "$REPO" commit --quiet --allow-empty -m subject
+  n="$(_maintenance_spawns "$trace")"
+  rm -f "$trace"
+  [ "$n" -eq 0 ]
 }

--- a/.gaia/tests/lib/plan-resume-point.bats
+++ b/.gaia/tests/lib/plan-resume-point.bats
@@ -24,8 +24,8 @@ setup() {
   git -C "$REPO" config user.name Test
   git -C "$REPO" config commit.gpgsign false
   # Left ungated, every `git commit` spawns a detached `git maintenance run
-  # --auto`, a git process that can outlive the test; a late write of its into
-  # .git/objects fails teardown's `rm -rf` with "Directory not empty".
+  # --auto`, a git process that can outlive the test; a late write from it
+  # into .git/objects fails teardown's `rm -rf` with "Directory not empty".
   # maintenance.auto is the gate on modern git, gc.auto on git predating the
   # maintenance task set; the autoDetach pair (both spellings, since modern git
   # reads maintenance.autoDetach first) keeps any run that starts anyway in the
@@ -365,7 +365,8 @@ EOF
   [ "${lines[1]}" = "COMPLETE 1 $sha1" ]
   [ "${lines[2]}" = "COMPLETE 2 $sha2" ]
   [ "${#lines[@]}" -eq 3 ]
-  ! grep -qF -- "COMPLETE 3 " <<<"$output"
+  grep -qF -- "COMPLETE 3 " <<<"$output" && return 1
+  true
 }
 
 # --- 015: delimiter-agnostic parse (dash form) ------------------------------
@@ -480,7 +481,8 @@ _maintenance_spawns() {
 }
 
 @test "fixture: a repo with the maintenance gates at git's defaults spawns maintenance on commit (control)" {
-  ctl="$(mktemp -d -t gaia-resume-ctl-XXXXXX)"
+  ctl="$BATS_TEST_TMPDIR/ctl"
+  mkdir "$ctl"
   git -C "$ctl" init --quiet --initial-branch=main
   git -C "$ctl" config user.email test@example.com
   git -C "$ctl" config user.name Test
@@ -488,19 +490,14 @@ _maintenance_spawns() {
   git -C "$ctl" config gc.auto 6700
   git -C "$ctl" config maintenance.auto true
   # Not gates: they keep the control's own run in the foreground, so it cannot
-  # outlive the commit into the rm -rf below.
+  # outlive the commit into bats' removal of $BATS_TEST_TMPDIR.
   git -C "$ctl" config gc.autoDetach false
   git -C "$ctl" config maintenance.autoDetach false
   GIT_TRACE2_EVENT="$ctl.trace" git -C "$ctl" commit --quiet --allow-empty -m control
-  n="$(_maintenance_spawns "$ctl.trace")"
-  rm -rf "$ctl" "$ctl.trace"
-  [ "$n" -gt 0 ]
+  [ "$(_maintenance_spawns "$ctl.trace")" -gt 0 ]
 }
 
 @test "fixture: committing into the setup() repo spawns no background maintenance" {
-  trace="$(mktemp -t gaia-resume-trace-XXXXXX)"
-  GIT_TRACE2_EVENT="$trace" git -C "$REPO" commit --quiet --allow-empty -m subject
-  n="$(_maintenance_spawns "$trace")"
-  rm -f "$trace"
-  [ "$n" -eq 0 ]
+  GIT_TRACE2_EVENT="$BATS_TEST_TMPDIR/subject.trace" git -C "$REPO" commit --quiet --allow-empty -m subject
+  [ "$(_maintenance_spawns "$BATS_TEST_TMPDIR/subject.trace")" -eq 0 ]
 }

--- a/.gaia/tests/lib/plan-resume-point.bats
+++ b/.gaia/tests/lib/plan-resume-point.bats
@@ -469,7 +469,10 @@ EOF
 # --- fixture: no background maintenance survives into teardown --------------
 # GIT_TRACE2_EVENT records a child's argv as a `child_start` event in the
 # spawning process's trace, so a --detach run is visible without waiting on it.
-# Both argv spellings count: modern git spawns `maintenance`, older git `gc`.
+# Both argv spellings count, so the control sees a spawn on any git: modern
+# git spawns `maintenance`, pre-2.29 git `gc`. The subject arm needs 2.29 or
+# later: earlier git spawns `gc --auto` on every commit and gc.auto=0 only
+# empties its work, so a correctly gated repo would still count one there.
 # A bare "no spawn" also holds when the trace saw nothing, so the control arm
 # commits into a repo that writes git's own defaults for the gates (a personal
 # ~/.gitconfig carrying gc.auto=0 would otherwise gate it) and must see one.


### PR DESCRIPTION
## Summary

- `plan-resume-point.bats` builds a real git fixture repo per test and deletes it in `teardown`. In an ungated repo every `git commit` spawns a detached `git maintenance run --auto --quiet --detach` (confirmed with `GIT_TRACE=1` on git 2.55, from a repository's very first commit), which can outlive the test and race the teardown delete. That is the `Directory not empty` false red on the `lib` leg.
- `setup()` now sets `gc.auto=0`, `maintenance.auto=false`, `gc.autoDetach=false`, and `maintenance.autoDetach=false` on the fixture, the same four keys the vitest side sets in `.gaia/cli/src/util/git-maintenance-env.ts`.
- Two trace-based arms pin it, mirroring `git-maintenance-env.test.ts`: a control repo with the gates written at git's defaults must show a maintenance `child_start` in its `GIT_TRACE2_EVENT` trace (proving the trace can see one), and a commit into the `setup()` repo must show none.

## Verification

- Suite green under bash 5 (22/22); `bash .gaia/tests/whole-tree-invariants.sh` green; CI `shard lib` green on ubuntu, so the trace arms hold on CI's git too.
- Mutants on scratch copies: an ungated `setup()` reds the subject arm; a gated control, a blind trace matcher, and a matcher missing the `maintenance` spelling each red the control arm. On git 2.55 either gate alone suppresses the spawn, so the subject arm pins the pair, which the suite states as its limit.
- A local repro loop (400 init/commit/delete cycles) did not reproduce the race either way on macOS, so the trace, not the loop, is the evidence.

## Scope

The fix set is this one suite, per the issue's dispatch note. The sibling check found 54 other tracked suites with the same ungated fixture-plus-teardown shape; filed as #1974 for a run-wide harness seam rather than widened here. No CHANGELOG entry: `.gaia/tests` is release-excluded and the change is test-only.

## Audit round 1 dispositions (code-audit-maintainer-shell, all Suggestions)

- `setup()` comment had a garbled clause: fixed.
- Control arm leaked its temp repo and trace file on a mid-test failure: fixed; both arms now write under `$BATS_TEST_TMPDIR`, which bats removes on every exit.
- Gating is suite-local while the fixture pattern is tree-wide: deliberately out of scope (see Scope); #1974 tracks the run-wide `GIT_CONFIG_*` seam the finding suggests.
- Pre-existing SC2314 on test 014's final `! grep`: folded while the digest was rotating anyway, rewritten to `grep ... && return 1` followed by `true`; a mutant swapping its needle for one the helper prints reds the test.

## Audit round 2 dispositions (code-audit-maintainer-shell, all Suggestions)

- The fixture header credited the pre-maintenance `gc` spelling to both arms, but on git before 2.29 a commit spawns `gc --auto` unconditionally, so the subject arm would red on a correctly gated repo there: fixed (comment-only). The header now scopes that spelling to the control and states the subject arm's 2.29 floor. No host here runs pre-2.29 git.
- Pre-existing SC2016 info hits in `.gaia/tests/lib/audit-ci-shards.bats`: no change. They are deliberate single-quoted literals, below the warning floor `shell-lint.sh` applies to bats suites, in a file this change does not modify (it arrived through the catch-up merge of main), and the finding itself marks the fix optional.

Closes #1964

🤖 Generated with [Claude Code](https://claude.com/claude-code)
