### PR TITLE
wiki: sync through bd795f4

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "692904fd0c88891445b116b333a1f56066119983",
-  "last_evaluated_at": "2026-09-12T01:53:32Z",
+  "last_evaluated_sha": "bd795f4b69e5948b76a1a19401a7ea9d916edefa",
+  "last_evaluated_at": "2026-09-12T09:05:37Z",
   "last_consolidated_sha": "78c69d0f81d5bc6460453391c466570f30da43c4",
   "last_consolidated_at": "2026-09-08T06:34:36Z"
 }

--- a/wiki/decisions/Sharded CI Test Matrix.md
+++ b/wiki/decisions/Sharded CI Test Matrix.md
@@ -4,7 +4,7 @@ status: active
 priority: 2
 date: 2026-08-13
 created: 2026-08-13
-updated: 2026-09-11
+updated: 2026-09-12
 tags: [decision, ci, performance, github-actions, bats]
 ---
 
@@ -122,7 +122,9 @@ The same rule carries an accepted cost in the safe direction. A path inventory t
 
 Measured against the tree, the saving is runner-minutes before it is wall clock. Some pages are named only by `lib`'s own suites and arm that single leg, which moves both wall clock and runner-minutes; others also reach the scripts group, whose legs sit on the critical path, so narrowing to them moves runner-minutes only. `wiki/.state.json`, the file every wiki sync rewrites, would arm nearly the whole matrix through this lever alone.
 
-A `code:` filter entry may be qualified by change type, and the `wiki/.state.json` entry is: a content-only rewrite of that file, which is what every wiki sync does to it, does not arm `code:` at all. What makes that safe is the checker the entry narrows against being blind to the file's content, not the entry being cheap; the invariant pinning that lives beside the per-leg gate's own invariants.
+A `code:` filter entry may be qualified by change type, and the `wiki/.state.json` entry is: a content-only rewrite of that file, which is what every wiki sync does to it, does not match that entry. That narrows the entry rather than the filter's output, because a separate `wiki/**` entry matches every path under `wiki/` on any change type, so a wiki sync still resolves `code=true` and runs the full matrix. What the change-type keying buys is that the `wiki/.state.json` entry specifically is not what arms it. What makes the keying safe is the checker that entry narrows against being blind to the file's content, not the entry being cheap; the invariant pinning that lives beside the per-leg gate's own invariants.
+
+The `wiki/**` entry exists because the per-page entries above it name one page each: a wiki-only pull request touching a page none of them names matched nothing before it was added, resolved `code=false`, and skipped every bats step, including suites that assert a property of every tracked file rather than of a page they name. It arms the job and decides no leg: a page the per-page entries already name stays a member of the narrowable class `.gaia/tests/leg-arming.sh` derives (matched by exact string equality), so the glob can only add a member to that class, never remove one.
 
 See `.gaia/tests/leg-arming.sh` for the decision, `.gaia/tests/bats-shards.sh` for the exchange groups it is derived through, and `.gaia/tests/lib/audit-ci-shards.bats` for what pins it, including the per-page armed-leg table.
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,17 @@ tags: [meta, log]
 
 ## [Unreleased]
 
+- 2026-09-12 bd795f4b SKIP - internal bug fixes to block-main-destructive-git.sh (quote-aware global parser, per-segment cd tracking, switch no-op carve-out), existing wiki descriptions stay accurate at their altitude
+- 2026-09-12 95e8045 WORTHY - arms audit-ci-tests.yml code: filter on every wiki path -> wiki/decisions/Sharded CI Test Matrix.md corrected, wiki/.state.json no longer 'does not arm code: at all'
+- 2026-09-12 7c710d6 SKIP - tests-only, drives block-no-verify's repo-scope degrade tests through staged tree
+- 2026-09-12 b8dd1e6 SKIP - tests-only, drives repo-scope degrade tests through staged hook tree
+- 2026-09-12 7b84113 SKIP - internal bug fix to RED-verify/worthiness-presence gates' tree resolution, no wiki claim about cwd-vs-command-target to correct
+- 2026-09-12 d1e6b25 WORTHY - wiki already updated in-commit: PR Merge Workflow and Release-Notes CHANGELOG entries now cite issue number, no further edit needed
+- 2026-09-12 d1c8b86 SKIP - internal bug fix to repo-scope.sh's -R/--repo reading, no wiki claim about this mechanism to correct
+- 2026-09-12 c04765c SKIP - wiki: self-referential sync commit
+- 2026-09-12 f85b134 SKIP - internal bug fixes to block-main-destructive-git.sh subcommand keying and hop guard; existing Git Workflow/Claude Hooks descriptions stay accurate at their altitude
+- 2026-09-12 055a49c SKIP - internal cli refactor consolidating collectPins onto shared tree walk, no behavior wiki documents
+- 2026-09-12 40f1259 WORTHY - wiki already updated in-commit: PR Merge Workflow gh 2.99.0 --delete-branch bound, Wiki Sync auto-merge remote-delete claim, no further edit needed
 - 2026-09-12 692904fd SKIP - wiki/concepts/Git Workflow.md already updated in-commit (repo-scope matches remotes, not checkout directory)
 - 2026-09-12 54145795 SKIP - wiki/concepts/Claude Hooks.md and wiki/concepts/PR Merge Workflow.md already updated in-commit (main-checkout hop guard)
 - 2026-09-12 1dacd926 SKIP - internal accuracy fix to capability-oracle-lib.sh install-arm matching, no capability declaration or documented behavior moves


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to bd795f4.