### PR TITLE
debt(tests): count every entry line in S19's vitest gate reader

### DIFF
--- a/.gaia/tests/lib/bats-shards.bats
+++ b/.gaia/tests/lib/bats-shards.bats
@@ -821,12 +821,14 @@ check_gate_parity() {
 
 # The vitest side's gate list in file $1, as the `key=value` words the shell
 # runners loop over: one pair per entry of its MAINTENANCE_SUPPRESSION array.
-# Prints nothing when any entry line fails to parse as a pair, so a reshaped
-# entry reads as no list rather than as the shorter list that did parse.
+# Every array line that is neither blank nor a `//` comment counts as an entry,
+# and the list prints nothing unless each one parses as a pair, so a reshaped
+# entry, a spread or a named constant among them, reads as no list rather than
+# as the shorter list that did parse.
 ts_gate_list() {
   local block entries pairs
   block="$(awk '/^const MAINTENANCE_SUPPRESSION/ {f = 1; next} f && /^\];$/ {exit} f' "$1")"
-  entries="$(grep -c '^ *\[' <<<"$block" || true)"
+  entries="$(grep -cvE '^[[:space:]]*(//|$)' <<<"$block" || true)"
   pairs="$(sed -n "s/^ *\['\([^']*\)', '\([^']*\)'\],\$/\1=\2/p" <<<"$block")"
   [ -n "$pairs" ] || return 0
   [ "$(printf '%s\n' "$pairs" | wc -l | tr -d ' ')" -eq "$entries" ] || return 0
@@ -931,6 +933,20 @@ doctor_dropped_gate() {
   awk '{print} /^  \[.maintenance\.autoDetach., .false.\],$/ {print "  [\x27maintenance.strategy\x27, \x27none\x27],"}' \
     "$BATS_TEST_DIRNAME/../../cli/src/util/git-maintenance-env.ts" >"$ts"
   grep -qF "['maintenance.strategy', 'none']," "$ts"
+  run check_ts_gate_parity "$ts" "$BATS_TEST_DIRNAME/../../scripts/bats5.sh"
+  [ "$status" -eq 1 ]
+}
+
+# A spread and a named constant are one shape to ts_gate_list, an entry line
+# that is not a bracketed pair, so this samples the spread. The pairs that do
+# parse still equal bats5.sh's list, which leaves the entry count as the only
+# thing that can red it.
+@test "A12: an entry that is not a bracketed pair reds S19's parity check" {
+  local ts
+  ts="$BATS_TEST_TMPDIR/git-maintenance-env.ts"
+  awk '{print} /^  \[.maintenance\.autoDetach., .false.\],$/ {print "  ...EXTRA_GATES,"}' \
+    "$BATS_TEST_DIRNAME/../../cli/src/util/git-maintenance-env.ts" >"$ts"
+  grep -qxF '  ...EXTRA_GATES,' "$ts"
   run check_ts_gate_parity "$ts" "$BATS_TEST_DIRNAME/../../scripts/bats5.sh"
   [ "$status" -eq 1 ]
 }


### PR DESCRIPTION
## Summary

`ts_gate_list` in `.gaia/tests/lib/bats-shards.bats` counted only bracket-led lines of the vitest side's `MAINTENANCE_SUPPRESSION` array. An entry in any other shape, such as a spread (`...EXTRA_GATES,`) or a named constant (`STRATEGY_GATE,`), was neither counted nor parsed, so the bracketed pairs still equalled `bats5.sh`'s loop list and S19 stayed green while the vitest run set a key the shell runners never set.

- The entry count now covers every array line that is neither blank nor a `//` comment, so any entry that is not a single-line bracketed string pair empties the list and S19 reds.
- New adversarial **A12** inserts a spread entry into a copy of the vitest file and asserts S19's parity check fails. It was red against the old count and is green now.
- The helper's comment now states what counts as an entry line, which is what makes its "prints nothing" claim true.

`git-maintenance-env.ts` is read, not edited, so the CLI bundle is untouched.

## Verification

- `bats-shards.bats` under bash 5: 33/33 pass.
- Hand probe against mutated copies: spread and named constant red; a blank line, a `//` line, and a tab-indented `//` line stay green; a `/* */` line reds (the safe direction, and the file uses none).
- `bash .gaia/tests/whole-tree-invariants.sh`: all pass.
- The Quality Gate skips: the diff is `.bats` only.

## Audit

`code-audit-maintainer-shell` cleared round 1. One Suggestion, accepted with no change: shellcheck reports SC2016 (info) on five single-quoted patterns in this suite whose `$` is meant literally, since they match script text such as `n="${GIT_CONFIG_COUNT:-0}"`. The base carries the same set, this diff adds none, and `.gaia/tests/shell-lint.sh` documents SC2016 on bats as a structural sub-floor note. The member recommended no action.

Closes #1986

🤖 Generated with [Claude Code](https://claude.com/claude-code)

