### PR TITLE
debt(scripts): take the sigpipe gate's quote-strip minimum at the arming position

### DIFF
--- a/.gaia/scripts/lint-sigpipe-readers.sh
+++ b/.gaia/scripts/lint-sigpipe-readers.sh
@@ -192,7 +192,9 @@
 # BELOW the true depth, when an apostrophe inside a double-quoted word pairs
 # across a real open `$(`: an arming scoped to that substitution then reads as
 # file-level and the file over-reports, the direction that costs a correct
-# edit. The arming test itself reads the raw line.
+# edit. The arming test takes the same minimum at the arming position, over the
+# line's prefix up to it, so the same holds there: it arms at least wherever the
+# raw count arms, and the misalignment can only over-arm.
 #
 # The script arm applies the same depth test to a FILE, and TWO shapes reach a
 # false negative through it, the direction this gate must not be wrong in, so
@@ -220,20 +222,18 @@
 # through the one function. The minimum closes the single-quoted form, and a
 # fixture on each arm pins it, only where the span opens and closes on one line
 # with no earlier stray quote on that line, because the strip reads one line at
-# a time and pairs quotes by position. Everything outside that stays open on
-# both arms, among it: a literal `$(` on a quote-free line inside a
-# single-quoted program spanning several lines (an awk or jq body); an
-# apostrophe inside double quotes ahead of the literal on the same line,
-# `echo "it's"; grep -nF 'x=$(' f`; a literal `$(` in a trailing `#` comment
-# (only a full-line comment is skipped), in a heredoc body (a body is scanned as
-# code, whatever its delimiter's quoting), or escaped as `\$(` inside double
-# quotes (a backslash is not read); and an unbalanced quoted `$(` on the SAME
-# line as the arming, `grep -nF 'x=$(' f; set -euo pipefail`, because the
-# arming test reads the raw line. The multi-line program and the heredoc body
-# need state carried across lines; the others need a tokenizer's reading of one
-# line rather than a character count, and the same-line arming needs less than
-# that: the minimum the carry takes at end of line, taken at the arming
-# position instead.
+# a time and pairs quotes by position. That scope holds whether the literal sits
+# on an earlier line or on the arming's own line, `grep -nF 'x=$(' f; set -euo
+# pipefail`, because the arming test takes the same minimum at the arming
+# position. Everything outside that stays open on both arms, among it: a literal
+# `$(` on a quote-free line inside a single-quoted program spanning several
+# lines (an awk or jq body); an apostrophe inside double quotes ahead of the
+# literal on the same line, `echo "it's"; grep -nF 'x=$(' f`; a literal `$(` in
+# a trailing `#` comment (only a full-line comment is skipped), in a heredoc body
+# (a body is scanned as code, whatever its delimiter's quoting), or escaped as
+# `\$(` inside double quotes (a backslash is not read). The multi-line program
+# and the heredoc body need state carried across lines; the others need a
+# tokenizer's reading of one line rather than a character count.
 #
 # Neither shape changes what this tree reports, and the honest form of that is
 # a differential rather than an absence. Run the gate with the cross-line carry
@@ -505,12 +505,22 @@ function carry_at(l,   raw, t, cut) {
 # trailing boundary narrow enough to reject the leftmost occurrence outright:
 # the same boundary gaia-react/gaia#1941 had to widen. Walking every occurrence
 # is what makes the boundary and the depth test independent of each other.
-function arms_at_depth_zero(l,   s, off, pos) {
+#
+# Each occurrence arms when EITHER the raw prefix or the single-quote-stripped
+# prefix sits at depth zero, the same minimum carry_at takes at end of line,
+# taken at the arming position, so the stripped read can only add arming. The
+# stripped prefix INCLUDES the character at pos: the match begins at its leading
+# boundary character, which in the substitution-scoped x=$(set -o pipefail; ...)
+# idiom is the paren of its dollar-paren, and depth_at reads that paren only as
+# the lookahead after the dollar. Cutting one character earlier drops it and
+# reads the scoped arming as file-level.
+function arms_at_depth_zero(l,   s, off, pos, t) {
   s = l
   off = 0
   while (match(s, PIPEFAIL_RE)) {
     pos = off + RSTART
-    if (depth_at(l, pos) == 0) return 1
+    t = strip_squoted(substr(l, 1, pos))
+    if (depth_at(l, pos) == 0 || depth_at(t, length(t) + 1) == 0) return 1
     off = pos
     s = substr(l, pos + 1)
   }

--- a/.gaia/scripts/tests/lint-sigpipe-readers.bats
+++ b/.gaia/scripts/tests/lint-sigpipe-readers.bats
@@ -517,6 +517,36 @@ printf "%s" "$a" | grep -q needle'
   grep -qF -- "check.sh:4:" <<<"$output"
 }
 
+# The unbalanced literal on the arming's OWN line rather than an earlier one.
+# The carry never reaches it, since the carry only feeds the next line, so the
+# arming test takes the same minimum at the arming position: a raw read puts
+# the set at depth 1, arms nothing, and every reader in the file goes
+# unreported.
+@test "an unbalanced dollar-paren on the arming line leaves the file armed" {
+  fixture_repo
+  fixture_file check.sh '#!/usr/bin/env bash
+grep -nF '"'"'x=$('"'"' file.txt; set -euo pipefail
+printf "%s" "$a" | grep -q needle'
+  run_linter
+  [ "$status" -eq 1 ]
+  grep -qF -- "check.sh:3:" <<<"$output"
+}
+
+# The no-rise property at the arming position. Here the strip pairs the
+# apostrophe with the quote opening the later word and leaves the prefix at
+# depth 1, while the raw prefix is balanced. The arming test is the raw test OR
+# the stripped one, never the stripped one alone, and this reds if it is ever
+# simplified to the strip.
+@test "a single-quote strip that would raise the depth at the arming does not disarm the file" {
+  fixture_repo
+  fixture_file check.sh '#!/usr/bin/env bash
+x=$(echo "it'"'"'s"); y='"'"'z'"'"'; set -euo pipefail
+printf "%s" "$a" | grep -q needle'
+  run_linter
+  [ "$status" -eq 1 ]
+  grep -qF -- "check.sh:3:" <<<"$output"
+}
+
 # --- the pipefail closure --------------------------------------------------
 #
 # pipefail is a process option, so a sourced library runs under whatever its
@@ -924,6 +954,24 @@ printf "%s" "$a" | grep -q needle'
   run_linter
   [ "$status" -eq 1 ]
   grep -qF -- ".github/workflows/probe.yml:8:" <<<"$output"
+}
+
+@test "an unbalanced dollar-paren on the arming line leaves the block armed" {
+  fixture_repo
+  fixture_workflow 'grep -nF '"'"'x=$('"'"' file.txt; set -euo pipefail
+printf "%s" "$a" | grep -q needle'
+  run_linter
+  [ "$status" -eq 1 ]
+  grep -qF -- ".github/workflows/probe.yml:7:" <<<"$output"
+}
+
+@test "a single-quote strip that would raise the depth at the arming does not disarm the block" {
+  fixture_repo
+  fixture_workflow 'x=$(echo "it'"'"'s"); y='"'"'z'"'"'; set -euo pipefail
+printf "%s" "$a" | grep -q needle'
+  run_linter
+  [ "$status" -eq 1 ]
+  grep -qF -- ".github/workflows/probe.yml:7:" <<<"$output"
 }
 
 # The mirror image of the substitution-scoped tests above, and the reason the


### PR DESCRIPTION
## Summary

The sigpipe gate's cross-line carry takes the lower of the raw depth and the depth with single-quoted spans removed, so an unbalanced single-quoted `$(` literal on an **earlier** line no longer disarms the unit. The arming test itself still read the **raw** line, so the same literal on the arming's **own** line held the arming at depth 1: the file (or `run:` block) was graded unarmed and every short-circuiting reader in it went unreported, a false negative.

- `arms_at_depth_zero` now also arms when the single-quote-stripped prefix, up to and **including** the match position, sits at depth zero: the carry's minimum, taken at the arming position. The `||` keeps the raw test, so the stripped read can only add arming, never remove any the raw test grants.
- The prefix includes the character at `pos` because the match begins at its leading boundary character, which is the `(` of `$(` in the substitution-scoped `x=$(set -o pipefail; ...)` idiom. Cutting one character earlier reads that idiom as file-level.
- The header's open-shape list drops the same-line shape and states that the closed scope holds on the arming's own line too.

## Tests

Four new fixtures in `.gaia/scripts/tests/lint-sigpipe-readers.bats`, one pair per arm:

- **same-line unbalanced literal**: reds before the fix, green after.
- **same-line no-rise**: an apostrophe inside double quotes pairs with a later quote so the stripped prefix sits at depth 1 while the raw prefix is balanced. Pins the `||` against a stripped-only simplification.

Mutation checks, each run against the full suite:

- stripped-only arming test → reds exactly the two no-rise fixtures.
- prefix cut at `pos - 1` → reds the substitution-scoped tree and spaced tests on both arms, plus the real-tree test.

Full suite 78/78 under bash 5; `whole-tree-invariants.sh` passes. The real scanned tree's report is unchanged. Release-excluded maintainer tooling, so no CHANGELOG entry.

## Audit notes (no action)

`code-audit-maintainer-shell` cleared this change on its first round. It left two informational notes, both on pre-existing lines outside this diff, and each names no live failure mode:

- `.gaia/scripts/lint-sigpipe-readers.sh:299`: shellcheck without `-x` does not follow the bracketed `guard-awk-lib.sh` load. SC1091 is already in `shell-lint.sh`'s tooling exclude, and the existing `source=` directive covers it.
- `.gaia/scripts/tests/lint-sigpipe-readers.bats:1114`: shellcheck's per-`@test` subshell model flags the `TMP` assignment. The reads are in the same test body, so the value is live where it is read; the note falls below the bats warning floor.

Closes #1979

🤖 Generated with [Claude Code](https://claude.com/claude-code)
