### PR TITLE
debt(tests): derive the staged hook libraries from the hooks directory

### DIFF
--- a/.gaia/tests/hooks/block-rm-rf.bats
+++ b/.gaia/tests/hooks/block-rm-rf.bats
@@ -1391,13 +1391,24 @@ assert_position_preserving() {
 stage_rmrf_tree() {
   STAGED_ROOT="$BATS_TEST_TMPDIR/staged"
   rm -rf "$STAGED_ROOT"
-  mkdir -p "$STAGED_ROOT/.claude/hooks/lib" "$STAGED_ROOT/.gaia/scripts"
-  cp "$HOOK_ABS" "$STAGED_ROOT/.claude/hooks/"
-  # The jq-availability arm runs ahead of everything these fixtures degrade, and
-  # refuses when it cannot load its own library, so a staged tree without it
-  # would answer every case below with that refusal rather than with the
-  # degrade under test.
-  cp "$HOOKS_SRC/lib/jq-availability.sh" "$STAGED_ROOT/.claude/hooks/lib/"
+  # `mkdir -p` stops at .claude on purpose: the copy below becomes
+  # $STAGED_ROOT/.claude/hooks, and creating that destination first would nest
+  # the source inside it instead.
+  mkdir -p "$STAGED_ROOT/.claude" "$STAGED_ROOT/.gaia/scripts"
+  # Staged wholesale rather than named library by library, so the staged set is
+  # derived from the hooks directory instead of restated here: a library this
+  # hook gains reaches the staged tree without anyone remembering this helper,
+  # and each case below then degrades only the library it is named for. It also
+  # keeps the jq-availability arm present, which runs ahead of everything these
+  # fixtures degrade and refuses when it cannot load its own library, so a
+  # staged tree without it would answer every case with that refusal rather
+  # than with the degrade under test.
+  cp -R "$HOOKS_SRC" "$STAGED_ROOT/.claude/hooks"
+  # Outside the hooks directory, so the wholesale copy above does not reach it.
+  # This line stays a hand-maintained list for that reason: a further
+  # .gaia/scripts load the hook's live path gains has to be added here, unless a
+  # case deliberately pins that library's absence, or the staged tree goes short
+  # with nothing red.
   cp "${HOOKS_SRC%/.claude/hooks}/.gaia/scripts/main-root-lib.sh" \
      "${HOOKS_SRC%/.claude/hooks}/.gaia/scripts/state-registry-lib.sh" \
      "$STAGED_ROOT/.gaia/scripts/"


### PR DESCRIPTION
Closes #2037

## Problem

The staged-tree harness in `block-rm-rf.bats` built its staged copy by naming each library individually: the hook, then `lib/jq-availability.sh`, then the two `.gaia/scripts` libraries. That enumeration was a hand-maintained parallel list of what the hook loads, so it went short the moment `block-rm-rf.sh` gained a library under `.claude/hooks`. The staged hook would then degrade on a load no case names, while every case kept asserting the outcome it was written for: green over a hook degraded in a way the suite does not describe.

## Fix

Stage the hooks directory wholesale with `cp -R`, so the staged set is derived from the artifact rather than restated. `mkdir -p` stops at `.claude`, so the copy becomes `.claude/hooks` rather than nesting inside it. The two `.gaia/scripts` copies stay by name, since those libraries live outside the hooks directory and the wholesale copy does not reach them.

That remaining hand-maintained obligation is written **conditionally** (a further `.gaia/scripts` load has to be added there unless a case deliberately pins that library as absent), rather than in the unconditional form. The unconditional wording was recorded as an accepted residual on the sibling suite, because a library can be left unstaged on purpose. No case in this suite pins such an absence today, so the caveat is written as a caveat.

## Verification

A staging change cannot be verified by the suite going green, because green is the state an inert case is permanently in. Every staged case was therefore driven red under a deliberate break:

- Blanking the staged hook reds every deny case.
- Neutralizing `write_conflicted_lib` reds the carve-out case while its control stays green, proving the staged corruption still reaches the hook.
- Unstaging `state-registry-lib.sh` reds the allow control.

Each break was run on an untracked copy and removed afterwards; the tracked suite is green (192 tests, 0 failures) under bash 5 via `.gaia/scripts/bats5.sh`. A direct probe confirms `cp -R` reproduces the hooks directory exactly, with no nesting. `shell-lint` and `whole-tree-invariants` pass.

No CHANGELOG entry: the path is absent from `.gaia/manifest.json`, so it is release-excluded test infrastructure and changes no shipped behavior.

## Accepted residual (recorded, not filed)

The pre-merge audit (`code-audit-maintainer-shell`, clean pass: no Critical, no Important) raised one Suggestion, accepted rather than applied.

- **`.gaia/tests/hooks/block-rm-rf.bats:1412`** — `holistic/drifting-duplicate`. The `.gaia/scripts` copy remains a hand-maintained restatement of the hook's load set, the same class this change removes one line above. A third `.gaia/scripts` load added to the hook would leave the staged tree short, the staged hook would degrade on a load no case names, and every case would keep asserting its written-for outcome with nothing red.

Why it is accepted here rather than fixed:

- **No live failure mode.** The audit re-derived the hook's `.gaia/scripts` loads and confirmed the list is complete today (`main-root-lib.sh` at `:414`, `state-registry-lib.sh` at `:416`).
- **It is new logic in an already-marked PR.** The member has cleared this content; folding in a logic change trades a reviewed tree for an unreviewed repair, which is the case the workflow directs to accept-and-note rather than to the delta-review price alone.
- **Cost the finding does not justify.** `.gaia/scripts` is 4.8M across 93 top-level entries against 992K for `.claude/hooks`, and `stage_rmrf_tree` runs once per test, so a wholesale copy would recopy that tree on all 7 staged cases per run.
- **Scope.** The originating issue, and its correction comment, both scope this fix to this file and keep that line hand-maintained under an explicitly conditional obligation; widening it here is the enumeration-decay direction that correction warned against.

The audit also notes this suite could adopt the wholesale form more easily than its sibling, since both its `.gaia/scripts` libraries are degraded by in-place corruption rather than by requiring absence. That remains true and is the argument for a future dedicated change, not for widening this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
