### PR TITLE
wiki: sync through 72ab2e6

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "4dab40a782d8924719f4cbac331b72cd8f49b212",
-  "last_evaluated_at": "2026-09-11T07:44:34Z",
+  "last_evaluated_sha": "72ab2e64cf70f1e7d5ad4c3adf84bfdee999820c",
+  "last_evaluated_at": "2026-09-11T12:23:10Z",
   "last_consolidated_sha": "78c69d0f81d5bc6460453391c466570f30da43c4",
   "last_consolidated_at": "2026-09-08T06:34:36Z"
 }

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,17 @@ tags: [meta, log]
 
 ## [Unreleased]
 
+- 2026-09-11 72ab2e64 SKIP - capability-oracle network detector widened for package-manager installs, Code Audit Team.md already describes the oracle generically
+- 2026-09-11 919ed27 SKIP - leg-arming code: filter widened for wiki-page bats suites, Sharded CI Test Matrix.md already points at leg-arming.sh generically
+- 2026-09-11 bf01dd8 SKIP - worktree provisioning installs .gaia/cli workspace, wiki/concepts/Claude Hooks.md already updated in-commit
+- 2026-09-11 e25d9c6 SKIP - audit-CI bound-check bugfix, no wiki-visible behavior change
+- 2026-09-11 041bc82 SKIP - update-deps Phase 6 dispatch fix, wiki/decisions/pnpm.md's pointer to SKILL.md already covers it
+- 2026-09-11 7b7aeeb SKIP - tests-only
+- 2026-09-11 d6a78e0 SKIP - prior wiki-sync commit, no action needed
+- 2026-09-11 d29d511 SKIP - bats-runner background-maintenance race fix, internal test infra already pointed at generically
+- 2026-09-11 6724900 SKIP - tests-only
+- 2026-09-11 2c843ab SKIP - update-deps Phase 0 stale-floor detection, wiki/decisions/pnpm.md already updated in-commit
+- 2026-09-11 b3f29cf SKIP - sigpipe-gate arming heuristic bugfix, internal lint-check logic no wiki page enumerates
 - 2026-09-11 4dab40a7 SKIP - devDependency pin-parity guard widened; wiki/dependencies/gaia-lint.md and wiki/decisions/pnpm.md already updated by the commit itself
 - 2026-09-11 8f075be6 SKIP - sigpipe gate carry-count fix; narrow script-internal correctness fix, no wiki page covers this detail
 - 2026-09-11 3d61382e SKIP - bats fixture git-maintenance gating, tests-only


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to 72ab2e6.