### PR TITLE
debt(tests): refuse a code: entry off the list's own indent in leg-arming's class reader

### DIFF
--- a/.gaia/tests/leg-arming.sh
+++ b/.gaia/tests/leg-arming.sh
@@ -205,8 +205,8 @@ resolve_seam() {
 # block string, and a non-comment line at or below the `code:` key's indent
 # ends the list unless it is itself a `- ` entry, which is YAML's compact
 # sequence form. Only a `- ` at the first entry's indent opens an entry: one
-# indented deeper is a continuation YAML folds into the entry above's plain
-# scalar, however much it looks like an entry of its own. An entry is a quoted
+# indented deeper is either a continuation YAML folds into a plain entry above
+# or a malformed list, never an entry of its own. An entry is a quoted
 # or plain string, or a change-type mapping (`deleted: 'x'`) whose one inline
 # value is the path. A multi-line entry, a `- ` line off the list's own indent,
 # a flow collection, or an escape this reader does not decode is a failure

--- a/.gaia/tests/leg-arming.sh
+++ b/.gaia/tests/leg-arming.sh
@@ -204,10 +204,13 @@ resolve_seam() {
 # whatever its indent, a line indented at or below the `filters:` key ends the
 # block string, and a non-comment line at or below the `code:` key's indent
 # ends the list unless it is itself a `- ` entry, which is YAML's compact
-# sequence form. An entry is a quoted or plain string, or a change-type
-# mapping (`deleted: 'x'`) whose one inline value is the path. A multi-line
-# entry, a flow collection, or an escape this reader does not decode is a
-# failure rather than a guess.
+# sequence form. Only a `- ` at the first entry's indent opens an entry: one
+# indented deeper is a continuation YAML folds into the entry above's plain
+# scalar, however much it looks like an entry of its own. An entry is a quoted
+# or plain string, or a change-type mapping (`deleted: 'x'`) whose one inline
+# value is the path. A multi-line entry, a `- ` line off the list's own indent,
+# a flow collection, or an escape this reader does not decode is a failure
+# rather than a guess.
 derive_class() {
   local wf="$1" out rc=0
   if [ ! -f "$wf" ] || [ ! -r "$wf" ]; then
@@ -275,6 +278,7 @@ derive_class() {
       steps = 0
       failed = 0
       top = -1
+      sind = -1
     }
     { sub(/\r$/, "") }
     /^[ \t]*(-[ \t]+)?uses:[ \t]*.?dorny\/paths-filter@/ { steps++ }
@@ -318,6 +322,8 @@ derive_class() {
         next
       }
       if ($0 !~ /^ *-([ \t]|$)/) bail("a line inside the code: list that is neither an entry nor a comment")
+      if (sind < 0) sind = ind($0)
+      else if (ind($0) != sind) bail("a - line off the entry indent of the code: list, which YAML reads as a multi-line entry or a malformed list, never as a new entry")
       s = $0
       sub(/^ *-[ \t]*/, "", s)
       if (s == "") bail("a code: entry with no inline value")

--- a/.gaia/tests/lib/audit-ci-shards.bats
+++ b/.gaia/tests/lib/audit-ci-shards.bats
@@ -4156,7 +4156,9 @@ $indent  - $tail" "$doctored"
   local pages page line mutated doctored="$BATS_TEST_TMPDIR/class-shallow.yml"
   local err="$BATS_TEST_TMPDIR/class-shallow.err" rc=0
   pages="$(arming_parser_class "$WORKFLOW")" || return 1
-  page="$(printf '%s\n' "$pages" | sed -n 1p)"
+  # code_entry_line finds only a bare quoted entry, never a change-type
+  # mapping; the space-carrying pages the cases above pick are written bare.
+  page="$(printf '%s\n' "$pages" | grep -F ' ' | sed -n 1p)"
   line="$(code_entry_line "$WORKFLOW" "$page")" || return 1
   mutated="${line# }"
   assert_doctored "$line" "$mutated" "shifting the entry for $page one column shallower" || return 1

--- a/.gaia/tests/lib/audit-ci-shards.bats
+++ b/.gaia/tests/lib/audit-ci-shards.bats
@@ -4065,14 +4065,20 @@ EOF
   done <<<"$group"
 }
 
-# The shape adversarial cases use for the class comparison are the ones the two
-# readers really do read differently, confirmed inside each case before the
+# The workflow shapes adversarial cases use for the class comparison are ones
+# PyYAML reads and the awk reader refuses, confirmed inside each case before the
 # comparison is asked about: a double-quoted scalar carrying an escape the awk
-# reader does not decode, which PyYAML decodes and the awk reader refuses; and a
-# plain scalar folded onto a continuation line that opens with `- `, which
-# PyYAML folds into one path and the awk reader reads as two entries. A plain
-# double-quoted scalar with no escape reads identically in both, so it could
-# not red.
+# reader does not decode; and a plain scalar folded onto a continuation line
+# that opens with `- `, which PyYAML folds into one path and a reader taking
+# every `- ` line as an entry would split into two. A plain double-quoted
+# scalar with no escape reads identically in both, so it could not red. An
+# entry shifted shallower than the list's entry indent is refused too, and
+# PyYAML rejects that workflow outright rather than reading it.
+#
+# The comparison's own disagreement branch is driven by a doctored script
+# rather than a doctored workflow: a shape both readers accept and read
+# differently is exactly what the awk reader exists to refuse, so a healthy
+# reader offers none.
 @test "W16 adversarial: an escaped double-quoted code: entry reds the class comparison" {
   require_yaml_parser
   local pages page line mutated doctored="$BATS_TEST_TMPDIR/class-escape.yml"
@@ -4100,9 +4106,10 @@ EOF
   grep -qF -- 'could not derive the class' <<<"$output"
 }
 
-@test "W16 adversarial: a folded plain code: entry that both readers accept but read differently reds the class comparison" {
+@test "W16 adversarial: a folded plain code: entry is refused by the awk reader rather than split into two entries" {
   require_yaml_parser
-  local pages page head tail indent line doctored="$BATS_TEST_TMPDIR/class-fold.yml" awk_class
+  local pages page head tail indent line doctored="$BATS_TEST_TMPDIR/class-fold.yml"
+  local err="$BATS_TEST_TMPDIR/class-fold.err" rc=0
   pages="$(arming_parser_class "$WORKFLOW")" || return 1
   page="$(printf '%s\n' "$pages" | grep -F ' ' | sed -n 1p)"
   [ -n "$page" ] || {
@@ -4120,24 +4127,71 @@ $indent  - $tail" "$doctored"
     return 1
   }
 
-  # Confirm the divergence before relying on it: both readers succeed, and
-  # they read different paths.
+  # Confirm the premise before relying on it: PyYAML reads one folded path.
   arming_parser_class "$doctored" | grep -qxF -- "$head - $tail" || {
     echo "PyYAML did not fold the entry into '$head - $tail'" >&2
     return 1
   }
-  awk_class="$(LEG_ARMING_WORKFLOW="$doctored" bash "$ARMING_SCRIPT" class 2>/dev/null)" || {
-    echo "the awk reader refused the folded entry, so this case would not reach the set comparison" >&2
+  LEG_ARMING_WORKFLOW="$doctored" bash "$ARMING_SCRIPT" class >/dev/null 2>"$err" || rc=$?
+  [ "$rc" -ne 0 ] || {
+    echo "the awk reader accepted an entry PyYAML folds into '$head - $tail'" >&2
     return 1
   }
-  grep -qxF -- "$head" <<<"$awk_class" || {
-    echo "the awk reader did not read '$head' as an entry of its own" >&2
+  grep -qF -- 'multi-line entry' "$err" || {
+    echo "the awk reader refused the folded entry for another reason:" >&2
+    cat "$err" >&2
     return 1
   }
 
   run assert_arming_class "$ARMING_SCRIPT" "$doctored"
   [ "$status" -ne 0 ] || {
-    echo "two readers reading different classes was not caught" >&2
+    echo "a folded entry the awk reader refuses was not caught" >&2
+    return 1
+  }
+  grep -qF -- 'could not derive the class' <<<"$output"
+}
+
+@test "W16 adversarial: a code: entry shifted shallower than the list's entry indent is refused by the awk reader" {
+  require_yaml_parser
+  local pages page line mutated doctored="$BATS_TEST_TMPDIR/class-shallow.yml"
+  local err="$BATS_TEST_TMPDIR/class-shallow.err" rc=0
+  pages="$(arming_parser_class "$WORKFLOW")" || return 1
+  page="$(printf '%s\n' "$pages" | sed -n 1p)"
+  line="$(code_entry_line "$WORKFLOW" "$page")" || return 1
+  mutated="${line# }"
+  assert_doctored "$line" "$mutated" "shifting the entry for $page one column shallower" || return 1
+  replace_line "$WORKFLOW" "$line" "$mutated" "$doctored"
+
+  # Confirm the premise before relying on it: PyYAML reads no entry here.
+  arming_parser_class "$doctored" >/dev/null 2>&1 && {
+    echo "PyYAML read the shifted entry for $page, so refusing it would be a divergence" >&2
+    return 1
+  }
+  LEG_ARMING_WORKFLOW="$doctored" bash "$ARMING_SCRIPT" class >/dev/null 2>"$err" || rc=$?
+  [ "$rc" -ne 0 ] || {
+    echo "the awk reader accepted an entry shifted off the list's entry indent" >&2
+    return 1
+  }
+  grep -qF -- 'off the entry indent' "$err" || {
+    echo "the awk reader refused the shifted entry for another reason:" >&2
+    cat "$err" >&2
+    return 1
+  }
+}
+
+@test "W16 adversarial: an arming script reading a different class than PyYAML reds the class comparison" {
+  require_yaml_parser
+  local line mutated doctored="$BATS_TEST_TMPDIR/leg-arming.sh"
+  line="$(sole_line_matching "$ARMING_SCRIPT" 'index\(v, "wiki/"\) == 1\) print v$')" || return 1
+  mutated="$line \"-doctored\""
+  assert_doctored "$line" "$mutated" "suffixing every page the awk reader prints" || return 1
+  replace_line "$ARMING_SCRIPT" "$line" "$mutated" "$doctored"
+
+  # The copy sits outside any checkout, so it cannot derive its root itself.
+  export LEG_ARMING_ROOT="$REPO_ROOT"
+  run assert_arming_class "$doctored" "$WORKFLOW"
+  [ "$status" -ne 0 ] || {
+    echo "a script reading a class PyYAML does not was not caught" >&2
     return 1
   }
   grep -qF -- 'read different classes' <<<"$output"


### PR DESCRIPTION
## Summary

`leg-arming.sh`'s `derive_class` awk reader treated every line opening with `- ` inside the `code:` list as a new entry, at any indent. YAML folds a deeper-indented `- ` line into the plain scalar of the entry above it, so

```yaml
code:
  - wiki/concepts/Foo.md
    - wiki/concepts/Bar.md
```

is the one path `wiki/concepts/Foo.md - wiki/concepts/Bar.md`, and the reader emitted two class members. The direction was over-arming only, and no such entry exists in the workflow, so the defect was latent.

- **Fix:** the reader records the first entry's indent, and only a `- ` at that indent opens an entry. One off it, deeper (a fold) or shallower (which PyYAML rejects outright), is refused with a message naming both readings, and a refusal arms.
- **W16:** the folded-entry case used to assert the divergence (both readers accept, the class comparison reds). It now asserts the awk reader refuses. A new case shifts an entry one column shallower and asserts the refusal, pinning the other direction.
- **Divergence branch kept driven:** the fold was the only workflow shape reaching `assert_arming_class`'s "read different classes" branch, and with the fix no healthy reader offers one. A new case drives that branch with a doctored copy of the script instead.

Scope follows the issue's relay comment: `leg-arming.sh` plus the W16 block only. W14 and W19 are untouched.

## Verification

- W16 to W19 of `audit-ci-shards.bats` (63 cases) green under bash 5; `workflow-filter-coverage.bats` green; `whole-tree-invariants.sh` green.
- The fold case was red against the unfixed reader before the fix landed.
- Mutants on the new predicate, each killed by exactly the case aimed at it: `!=` to `>` (deeper-only) kills the shallower case; `!=` to `<` (shallower-only) kills the fold case; never recording the entry indent kills the healthy class comparison and the divergence case.
- Quality Gate skipped by its own rule: the diff is `.sh` and `.bats` only.
- No CHANGELOG entry: the defect is latent and the change sits in release-excluded test infrastructure.

## Audit

`code-audit-maintainer-shell`, round 1: clean pass, two Suggestions. The in-scope one (the new `derive_class` docblock claimed a deeper `- ` line always folds, when after a quoted or mapping entry PyYAML rejects the list instead) is fixed in b32fa384 to match the bail message. The other is recorded below.

Round 2 (after absorbing `origin/main`, which brought in #1981): clean pass. Its two Suggestions are shellcheck info-level notes on #1981's files, which reach this round only through the merge and are not in this PR's diff. Neither is a defect, so neither is filed: `.gaia/scripts/lint-sigpipe-readers.sh:299` (SC1091) already carries a `# shellcheck source=` directive and `guard-awk-lib.sh` is linted on its own as a tracked script; `.gaia/scripts/tests/lint-sigpipe-readers.bats:1114` (SC2030/SC2031) is shellcheck modelling a `@test` body as a subshell, while `TMP` is set and read in the same body.

## Out-of-scope machinery findings (recorded, not filed)

- `.gaia/tests/lib/audit-ci-shards.bats:1076`: shellcheck at its default floor reports SC2016 (info) at this line and others. Each site is a regex, fixture line, or doctored-script text that is literal on purpose, none is on a line this PR changes, and the repo lints bats at `-S warning`, where SC2016 never fires. No failure mode. Key: `v1 class=holistic/unclassified path=.gaia/tests/lib/audit-ci-shards.bats line=1076`.
  <!-- gaia-debt-origin: branch=worktree-debt+1960-leg-arming-folded-scalar mode=drain unit=1960 changed=1 head=5eeca010079212f1e25462c607e019e16ece4038 session=bb780e03-ab3a-4f8d-83e0-01a93f5357ef -->

Closes #1960

🤖 Generated with [Claude Code](https://claude.com/claude-code)
