### PR TITLE
debt(ci): arm the code: filter on the wiki pages bats suites read

### DIFF
--- a/.gaia/tests/lib/audit-ci-shards.bats
+++ b/.gaia/tests/lib/audit-ci-shards.bats
@@ -3225,15 +3225,23 @@ PY
 # W16's recomputation from the tree, one `<page>|<armed legs>` row per page of
 # the class PyYAML reads from <workflow>. See arming_scan_py for the rules.
 #
-# Two kinds of file in the input set name narrowable pages without reading them,
-# and both are counted rather than special-cased. This suite is a discovered
-# `lib` suite, and w16_declared_table names every page, so it is a namer of all
-# and the namer-of-all rule drops it. Of the committed fixtures under
+# Files in the input set that name narrowable pages without reading them are
+# counted rather than special-cased. This suite is a discovered `lib` suite, and
+# w16_declared_table names every page, so it is a namer of all and the
+# namer-of-all rule drops it. Of the committed fixtures under
 # .gaia/tests/lib/fixtures/spec-078/, which sit in a fixtures/ subtree beside
 # the `lib` suites, only codefilter-token-out-of-set.yml names wiki/.state.json,
 # so it attributes to `lib`; paths-filter-pin-bumped.yml names no narrowable
-# page. Neither can move an armed set: `lib` holds this suite, which rule 5
-# arms on every page anyway.
+# page. None of those can move an armed set: `lib` holds this suite, which rule
+# 5 arms on every page anyway.
+#
+# .gaia/tests/hooks/fixtures/audit-routing-before.tsv does move armed sets. It
+# is a frozen path inventory in the fixtures/ subtree beside the `hooks-*`
+# suites, listing most of wiki/ and reading none of it. While it lists every
+# class page the namer-of-all rule drops it; once the class holds a page it does
+# not list, it is a namer of every class page it does list, and each of those
+# rows gains every `hooks-*` leg with no hooks suite reading the page. That
+# over-arms, the safe direction, and #1994 tracks it.
 arming_recompute() {
   local sharder="$1" root="$2" workflow="$3" conc_dir="$4" conc_leg="$5" stats="${6:-}"
   local class legs data

--- a/.gaia/tests/lib/audit-ci-shards.bats
+++ b/.gaia/tests/lib/audit-ci-shards.bats
@@ -3778,13 +3778,19 @@ arming_baseline_false() {
 w16_declared_table() {
   cat <<'TABLE'
 wiki/.state.json|concurrency hooks-1 hooks-2 hooks-3 hooks-4 lib misc scripts-1 scripts-2 scripts-3
-wiki/concepts/Audit Disposition and Debt Fix.md|lib scripts-1 scripts-2 scripts-3
-wiki/concepts/Claude Hooks.md|lib scripts-1 scripts-2 scripts-3
-wiki/concepts/Code Review Audit Agent.md|lib
-wiki/concepts/GAIA Audit.md|lib
-wiki/concepts/PR Merge Workflow.md|hooks-2 hooks-3 hooks-4 lib misc scripts-1 scripts-2 scripts-3
-wiki/concepts/Policy-Memory Loop.md|lib
-wiki/concepts/Task Orchestration.md|lib scripts-1 scripts-2 scripts-3
+wiki/concepts/Audit Disposition and Debt Fix.md|hooks-1 hooks-2 hooks-3 hooks-4 lib scripts-1 scripts-2 scripts-3
+wiki/concepts/Claude Hooks.md|hooks-1 hooks-2 hooks-3 hooks-4 lib scripts-1 scripts-2 scripts-3
+wiki/concepts/Code Review Audit Agent.md|hooks-1 hooks-2 hooks-3 hooks-4 lib
+wiki/concepts/GAIA Audit.md|hooks-1 hooks-2 hooks-3 hooks-4 lib
+wiki/concepts/Issue Claim.md|lib
+wiki/concepts/Local Working State.md|hooks-1 hooks-2 hooks-3 hooks-4 lib
+wiki/concepts/PR Merge Workflow.md|hooks-1 hooks-2 hooks-3 hooks-4 lib misc scripts-1 scripts-2 scripts-3
+wiki/concepts/Policy-Memory Loop.md|hooks-1 hooks-2 hooks-3 hooks-4 lib
+wiki/concepts/Registering a Code Audit Team Member.md|lib
+wiki/concepts/Task Orchestration.md|hooks-1 hooks-2 hooks-3 hooks-4 lib scripts-1 scripts-2 scripts-3
+wiki/decisions/Code Audit Team.md|hooks-1 hooks-2 hooks-3 hooks-4 lib
+wiki/decisions/Shell Guard Fixture Discrimination.md|lib scripts-1 scripts-2 scripts-3
+wiki/index.md|hooks-1 hooks-2 hooks-3 hooks-4 lib misc scripts-1 scripts-2 scripts-3
 TABLE
 }
 

--- a/.github/workflows/audit-ci-tests.yml
+++ b/.github/workflows/audit-ci-tests.yml
@@ -399,6 +399,33 @@ jobs:
               # job having run that comparison zero times. Same
               # test-dir/source-dir pairing as the entries above.
               - 'wiki/concepts/Task Orchestration.md'
+              # Each page from here through wiki/index.md is opened and asserted
+              # on by the suite named beside it, and matches no other pattern
+              # here, so without its line a wiki-only edit to that page would
+              # report `code=false`, skip every bats step, and green the job
+              # having run that suite's assertions zero times. A suite that only
+              # names a page in a comment, or reuses its path inside a synthetic
+              # temp repo, never reads the tracked file, so it earns no entry.
+              #
+              # doc-issue-claim-parity.bats (.gaia/tests/lib/) compares, path by
+              # path, this page's list of merges that leave the claim in place
+              # against the same list in .claude/rules/issue-claim.md.
+              - 'wiki/concepts/Issue Claim.md'
+              # local-janitor-wiki-doc.bats (.gaia/tests/hooks/) cross-checks
+              # this page's janitor sweep enumeration against the hook source.
+              - 'wiki/concepts/Local Working State.md'
+              # doc-scope-digest-obligation.bats (.gaia/tests/lib/) requires the
+              # scope-digest obligation literal under this page's step-1 heading.
+              - 'wiki/concepts/Registering a Code Audit Team Member.md'
+              # doc-audit-rekey-record-prose.bats (.gaia/tests/lib/) greps this
+              # page's re-spawn breadcrumbs section for the settled re-key record.
+              - 'wiki/decisions/Code Audit Team.md'
+              # guard-awk-lib.bats (.gaia/scripts/tests/) reads this page's
+              # pinned headings and runs the wiki-style audit greps over it.
+              - 'wiki/decisions/Shell Guard Fixture Discrimination.md'
+              # The same suite reads this page's Decisions (ADRs) section for the
+              # page above's registration inside the maintainer-only block.
+              - 'wiki/index.md'
               # The doc-setup-gaia-isolation and doc-gaia-init-isolation suites
               # (.gaia/tests/lib/) grep the /setup-gaia Phase 3.5 clause and the
               # /gaia-init Step 9 question block; trigger on the two command


### PR DESCRIPTION
Closes #1957

## What

Six tracked `wiki/` pages are opened and asserted on by a bats suite but matched no pattern in `audit-ci-tests.yml`'s `code:` filter. A PR touching only one of them resolved `code=false`, skipped every bats step, and greened the required `Audit CI Tests` context having run that suite zero times.

Each page is now a literal `code:` entry with a comment naming its reader, the filter's existing convention (the fork #1957's comment settled on; not mechanized, per #1311's decision):

| Page | Reader | Leg |
|---|---|---|
| `wiki/concepts/Issue Claim.md` | `doc-issue-claim-parity.bats` | `lib` |
| `wiki/concepts/Local Working State.md` | `local-janitor-wiki-doc.bats` | `hooks-3` |
| `wiki/concepts/Registering a Code Audit Team Member.md` | `doc-scope-digest-obligation.bats` | `lib` |
| `wiki/decisions/Code Audit Team.md` | `doc-audit-rekey-record-prose.bats` | `lib` |
| `wiki/decisions/Shell Guard Fixture Discrimination.md` | `guard-awk-lib.bats` | `scripts-3` |
| `wiki/index.md` | `guard-awk-lib.bats` | `scripts-3` |

The count was re-derived at `bf01dd8c` with the issue's recipe: the same 6 real reads, the same 5 mention-only pages (left out, since no suite reads their content), and the 4 known basename false positives.

## Second gate (`leg-arming.sh`)

`leg-arming.sh` derives its narrowable class from the `code:` filter's `wiki/` literals, so each page joins it with no script change. Running `leg-arming.sh` with one page changed at a time, each page arms the leg holding its reader, and a leg with no namer for it (`concurrency`) answers `false`. W16's declared table in `.gaia/tests/lib/audit-ci-shards.bats` takes the recomputed rows.

**Side effect, over-arming only:** existing class pages now also arm `hooks-1..4`. The frozen inventory fixture `.gaia/tests/hooks/fixtures/audit-routing-before.tsv` named every class member before this change, so the "namer of all is a namer of none" rule excluded it. It doesn't list three of the new pages, so that rule no longer covers it. This errs in the safe direction and costs CI minutes only: in the last 60 wiki commits, about 4 wiki-only commits touched a class page without `wiki/index.md`. Tracked as #1994 rather than widened into this PR.

## Verification

- bats under bash 5: `audit-ci-shards.bats` + `workflow-filter-coverage.bats` (150), every other suite reading `audit-ci-tests.yml` plus the six reader suites (352), all green.
- Adversarial: removing the `Issue Claim.md` entry reds both W16 table comparisons, naming the page; restored and green again.
- `bash .gaia/tests/whole-tree-invariants.sh`: pass.
- Quality Gate: skipped by its own rule (only `.yml`/`.bats` change). No CHANGELOG entry: this is maintainer-only, release-excluded CI.

## Audit dispositions

- **Fixed (round 1, `code-audit-maintainer-shell`):** the `arming_recompute` docblock (`.gaia/tests/lib/audit-ci-shards.bats:3228`) listed only non-reading namers that cannot move an armed set. It now names the routing inventory fixture as the one that does, paired with #1994.
- **Accepted residual (round 2, `code-audit-maintainer-shell`, prose round 1 wrote):** the new docblock's "each of those rows gains every `hooks-*` leg" is too broad. Four of the ten listed rows already arm some or all hooks legs through other namers. Recorded on #1994 as a correction comment so that issue's fixer, who edits this docblock anyway, corrects it. Not worth a third audit round for a comment.
- **Accepted, no action:** shellcheck SC2016 info notes in `.gaia/tests/lib/audit-ci-shards.bats` (first at `:1075`). They predate this PR, are deliberate literal `$` strings, and sit below `shell-lint.sh`'s `warning` severity floor for bats.

## Out-of-scope machinery findings (recorded, not filed)

- `.github/workflows/audit-ci-tests.yml:114`: suites that grep the whole tracked tree, wiki included (`cost-consolidate-absence.bats`, `doc-noop-terminal-contract.bats`, `debt-origin-contract.bats`), never arm on a wiki-only edit to a page outside the `code:` class. A PR adding a banned string to such a page greens `Audit CI Tests` having run the assertion zero times. This predates the PR and isn't caused by it; arming `wiki/**` would run the full matrix on every wiki sync, so it needs an owner decision (see #1311's guard shapes). Key: `v1 class=holistic/unarmed-guard path=.github/workflows/audit-ci-tests.yml line=114`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

