### PR TITLE
debt(scripts): read a package-manager install as network reach in the capability oracle

### DIFF
--- a/.gaia/hook-capabilities.json
+++ b/.gaia/hook-capabilities.json
@@ -314,13 +314,14 @@
     {
       "hook": ".claude/hooks/provision-worktree.sh",
       "capabilities": [
+        "network",
         "fs-write:**",
         "fs-write:.gaia/local",
         "fs-write:.gaia/local/**",
         "invokes:.gaia/scripts/link-worktree.sh",
         "invokes:.gaia/scripts/main-root-lib.sh"
       ],
-      "why": "On entering or starting a session inside a linked worktree, re-links the shared state the worktree registry declares and regenerates the typed routes the worktree's own branch needs, idempotently. Sources `link-worktree.sh`, which symlinks each shared path under `.gaia/local` from the worktree side to the main checkout, hence `fs-write:.gaia/local` and `fs-write:.gaia/local/**`; the symlink's worktree-side location is wherever the session's own checkout sits, which is what the caller-chosen `fs-write:**` stands for. Sources main-root-lib.sh to resolve the main checkout.",
+      "why": "On entering or starting a session inside a linked worktree, re-links the shared state the worktree registry declares and regenerates the typed routes the worktree's own branch needs, idempotently. Sources `link-worktree.sh`, which symlinks each shared path under `.gaia/local` from the worktree side to the main checkout, hence `fs-write:.gaia/local` and `fs-write:.gaia/local/**`; the symlink's worktree-side location is wherever the session's own checkout sits, which is what the caller-chosen `fs-write:**` stands for. Sources main-root-lib.sh to resolve the main checkout. `network` is the frozen-lockfile `pnpm install` it runs for the tree root, and for the `.gaia/cli` workspace where that workspace carries its own lockfile: a frozen install refuses to rewrite the lockfile but still downloads from the package registry whenever the store lacks a locked package.",
       "maintainer_only": false
     },
     {

--- a/.gaia/scripts/capability-oracle-lib.sh
+++ b/.gaia/scripts/capability-oracle-lib.sh
@@ -2368,18 +2368,29 @@ _GAIA_CAPCHECK_DOTCMD='(^|[;|&(`{}]|(^|[[:space:]])(if|then|else|do|elif|while|u
 # of one that does.
 _GAIA_CAPCHECK_PATHCMD='(^|[;|&`]|\$\(|[[:space:]]then[[:space:]]|[[:space:]]else[[:space:]]|[[:space:]]do[[:space:]]|[[:space:]]elif[[:space:]]|[[:space:]]![[:space:]])[[:space:]]*'
 
-# _gaia_capcheck_detect_network <text>: curl, wget, any gh invocation, and the
-# remote-touching git verbs. Deliberately not matched: `command -v gh` and
-# friends, where `gh` is an argument rather than the command -- the match
-# requires a lowercase subcommand letter after it.
+# _gaia_capcheck_detect_network <text>: curl, wget, any gh invocation, the
+# remote-touching git verbs, and a package-manager install. Deliberately not
+# matched: `command -v gh` and friends, where `gh` is an argument rather than the
+# command -- the match requires a lowercase subcommand letter after it.
+#
+# The install arm counts an install as reach because it downloads whenever the
+# store lacks a locked package; a frozen lockfile refuses to rewrite the lockfile
+# and still downloads. Flags may stand between the manager and its verb, each
+# with at most one operand (`pnpm -C <dir> install`), and `command -v pnpm`
+# stays unmatched because no install verb follows it. What it misses: a bare
+# `yarn`, which installs with no verb; `pnpm dlx`, `npx`, and the update verbs,
+# which fetch too; any manager other than pnpm, npm and yarn; and a flag
+# followed by two operands, since the second one stands where the verb has to.
 _gaia_capcheck_detect_network() {
   local t="$1"
   local p1="${_GAIA_CAPCHECK_CMD}(curl|wget)([[:space:]]|\$)"
   local p2="${_GAIA_CAPCHECK_CMD}gh[[:space:]]+[a-z]"
   local p3="${_GAIA_CAPCHECK_CMD}git([[:space:]]+-[Cc][[:space:]]+[^[:space:]]+)?[[:space:]]+(fetch|push|clone|pull|ls-remote)([[:space:]]|\$)"
+  local p4="${_GAIA_CAPCHECK_CMD}(pnpm|npm|yarn)([[:space:]]+-[^[:space:]]+([[:space:]]+[^-[:space:]][^[:space:]]*)?)*[[:space:]]+(install|i|add|ci)([[:space:]]|\$)"
   [[ $t =~ $p1 ]] && return 0
   [[ $t =~ $p2 ]] && return 0
   [[ $t =~ $p3 ]] && return 0
+  [[ $t =~ $p4 ]] && return 0
   return 1
 }
 

--- a/.gaia/scripts/capability-oracle-lib.sh
+++ b/.gaia/scripts/capability-oracle-lib.sh
@@ -2377,10 +2377,19 @@ _GAIA_CAPCHECK_PATHCMD='(^|[;|&`]|\$\(|[[:space:]]then[[:space:]]|[[:space:]]els
 # store lacks a locked package; a frozen lockfile refuses to rewrite the lockfile
 # and still downloads. Flags may stand between the manager and its verb, each
 # with at most one operand (`pnpm -C <dir> install`), and `command -v pnpm`
-# stays unmatched because no install verb follows it. What it misses: a bare
-# `yarn`, which installs with no verb; `pnpm dlx`, `npx`, and the update verbs,
-# which fetch too; any manager other than pnpm, npm and yarn; and a flag
-# followed by two operands, since the second one stands where the verb has to.
+# stays unmatched because no install verb follows it.
+#
+# It is a vocabulary, not a parse, so it errs in both directions. Among what it
+# does not see: a bare `yarn`, which installs with no verb; `pnpm dlx`, `pnpm
+# fetch`, `pnpm audit`, `npx`, and the update verbs, which reach the registry
+# too; a manager reached through a path or an expansion
+# (`./node_modules/.bin/pnpm install`); and a flag followed by two operands, or
+# by one quoted operand holding a space, since the second word stands where the
+# verb has to. What it over-reads: the word after a boolean flag is taken as
+# that flag's operand, so `pnpm --silent run install` reads the script name as
+# the verb. The flag repeat is unbounded, so a line of thousands of
+# manager-and-flag pairs matches in quadratic time under glibc. The positive
+# and negative tables in check-hook-capabilities.bats pin what it does decide.
 #
 # The verb arms end at a shell separator as well as at whitespace, because a
 # verb is the last word of its command as often as not: `(cd "$d" && pnpm

--- a/.gaia/scripts/capability-oracle-lib.sh
+++ b/.gaia/scripts/capability-oracle-lib.sh
@@ -163,7 +163,7 @@ _gaia_capcheck_strip_literals() {
 # Command words that only ever mean reach when the shell is going to run them:
 # every name the detectors below look for, plus the `.` builtin. Held with
 # leading and trailing spaces so a membership test is one `case`.
-_GAIA_CAPCHECK_QUOTED_WORDS=" mkdir rm touch tee install mktemp cp mv ln sed find bash sh source . curl wget gh git "
+_GAIA_CAPCHECK_QUOTED_WORDS=" mkdir rm touch tee install mktemp cp mv ln sed find bash sh source . curl wget gh git pnpm npm yarn "
 
 # The characters, besides the space, that can bound one of those words inside a
 # double-quoted span. A membership test delimited by spaces alone missed every
@@ -2381,12 +2381,19 @@ _GAIA_CAPCHECK_PATHCMD='(^|[;|&`]|\$\(|[[:space:]]then[[:space:]]|[[:space:]]els
 # `yarn`, which installs with no verb; `pnpm dlx`, `npx`, and the update verbs,
 # which fetch too; any manager other than pnpm, npm and yarn; and a flag
 # followed by two operands, since the second one stands where the verb has to.
+#
+# The verb arms end at a shell separator as well as at whitespace, because a
+# verb is the last word of its command as often as not: `(cd "$d" && pnpm
+# install)`, `out=$(npm ci)`, `git fetch;`. The curl/wget arm keeps the
+# whitespace-only end, since a `curl)` there is far likelier to be a case
+# pattern than a call with no arguments.
 _gaia_capcheck_detect_network() {
   local t="$1"
+  local end="([[:space:]);|&<>\`]|\$)"
   local p1="${_GAIA_CAPCHECK_CMD}(curl|wget)([[:space:]]|\$)"
   local p2="${_GAIA_CAPCHECK_CMD}gh[[:space:]]+[a-z]"
-  local p3="${_GAIA_CAPCHECK_CMD}git([[:space:]]+-[Cc][[:space:]]+[^[:space:]]+)?[[:space:]]+(fetch|push|clone|pull|ls-remote)([[:space:]]|\$)"
-  local p4="${_GAIA_CAPCHECK_CMD}(pnpm|npm|yarn)([[:space:]]+-[^[:space:]]+([[:space:]]+[^-[:space:]][^[:space:]]*)?)*[[:space:]]+(install|i|add|ci)([[:space:]]|\$)"
+  local p3="${_GAIA_CAPCHECK_CMD}git([[:space:]]+-[Cc][[:space:]]+[^[:space:]]+)?[[:space:]]+(fetch|push|clone|pull|ls-remote)${end}"
+  local p4="${_GAIA_CAPCHECK_CMD}(pnpm|npm|yarn)([[:space:]]+-[^[:space:]]+([[:space:]]+[^-[:space:]][^[:space:]]*)?)*[[:space:]]+(install|i|add|ci)${end}"
   [[ $t =~ $p1 ]] && return 0
   [[ $t =~ $p2 ]] && return 0
   [[ $t =~ $p3 ]] && return 0

--- a/.gaia/scripts/tests/check-hook-capabilities.bats
+++ b/.gaia/scripts/tests/check-hook-capabilities.bats
@@ -671,6 +671,78 @@ curl https://example.com/'
   [ "$(grep -c -- "invokes:.claude/hooks/b.sh" <<<"$output")" -eq 1 ]
 }
 
+# ========== a package-manager install is network reach ==========
+#
+# An install reaches the registry whenever the store lacks a locked package,
+# frozen lockfile or not. The first fixture drives the check end to end on
+# provision-worktree.sh's own spelling, the second on a flag standing between
+# the manager and its verb; the tables below them drive the detector directly,
+# one spelling per element, because a table is cheap there and a full check run
+# per spelling is not.
+
+@test "a hook installing behind a subshell cd while its entry omits network is UNDECLARED" {
+  repo="$(make_fixture_repo install-undeclared)"
+  add_hook "$repo" .claude/hooks/prov.sh '#!/usr/bin/env bash
+if (cd "$dir" && pnpm install --frozen-lockfile) >/dev/null 2>&1; then :; fi'
+  write_registrations "$repo" SessionStart .claude/hooks/prov.sh
+  write_manifest "$repo" '[{"hook":".claude/hooks/prov.sh","capabilities":[],
+    "why":"declared as reaching nothing","maintainer_only":false}]'
+  run bash "$CHECK" "$repo"
+  [ "$status" -eq 1 ]
+  grep -qF -- "UNDECLARED .claude/hooks/prov.sh network .claude/hooks/prov.sh:2" <<<"$output"
+}
+
+@test "network declared for an install with a flag before its verb is reached, not SURPLUS" {
+  repo="$(make_fixture_repo install-declared)"
+  add_hook "$repo" .claude/hooks/prov.sh '#!/usr/bin/env bash
+pnpm -C "$tree/.gaia/cli" install --frozen-lockfile'
+  write_registrations "$repo" SessionStart .claude/hooks/prov.sh
+  write_manifest "$repo" '[{"hook":".claude/hooks/prov.sh","capabilities":["network"],
+    "why":"installs the workspace from its lockfile","maintainer_only":false}]'
+  run bash "$CHECK" "$repo"
+  grep -qF -- "SURPLUS .claude/hooks/prov.sh network" <<<"$output" && return 1
+  [ "$status" -eq 0 ]
+}
+
+@test "the network detector reads each install spelling below as reach" {
+  local line missed=""
+  for line in \
+    'pnpm install' \
+    'pnpm install --frozen-lockfile' \
+    'pnpm i' \
+    'pnpm add zod' \
+    'pnpm -C "$tree/.gaia/cli" install' \
+    'pnpm --dir=.gaia/cli install' \
+    'pnpm --filter app --silent install' \
+    'npm ci' \
+    'npm install' \
+    'npm --prefix app i' \
+    'yarn install' \
+    'yarn add zod' \
+    '  if (cd "$dir" && pnpm install --frozen-lockfile) >/dev/null 2>&1; then'; do
+    _gaia_capcheck_detect_network "$line" || missed="$missed
+  $line"
+  done
+  [ -z "$missed" ] || { printf 'not read as reach:%s\n' "$missed"; return 1; }
+}
+
+@test "the network detector does not read a package manager that installs nothing as reach" {
+  local line hit=""
+  for line in \
+    'command -v pnpm >/dev/null 2>&1' \
+    'pnpm run lint' \
+    'pnpm -C .gaia/cli run build' \
+    'pnpm --version' \
+    'pnpm exec eslint --fix' \
+    'pnpm install-completion' \
+    'npm i18n-report' \
+    'run_step install node --version'; do
+    _gaia_capcheck_detect_network "$line" && hit="$hit
+  $line"
+  done
+  [ -z "$hit" ] || { printf 'read as reach:%s\n' "$hit"; return 1; }
+}
+
 # ========== UAT-017, the shared oracle, sourced not forked ==========
 #
 # The vendored pre-fix copy at .gaia/scripts/tests/fixtures/capability-oracle

--- a/.gaia/scripts/tests/check-hook-capabilities.bats
+++ b/.gaia/scripts/tests/check-hook-capabilities.bats
@@ -755,7 +755,7 @@ pnpm -C "$tree/.gaia/cli" install --frozen-lockfile'
   [ -z "$missed" ] || { printf 'not read as reach:%s\n' "$missed"; return 1; }
 }
 
-@test "the network detector does not read a package manager that installs nothing as reach" {
+@test "the network detector does not read a run script, a non-install verb, or a quoted message as reach" {
   local line hit=""
   for line in \
     'command -v pnpm >/dev/null 2>&1' \

--- a/.gaia/scripts/tests/check-hook-capabilities.bats
+++ b/.gaia/scripts/tests/check-hook-capabilities.bats
@@ -679,6 +679,15 @@ curl https://example.com/'
 # the manager and its verb; the tables below them drive the detector directly,
 # one spelling per element, because a table is cheap there and a full check run
 # per spelling is not.
+#
+# reads_as_reach hands the detector what a scanned line hands it: the text after
+# both strip passes, so a double-quoted message is judged the way the check
+# judges it rather than as raw bytes it never sees.
+reads_as_reach() {
+  _gaia_capcheck_strip_literals "$1"
+  _gaia_capcheck_strip_quoted_code "$_GAIA_CAPCHECK_RET"
+  _gaia_capcheck_detect_network "$_GAIA_CAPCHECK_RET"
+}
 
 @test "a hook installing behind a subshell cd while its entry omits network is UNDECLARED" {
   repo="$(make_fixture_repo install-undeclared)"
@@ -719,8 +728,28 @@ pnpm -C "$tree/.gaia/cli" install --frozen-lockfile'
     'npm --prefix app i' \
     'yarn install' \
     'yarn add zod' \
-    '  if (cd "$dir" && pnpm install --frozen-lockfile) >/dev/null 2>&1; then'; do
-    _gaia_capcheck_detect_network "$line" || missed="$missed
+    '  if (cd "$dir" && pnpm install --frozen-lockfile) >/dev/null 2>&1; then' \
+    '  if (cd "$dir" && pnpm install) >/dev/null 2>&1; then' \
+    'pnpm install; echo done' \
+    'pnpm install>/dev/null' \
+    'pnpm install|tee log' \
+    'pnpm install&' \
+    'out=$(npm ci)' \
+    'out="$(npm ci)"' \
+    'out=`npm ci`'; do
+    reads_as_reach "$line" || missed="$missed
+  $line"
+  done
+  [ -z "$missed" ] || { printf 'not read as reach:%s\n' "$missed"; return 1; }
+}
+
+@test "the network detector reads a remote git verb ending at a shell separator as reach" {
+  local line missed=""
+  for line in \
+    '(git fetch)' \
+    'git -C "$repo" fetch; echo done' \
+    'heads=$(git ls-remote)'; do
+    reads_as_reach "$line" || missed="$missed
   $line"
   done
   [ -z "$missed" ] || { printf 'not read as reach:%s\n' "$missed"; return 1; }
@@ -736,8 +765,15 @@ pnpm -C "$tree/.gaia/cli" install --frozen-lockfile'
     'pnpm exec eslint --fix' \
     'pnpm install-completion' \
     'npm i18n-report' \
-    'run_step install node --version'; do
-    _gaia_capcheck_detect_network "$line" && hit="$hit
+    'run_step install node --version' \
+    'npm run ci' \
+    'pnpm run install' \
+    'npm --prefix app run ci' \
+    'pnpm --filter app run install' \
+    'log "try pnpm add zod to fix"' \
+    'log "install failed -- run npm ci there first"' \
+    'echo "hint: yarn add the missing peer (or npm i it)"'; do
+    reads_as_reach "$line" && hit="$hit
   $line"
   done
   [ -z "$hit" ] || { printf 'read as reach:%s\n' "$hit"; return 1; }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -435,6 +435,7 @@ A release change that requires the adopter to act, run a command or hand-migrate
 
 ### Fixed
 
+- the hook and script capability checks now count a package-manager install as network reach. They could not see one, so worktree provisioning's lockfile installs went undeclared and the check read a hand-written `network` declaration as surplus; the provisioning hook now declares it. The checks are maintainer-only and adopters see no change (#1995)
 - worktree provisioning now installs the `.gaia/cli` workspace's dependencies alongside the tree's own. That workspace is its own pnpm root, so a fresh worktree had no CLI dependencies and every suite resolving one failed there while passing on the main checkout, a false red a drainer had to diagnose before trusting the run. The CLI install is gated on the workspace's own lockfile, which is release-excluded, so adopters see no change (#1990)
 
 - `/update-deps` now gates every override change its post-update audit keeps. That audit could re-floor or remove an override and hand back no quality-gate result, and nothing said what to do when the gate failed, so a change that broke the build could stay in the tree while the final report and the commit both read as gated. The audit's agent now re-runs the gate whenever it changes an override, restores the previous values when the gate fails, and returns the gate result for the final report (#1985)


### PR DESCRIPTION
## Summary

The capability oracle's network detector saw `curl`, `wget`, any `gh` subcommand, and the remote-touching git verbs, but not a package-manager install. An install downloads from the registry whenever the store lacks a locked package, frozen lockfile or not. `.claude/hooks/provision-worktree.sh` runs frozen-lockfile `pnpm install`s, so its `.gaia/hook-capabilities.json` entry understated its reach, and `check-hook-capabilities.sh` could neither report the gap (no `UNDECLARED`) nor accept a hand-written `network` declaration (it read it as `SURPLUS`).

- **Oracle:** `_gaia_capcheck_detect_network` gains an install arm for `pnpm`/`npm`/`yarn` with `install`/`i`/`add`/`ci`, in the same `_GAIA_CAPCHECK_CMD`-anchored form as its siblings. Flags may stand between the manager and the verb, each with at most one operand (`pnpm -C <dir> install`). `command -v pnpm` stays unmatched. The install arm and the remote-git-verb arm end at a shell separator (`)`, `;`, `|`, `&`, a redirect, a backtick) as well as at whitespace; the curl/wget arm keeps its whitespace end because `curl)` is likelier a case pattern. The header gives examples of what the arm misses and over-reads.
- **Quoted words:** `_GAIA_CAPCHECK_QUOTED_WORDS` gains `pnpm npm yarn`, so an install named inside a double-quoted message is blanked rather than read as reach. Whole-tree `--print-reach` on the hook and script surfaces is byte-identical before and after.
- **Manifest:** `provision-worktree.sh` now declares `network`, with a `why` naming the frozen-lockfile installs for the tree root and for `.gaia/cli` where that workspace carries its own lockfile (true on adopter clones too, where it doesn't).
- **Tests** (`check-hook-capabilities.bats`): an end-to-end `UNDECLARED` fixture on the hook's own spelling (`(cd "$dir" && pnpm install --frozen-lockfile)`), an end-to-end declared-`network`-is-not-`SURPLUS` fixture with a flag before the verb, and detector-level tables (fed the same stripped text a scanned line produces) of install spellings, separator-ended remote git verbs, and non-install spellings including run scripts and quoted messages.

## Audit rounds

- **Round 1** (`code-audit-maintainer-shell`, refused): the install tail missed a verb ending at a separator (`(cd "$d" && pnpm install)`, `out=$(npm ci)`), the quoted-words list no longer held every detector name, and the negative table left two loosened-flag mutants alive. All fixed in a4f18d04; `p3`'s identical pre-existing tail was folded into the same fix.
- **Round 2** (cleared): four suggestions. The misses-list and test-name ones were applied as prose in 503ea641.
- **Round 3** (cleared, delta review of 503ea641): four suggestions, all on prose round 2 wrote or on the residuals below. Not applied, since applying them would need a fourth round: the two header corrections (a single-quoted operand is blanked before the detector and so *is* read; the quadratic cost falls on a line that fails to match) are recorded on #1997, whose fix rewrites those sentences.

## Accepted residuals

Tracked in #1997, stated in the detector header as limits, not fixed here because each repair adds new matching logic to an already-cleared PR:
- A boolean flag's following word is read as its operand, so `pnpm --silent run install` reads as reach. No such spelling on either capability surface.
- The flag repeat is unbounded, so a line of thousands of manager-and-flag pairs matches in quadratic time under glibc. No line in the tree is near that size.

## Verification

- Whole-tree `check-hook-capabilities.sh .`: only `provision-worktree.sh` newly reported `UNDECLARED` (at `:250`), now clean. Whole-tree `check-script-capabilities.sh .`: unchanged and clean, so the fork-point reach-identity arm stays green.
- `--print-reach .claude/hooks/provision-worktree.sh` now prints `network`.
- Bats (bash 5): `check-hook-capabilities`, `check-script-capabilities`, `capability-oracle-anchors`, `capability-oracle-termination`, `lint-oracle-blind-invocations`: 282 ok, 1 opt-in skip (the live-tree walk, run directly instead). `whole-tree-invariants.sh`: pass.
- Red first: the three positive tests failed before the arm existed. Mutants, each killed by its targeted test: flag group dropped, operand dropped, flag group loosened to any word, operand quantifier unbounded, verb requirement dropped, verb boundary dropped, `p4` tail reverted to whitespace, `p3` tail reverted to whitespace, managers removed from the quoted-words list.
- Quality Gate skipped: no source or gate-affecting config staged.
- CHANGELOG: `### Fixed` entry under `## [Unreleased]` (a bugfix in maintainer tooling; adopters see no change).

Closes #1992

🤖 Generated with [Claude Code](https://claude.com/claude-code)
