### PR TITLE
debt(cli): consolidate collectPins onto the shared tree walk

### DIFF
--- a/.gaia/cli/src/automation/__tests__/adopter-ci-action-pins.test.ts
+++ b/.gaia/cli/src/automation/__tests__/adopter-ci-action-pins.test.ts
@@ -93,10 +93,13 @@ const extractPins = (text: string, source: string): readonly ActionPin[] =>
 
 const TEMPLATE_EXTENSIONS: ReadonlySet<string> = new Set(['.tmpl']);
 
-// Both spellings, because GitHub honors both. `.github/actions/` is scanned
-// with the same set as `.github/workflows/`: a composite action is YAML too.
 const YAML_EXTENSIONS: ReadonlySet<string> = new Set(['.yaml', '.yml']);
 
+// The shared walk reports regular files only, so a symlinked workflow, action
+// or template is not scanned and its pins never reach the assertions below.
+// Worth stating at the call site because the miss is silent in the
+// safe-looking direction: every assertion here compares against an empty
+// array, so a corpus that quietly got smaller still reads as a pass.
 const collectPins = (
   dir: string,
   extensions: ReadonlySet<string>,

--- a/.gaia/cli/src/automation/__tests__/adopter-ci-action-pins.test.ts
+++ b/.gaia/cli/src/automation/__tests__/adopter-ci-action-pins.test.ts
@@ -38,9 +38,10 @@
  * `.github/workflows/` is absent, mirroring the sibling guards.
  */
 import {describe, expect, test} from 'vitest';
-import {existsSync, readdirSync, readFileSync} from 'node:fs';
+import {existsSync, readFileSync} from 'node:fs';
 import path from 'node:path';
 import {resolveRepoRootFromImportMeta} from '../../util/repo-root-fixture.js';
+import {collectTreeFiles} from '../../util/tree-walk.js';
 import {githubWorkflowsDirectory, workflowTemplatePath} from '../paths.js';
 
 type ActionPin = {
@@ -90,24 +91,23 @@ const extractPins = (text: string, source: string): readonly ActionPin[] =>
     return [{...parsed, line: index + 1, source}];
   });
 
+const TEMPLATE_EXTENSIONS: ReadonlySet<string> = new Set(['.tmpl']);
+
+// Both spellings, because GitHub honors both. `.github/actions/` is scanned
+// with the same set as `.github/workflows/`: a composite action is YAML too.
+const YAML_EXTENSIONS: ReadonlySet<string> = new Set(['.yaml', '.yml']);
+
 const collectPins = (
   dir: string,
-  extensions: readonly string[],
+  extensions: ReadonlySet<string>,
   prefix: string
 ): readonly ActionPin[] =>
-  readdirSync(dir, {withFileTypes: true}).flatMap((entry) => {
-    const full = path.join(dir, entry.name);
-
-    if (entry.isDirectory()) {
-      return collectPins(full, extensions, `${prefix}${entry.name}/`);
-    }
-
-    if (!extensions.some((extension) => entry.name.endsWith(extension))) {
-      return [];
-    }
-
-    return extractPins(readFileSync(full, 'utf8'), `${prefix}${entry.name}`);
-  });
+  collectTreeFiles(dir, extensions).flatMap((relative) =>
+    extractPins(
+      readFileSync(path.join(dir, relative), 'utf8'),
+      `${prefix}${relative}`
+    )
+  );
 
 const describePin = (pin: ActionPin): string =>
   `${pin.source}:${pin.line} ${pin.action}@${pin.ref}`;
@@ -129,7 +129,7 @@ const liveActionsDir = path.join(repoRoot, '.github', 'actions');
 // different repairs.
 const templatePins = collectPins(
   sourceTemplatesDir,
-  ['.tmpl'],
+  TEMPLATE_EXTENSIONS,
   'src/automation/templates/workflows/'
 );
 
@@ -143,19 +143,19 @@ const templatePins = collectPins(
 // otherwise sit outside every comparison below: the agreement test would not
 // see it drift from the workflows, and a template pinning the same action
 // would be compared against a live set that does not contain it.
-// Collected separately so the recursion into `.github/actions/` is expressed
+// Collected separately so the walk into `.github/actions/` is expressed
 // once; the SHA-shape test below asserts over the whole live set, workflows
 // included. A composite action pinned to a moving major tag and used by no
 // workflow would otherwise pass every test here: it agrees with itself, and no
 // template pins it, so neither comparison reaches it.
 const liveActionPins =
   existsSync(liveActionsDir) ?
-    collectPins(liveActionsDir, ['.yml', '.yaml'], '../actions/')
+    collectPins(liveActionsDir, YAML_EXTENSIONS, '../actions/')
   : [];
 
 const liveWorkflowPins = [
   ...(existsSync(liveWorkflowsDir) ?
-    collectPins(liveWorkflowsDir, ['.yml', '.yaml'], '')
+    collectPins(liveWorkflowsDir, YAML_EXTENSIONS, '')
   : []),
   ...liveActionPins,
 ];


### PR DESCRIPTION
Consolidates `collectPins` in `.gaia/cli/src/automation/__tests__/adopter-ci-action-pins.test.ts` onto the shared `collectTreeFiles` walk, re-applying the prefix at each call site. It was the last hand-rolled recursive walk in `.gaia/cli/src` that the shared walk could serve, and the uniqueness guard's match shape cannot see it.

Closes #1899

## Scope

Fix set is that one test file, as the issue's scope guard requires. `tree-walk-uniqueness.test.ts` and `util/tree-walk.ts` are both deliberately untouched.

No CLI bundle rebuild is owed. `collectPins`, `extractPins` and `pinIdentity` are each absent from both committed binaries, measured rather than assumed, so this test file is reachable from neither entry graph.

## The swap was checked against all six corpus differences, not only the symlink one

The issue calls a green test run insufficient evidence here, so the two walks were run side by side over the three roots `collectPins` walks. The six known differences are: a symlink to a file (drops), a symlink to a directory (adds), extension case (adds), a file named exactly `.yml` (drops), sort order, and path separators.

None of them changes the pin set today: templates 14 = 14, `.github/workflows` 15 = 15, `.github/actions` 3 = 3, total 32 = 32, symmetric difference 0, and identical order on all three roots. The roots hold zero symbolic links and no uppercase extension, which is what makes every one of the six inert here. `collectTreeFiles` is the more correct of the two on extension case, since GitHub is case-insensitive about workflow filenames.

The regular-files-only narrowing is now named at the call site, so the latent half is documented where a reader looks for it rather than only in the reserved guard docblock.

## Non-vacuity proven by mutation, not by a green run

All three assertions compare against `[]`, so an empty corpus would pass every one of them silently. Pinning a template partial and a composite action to a moving tag reds the suite and names:

- `src/automation/templates/workflows/partials/node-setup.yml.tmpl:12`
- `../actions/gaia-setup-node/action.yml:99`

with the agreement test separately naming the SHA the other live workflows carry. That establishes each of the three roots collects, descends into subdirectories, and composes its prefix and line numbers correctly. Both mutations were reverted.

## Audit findings and dispositions

Round one of `code-audit-maintainer-node` earned its marker and returned three findings.

**Applied on this branch**, both in scope, both comment-only:

- `adopter-ci-action-pins.test.ts:105` (suggestion) — the consolidated walk narrows the corpus to regular files and the call site recorded nothing about it. Now stated there.
- `adopter-ci-action-pins.test.ts:96` (suggestion) — the extension-set comment restated rationale the `liveActionPins` block already carries in full. Dropped, leaving the single site that explains it.

**Accepted residual, tracked rather than waived:**

- `tree-walk-uniqueness.test.ts:48` (warning, `holistic/uncoupled-restatement`) — the scope-boundary docblock still presents `collectPins` as an unconsolidated private walk and its consolidation as outstanding work. This change falsifies that paragraph and the dependent clause on line 58.

  This is **not** recorded as a waive. A waive is unavailable by rule when the finding is a claim this change itself falsifies, so it owes a tracked destination instead, and it has one: #2009, which the operator split this file out into on 2026-09-11 and whose own fix rewrites exactly that paragraph. Repairing it here would collide with the change that runs next, and retiring an operator's scope decision is not this run's call. Recorded on #2009 so the obligation is tracked rather than implied.

  The guard's behavior is unaffected in both directions: this file now contains no `readdirSync` at all, so it still does not match `RECURSIVE_DIRECTORY_READ`, and no file leaves the corpus, so the `corpusFloor` is untouched.

## Verification

Full CLI suite 2635/2635, CLI lint and typecheck clean, root typecheck, lint, test and build clean, and `whole-tree-invariants.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)