### PR TITLE
debt(tests): stage the whole hooks directory for the staged-tree degrade cases

### DIFF
--- a/.gaia/tests/hooks/block-main-destructive-git.bats
+++ b/.gaia/tests/hooks/block-main-destructive-git.bats
@@ -492,11 +492,9 @@ stage_hook_tree() {
   # test.
   cp -R "$HOOKS_SRC" "$STAGED_ROOT/.claude/hooks"
   # Outside the hooks directory, so the wholesale copy above does not reach it.
-  # This line is therefore the hand-maintained list the comment above argues
-  # against: a second .gaia/scripts load on the hook's live path has to be added
-  # here, or it goes short with nothing red. Copying that directory wholesale is
-  # not available as the fix, because a case below degrades by
-  # gh-artifact-lib.sh never being staged and asserts its absence.
+  # This line stays a hand-maintained list for that reason: a further
+  # .gaia/scripts load the hook's live path gains has to be added here, or it
+  # goes short with nothing red.
   cp "${HOOKS_SRC%/.claude/hooks}/.gaia/scripts/main-root-lib.sh" "$STAGED_ROOT/.gaia/scripts/"
   git -C "$STAGED_ROOT" init --quiet --initial-branch=main
   git -C "$STAGED_ROOT" config user.email "test@example.com"

--- a/.gaia/tests/hooks/block-main-destructive-git.bats
+++ b/.gaia/tests/hooks/block-main-destructive-git.bats
@@ -483,13 +483,20 @@ stage_hook_tree() {
   # The whole hooks directory, lib/ included, rather than the libraries this
   # hook happens to load today: an enumeration goes short the moment the hook
   # gains a load, and the cases below would then drive a hook degraded in a way
-  # none of them names while still reporting green. Each case removes or
-  # corrupts only the library it is named for. Staging the directory wholesale
-  # also keeps the jq-availability arm present, which runs ahead of the loads
-  # under test and refuses when it cannot find its own library, answering every
-  # case with that refusal instead of with the decision under test.
+  # none of them names while still reporting green. Each case then degrades one
+  # named library and nothing else, by corrupting it, by removing it, or by
+  # relying on it never having been staged at all. Staging the directory
+  # wholesale also keeps the jq-availability arm present, which runs ahead of
+  # the loads under test and refuses when it cannot find its own library,
+  # answering every case with that refusal instead of with the decision under
+  # test.
   cp -R "$HOOKS_SRC" "$STAGED_ROOT/.claude/hooks"
   # Outside the hooks directory, so the wholesale copy above does not reach it.
+  # This line is therefore the hand-maintained list the comment above argues
+  # against: a second .gaia/scripts load on the hook's live path has to be added
+  # here, or it goes short with nothing red. Copying that directory wholesale is
+  # not available as the fix, because a case below degrades by
+  # gh-artifact-lib.sh never being staged and asserts its absence.
   cp "${HOOKS_SRC%/.claude/hooks}/.gaia/scripts/main-root-lib.sh" "$STAGED_ROOT/.gaia/scripts/"
   git -C "$STAGED_ROOT" init --quiet --initial-branch=main
   git -C "$STAGED_ROOT" config user.email "test@example.com"

--- a/.gaia/tests/hooks/block-main-destructive-git.bats
+++ b/.gaia/tests/hooks/block-main-destructive-git.bats
@@ -479,13 +479,17 @@ write_conflicted_lib() {
 stage_hook_tree() {
   STAGED_ROOT="$BATS_TEST_TMPDIR/staged"
   rm -rf "$STAGED_ROOT"
-  mkdir -p "$STAGED_ROOT/.claude/hooks/lib" "$STAGED_ROOT/.gaia/scripts"
-  cp "$HOOK_ABS" "$STAGED_ROOT/.claude/hooks/"
-  cp "$HOOKS_SRC/lib/repo-scope.sh" "$STAGED_ROOT/.claude/hooks/lib/"
-  # The jq-availability arm runs ahead of the library loads under test and
-  # refuses when it cannot find its own library, so a staged tree without it
-  # answers every case with that refusal instead of the decision under test.
-  cp "$HOOKS_SRC/lib/jq-availability.sh" "$STAGED_ROOT/.claude/hooks/lib/"
+  mkdir -p "$STAGED_ROOT/.claude" "$STAGED_ROOT/.gaia/scripts"
+  # The whole hooks directory, lib/ included, rather than the libraries this
+  # hook happens to load today: an enumeration goes short the moment the hook
+  # gains a load, and the cases below would then drive a hook degraded in a way
+  # none of them names while still reporting green. Each case removes or
+  # corrupts only the library it is named for. Staging the directory wholesale
+  # also keeps the jq-availability arm present, which runs ahead of the loads
+  # under test and refuses when it cannot find its own library, answering every
+  # case with that refusal instead of with the decision under test.
+  cp -R "$HOOKS_SRC" "$STAGED_ROOT/.claude/hooks"
+  # Outside the hooks directory, so the wholesale copy above does not reach it.
   cp "${HOOKS_SRC%/.claude/hooks}/.gaia/scripts/main-root-lib.sh" "$STAGED_ROOT/.gaia/scripts/"
   git -C "$STAGED_ROOT" init --quiet --initial-branch=main
   git -C "$STAGED_ROOT" config user.email "test@example.com"


### PR DESCRIPTION
Closes #2031

`stage_hook_tree` built the staged tree by naming each of the libraries it loads individually. That enumeration is a hand-maintained parallel list of what `block-main-destructive-git.sh` loads, and it goes short the moment the hook gains a library load: the staged copy would lack the new library, so the staged hook degrades on a load no case names while every case keeps asserting the outcome it was written for, and the suite reports green over a hook degraded in a way it does not describe.

The hooks directory is now copied wholesale, so the staged set is derived from the artifact rather than restated. Each degrade case still degrades only the library it is named for. `main-root-lib.sh` keeps its own copy because it lives outside the hooks directory, so the wholesale copy does not reach it.

Two sibling suites already use this form: `.gaia/tests/hooks/pr-merge-audit-check.bats` (`run_merge_hook_lib_absent`) and `.gaia/tests/hooks/block-no-verify.bats`.

## Verification

Every degrade case was driven into its failing state before being relied on, rather than only re-run green:

- Removing the repo-scope errexit bracket and its `[ -f ]` guard reds all three repo-scope cases.
- Removing the main-root-lib errexit bracket reds both of its `/bin/bash`-pinned cases.

The hook was restored byte-identical after each mutation. Full suite green with zero failures, `shell-lint` clean, `whole-tree-invariants` clean.

No CHANGELOG entry: `.gaia/tests/` is release-excluded test infrastructure and this changes no shipped behavior.

## Accepted residual

One Suggestion from the final audit round is accepted rather than fixed, recorded here rather than dropped silently:

- `.gaia/tests/hooks/block-main-destructive-git.bats:495-497` (`holistic/overclaimed-guarantee`, suggestion). The surviving sentence states unconditionally that a future `.gaia/scripts` load has to be added to that line, while `gh-artifact-lib.sh` is deliberately never staged because a case below pins its absence. Accepted because the wrong action fails loudly rather than silently: staging that library reds a POSIX `[ ! -e ]` assertion, which fails correctly on bash 3.2 and bash 5 alike. If the line is revisited, the fix is to make the obligation conditional, not to restore the library name, which would restart the enumeration decay this branch cut.

## Out-of-scope finding, filed

- `.gaia/tests/hooks/block-rm-rf.bats:1391` — `stage_rmrf_tree` is a third independent copy of the same by-name enumeration. Not waive-eligible, since a `.bats` path is not gate machinery and this pull request does not change that file, so it is filed as #2037 rather than recorded here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
