### PR TITLE
debt(tests): drive block-no-verify's repo-scope degrade tests through a staged tree

### DIFF
--- a/.gaia/tests/hooks/block-no-verify.bats
+++ b/.gaia/tests/hooks/block-no-verify.bats
@@ -9,13 +9,15 @@
 # core.hooksPath=` override. Foreign-repo commands pass via the shared
 # repo-scope helper.
 #
-# Each test drives the hook exactly as the harness does: a PreToolUse JSON
-# payload on stdin, run with the repo as the working directory, which is where
-# the shared repo-scope helper resolves the home repository's identity from: it
-# reads the toplevel and the remote URLs of whatever repo cwd sits in. The hook
-# loads that helper from its own on-disk location rather than from cwd, so the
-# staged-tree harness below is what puts a library a test controls in front of
-# it. The hook always exits 0; allow vs deny is carried in stdout
+# Most tests drive the hook exactly as the harness does: a PreToolUse JSON
+# payload on stdin, run with the tmp repo as the working directory, which is
+# where the shared repo-scope helper resolves the home repository's identity
+# from: it reads the toplevel and the remote URLs of whatever repo cwd sits in.
+# The hook loads that helper from its own on-disk location rather than from cwd,
+# so the degrade cases at the end run a copy of the hook from a staged tree
+# instead, with that tree as the working directory, which is what puts a library
+# the test controls in front of it. The hook always exits 0; allow vs deny is
+# carried in stdout
 # a deny emits `"permissionDecision": "deny"`, an allow emits nothing. The
 # deny cases double as a jq/setup canary: a missing jq would exit early with no
 # output and those assertions would fail rather than false-pass.

--- a/.gaia/tests/hooks/block-no-verify.bats
+++ b/.gaia/tests/hooks/block-no-verify.bats
@@ -10,9 +10,12 @@
 # repo-scope helper.
 #
 # Each test drives the hook exactly as the harness does: a PreToolUse JSON
-# payload on stdin, run with the repo as the working directory (the hook loads
-# .claude/hooks/lib/repo-scope.sh relative to cwd, so the helper is copied into
-# the tmp repo). The hook always exits 0; allow vs deny is carried in stdout
+# payload on stdin, run with the repo as the working directory, which is where
+# the shared repo-scope helper resolves the home repository's identity from: it
+# reads the toplevel and the remote URLs of whatever repo cwd sits in. The hook
+# loads that helper from its own on-disk location rather than from cwd, so the
+# staged-tree harness below is what puts a library a test controls in front of
+# it. The hook always exits 0; allow vs deny is carried in stdout
 # a deny emits `"permissionDecision": "deny"`, an allow emits nothing. The
 # deny cases double as a jq/setup canary: a missing jq would exit early with no
 # output and those assertions would fail rather than false-pass.
@@ -31,11 +34,6 @@ setup() {
   git -C "$REPO" add README.md
   git -C "$REPO" commit --quiet -m "init"
   git -C "$REPO" checkout --quiet -b feature
-
-  # The hook sources the repo-scope helper relative to cwd; give the tmp repo
-  # a real copy so the foreign-repo bypass resolves.
-  mkdir -p "$REPO/.claude/hooks/lib"
-  cp "$HOOKS_SRC/lib/repo-scope.sh" "$REPO/.claude/hooks/lib/repo-scope.sh"
 
   # A second, distinct repo for the foreign-repo case.
   FOREIGN=$(mktemp -d -t no-verify-foreign-XXXXXX)
@@ -220,20 +218,13 @@ run_hook() {
   return 0
 }
 
-# --- an unparseable repo-scope.sh degrades, it does not deny ---
+# --- the staged-tree harness the degrade cases below share ---
 #
-# The repo-scope load sits under this hook's `set -euo pipefail`, so before the
-# fix an unparseable copy abandoned the shell ahead of the `type
-# cmd_targets_foreign_repo` check on the next line. That exits 2, the
-# PreToolUse deny code, refusing every git command the hook matches -- including
-# the very edit that would repair the library. Unlike the verb-arming sites,
-# this one denies on bash 5 as well as on 3.2, so neither case below needs a
-# /bin/bash pin to have teeth.
-#
-# The pair is what discriminates. The allow case alone is satisfied by a hook
-# that stopped enforcing entirely, so the deny twin proves the degrade kept the
-# floor: without cmd_targets_foreign_repo the foreign-repo carve-out simply does
-# not fire, which is the fail-closed direction this hook documents at :47-50.
+# The repo-scope load resolves off BASH_SOURCE, never off the process working
+# directory, so expressing a degraded library needs a COPY of the hook in a tree
+# the test controls: running the real $HOOK_ABS leaves it resolving the real
+# checkout's library beside itself, whatever a fixture does to a copy anywhere
+# else.
 
 # Overwrites <path> with an unresolved-merge-conflict body: the file opens and
 # reads fine, so an existence test passes it, and bash cannot parse it.
@@ -242,20 +233,74 @@ write_conflicted_lib() {
     printf 'y() { :; }\n'; printf '>>>>>>> other\n'; } > "$1"
 }
 
+stage_hook_tree() {
+  STAGED_ROOT="$BATS_TEST_TMPDIR/staged"
+  rm -rf "$STAGED_ROOT"
+  mkdir -p "$STAGED_ROOT/.claude/hooks/lib"
+  cp "$HOOK_ABS" "$STAGED_ROOT/.claude/hooks/"
+  cp "$HOOKS_SRC/lib/repo-scope.sh" "$STAGED_ROOT/.claude/hooks/lib/"
+  # The jq-availability arm runs ahead of the load under test and refuses when
+  # it cannot find its own library, so a staged tree without it answers every
+  # case with that refusal instead of the decision under test.
+  cp "$HOOKS_SRC/lib/jq-availability.sh" "$STAGED_ROOT/.claude/hooks/lib/"
+  STAGED_HOOK="$STAGED_ROOT/.claude/hooks/block-no-verify.sh"
+}
+
+# Run the staged copy of the hook, from inside the staged tree.
+run_staged() {
+  local json
+  json=$(jq -n --arg c "$1" '{tool_name: "Bash", tool_input: {command: $c}}')
+  invoke_hook_in "$STAGED_ROOT" "$json" "$STAGED_HOOK"
+}
+
+# --- a degraded repo-scope.sh degrades the hook, it does not deny ---
+#
+# The repo-scope load sits under this hook's `set -euo pipefail`, so without the
+# bracket suspending errexit an unparseable copy abandons the shell ahead of the
+# `type cmd_targets_foreign_repo` check on the next line. That exits 2, the
+# PreToolUse deny code, refusing every git command the hook matches -- including
+# the very edit that would repair the library. Unlike the verb-arming sites,
+# this one denies on bash 5 as well as on 3.2, so neither conflict-marker case
+# needs a /bin/bash pin to have teeth.
+#
+# Each pair is what discriminates. The allow case alone is satisfied by a hook
+# that stopped enforcing entirely, so the deny twin proves the degrade kept the
+# floor: without cmd_targets_foreign_repo the foreign-repo carve-out simply does
+# not fire, which is the fail-closed direction the hook's own repo-scope comment
+# documents.
+#
+# The absent-library case pins those same two directions against a different
+# trigger, and an unbracketed load alone is not a probe that can red it: with
+# the library missing, the `[ -f ]` guard ahead of the source short-circuits,
+# and errexit exempts a non-final command in an `&&` list, so that path never
+# reaches the source the bracket protects. Dropping that guard along with the
+# bracket is what reds it, by turning a missing library into the same abandoned
+# shell.
+
 @test "repo-scope.sh holding conflict markers: an ordinary git command is still allowed" {
-  write_conflicted_lib "$REPO/.claude/hooks/lib/repo-scope.sh"
-  run_hook 'git status'
+  stage_hook_tree
+  write_conflicted_lib "$STAGED_ROOT/.claude/hooks/lib/repo-scope.sh"
+  run_staged 'git status'
   assert_allowed_by_json
 }
 
 @test "repo-scope.sh holding conflict markers: a --no-verify commit is still denied" {
-  write_conflicted_lib "$REPO/.claude/hooks/lib/repo-scope.sh"
-  run_hook 'git commit --no-verify -m x'
+  stage_hook_tree
+  write_conflicted_lib "$STAGED_ROOT/.claude/hooks/lib/repo-scope.sh"
+  run_staged 'git commit --no-verify -m x'
   assert_denied_by_json
 }
 
 @test "repo-scope.sh absent entirely: an ordinary git command is still allowed" {
-  rm -f "$REPO/.claude/hooks/lib/repo-scope.sh"
-  run_hook 'git status'
+  stage_hook_tree
+  rm -f "$STAGED_ROOT/.claude/hooks/lib/repo-scope.sh"
+  run_staged 'git status'
   assert_allowed_by_json
+}
+
+@test "repo-scope.sh absent entirely: a --no-verify commit is still denied" {
+  stage_hook_tree
+  rm -f "$STAGED_ROOT/.claude/hooks/lib/repo-scope.sh"
+  run_staged 'git commit --no-verify -m x'
+  assert_denied_by_json
 }

--- a/.gaia/tests/hooks/block-no-verify.bats
+++ b/.gaia/tests/hooks/block-no-verify.bats
@@ -17,10 +17,9 @@
 # so the degrade cases at the end run a copy of the hook from a staged tree
 # instead, with that tree as the working directory, which is what puts a library
 # the test controls in front of it. The hook always exits 0; allow vs deny is
-# carried in stdout
-# a deny emits `"permissionDecision": "deny"`, an allow emits nothing. The
-# deny cases double as a jq/setup canary: a missing jq would exit early with no
-# output and those assertions would fail rather than false-pass.
+# carried in stdout: a deny emits `"permissionDecision": "deny"`, an allow emits
+# nothing. The deny cases double as a jq/setup canary: a missing jq would exit
+# early with no output and those assertions would fail rather than false-pass.
 
 setup() {
   . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
@@ -238,13 +237,16 @@ write_conflicted_lib() {
 stage_hook_tree() {
   STAGED_ROOT="$BATS_TEST_TMPDIR/staged"
   rm -rf "$STAGED_ROOT"
-  mkdir -p "$STAGED_ROOT/.claude/hooks/lib"
-  cp "$HOOK_ABS" "$STAGED_ROOT/.claude/hooks/"
-  cp "$HOOKS_SRC/lib/repo-scope.sh" "$STAGED_ROOT/.claude/hooks/lib/"
-  # The jq-availability arm runs ahead of the load under test and refuses when
-  # it cannot find its own library, so a staged tree without it answers every
-  # case with that refusal instead of the decision under test.
-  cp "$HOOKS_SRC/lib/jq-availability.sh" "$STAGED_ROOT/.claude/hooks/lib/"
+  mkdir -p "$STAGED_ROOT/.claude"
+  # The whole hooks directory, lib/ included, rather than the libraries this
+  # hook happens to load today: an enumeration goes short the moment the hook
+  # gains a load, and the cases below would then drive a hook degraded in a way
+  # none of them names while still reporting green. Each case removes or
+  # corrupts only the library it is named for. Staging the directory wholesale
+  # also keeps the jq-availability arm present, which runs ahead of the load
+  # under test and refuses when it cannot find its own library, answering every
+  # case with that refusal instead of with the decision under test.
+  cp -R "$HOOKS_SRC" "$STAGED_ROOT/.claude/hooks"
   STAGED_HOOK="$STAGED_ROOT/.claude/hooks/block-no-verify.sh"
 }
 
@@ -276,8 +278,10 @@ run_staged() {
 # the library missing, the `[ -f ]` guard ahead of the source short-circuits,
 # and errexit exempts a non-final command in an `&&` list, so that path never
 # reaches the source the bracket protects. Dropping that guard along with the
-# bracket is what reds it, by turning a missing library into the same abandoned
-# shell.
+# bracket is what reds it, and the shape of that failure differs from the
+# conflict-marker pair above: the shell is abandoned on a status PreToolUse does
+# not read as a deny, so the hook returns no verdict at all rather than a
+# refusal, and both halves of the pair red on the missing verdict.
 
 @test "repo-scope.sh holding conflict markers: an ordinary git command is still allowed" {
   stage_hook_tree


### PR DESCRIPTION
Closes #2025

The repo-scope degrade tests corrupted or removed a library copy under `$REPO`, but `block-no-verify.sh` resolves its libraries from its own on-disk location through `BASH_SOURCE`, never from the working directory. It sourced the untouched library beside itself, so the copy the tests broke was never read and each test passed whatever the degrade path did.

They now run through a staged hook tree the test controls, so the hook under test really loads the broken library. The `$REPO` library copy is dropped along with the suite-header claim that the hook loads the helper relative to cwd; what cwd actually decides is where the shared repo-scope helper resolves the home repository's identity from, which is what the header now says.

The absent-library case gains the deny twin its conflict-marker sibling already had. Driven through the staged tree, an allow-only assertion is satisfied by a hook that stopped enforcing entirely, which is the state the pair exists to discriminate.

The staged tree copies the hooks directory wholesale rather than naming the libraries this hook loads today, so the staged set is derived from the artifact instead of restated; each case removes or corrupts only the library it is named for.

## Verification

Each of the four degrade tests reds against a hook whose repo-scope load is unguarded and unbracketed: 25 green, 4 red, tests 26-29. Re-proved after the staging rework rather than inherited from the earlier proof. With the hook restored the suite is green at 29. shell-lint and the whole-tree invariants pass.

## Audit dispositions

Three rounds of `code-audit-maintainer-shell`, all clean: no Critical, no Important.

**Round 1.** Applied the header fix (it claimed every test runs with the tmp repo as cwd, while the staged tests run in `$STAGED_ROOT`). Accepted without fixing: `stage_hook_tree` / `run_staged` / `write_conflicted_lib` resemble shapes in sibling suites with no shared source, but the copies differ deliberately, `helpers/run-hook.sh` documents a deliberate non-sharing convention for this shape, and lifting them would edit several suites unreviewed on an already-marked branch. No action on `info`-tier shellcheck codes.

**Round 2.** Applied three: the staged-tree enumeration above; a correction to a comment that carried the exit-2 deny reading onto a mutant measured at exit 1 (it abandons the shell on a status PreToolUse does not read as a deny, so the hook returns no verdict at all); and an unterminated clause the header reflow made conspicuous. Declined the shellcheck codes again, identical against the base blob, so this change introduces none.

**Round 3.** One out-of-scope finding, filed as #2031: the sibling `block-main-destructive-git.bats` staged-tree harness still enumerates its libraries by name. Filed rather than recorded here because it is not waive-eligible, a `.bats` path is not gate machinery and that file is not one this pull request changes. It is latent at the fork point and reads the same whether or not this change lands, so it is untouched-sibling debt rather than an inconsistency this change authored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)